### PR TITLE
feat: add printenvcfg rule

### DIFF
--- a/scripts/mk/printvars.mk
+++ b/scripts/mk/printvars.mk
@@ -6,3 +6,7 @@
 .PHONY: printvars
 printvars: ## Print variable name and values
 	@true $(foreach V, $(sort $(.VARIABLES)),$(if $(filter-out environment% default automatic,$(origin $V)),$(info $V=$(value $V))))
+
+.PHONY: printenvcfg
+printenvcfg: ## Print the environment the resulting exported environment
+	@env | grep -e ^DATABASE_ -e ^KAFKA_ -e ^APP_ -e ^WEB_ -e ^LOGGING_ -e ^CONFIG_PATH= | sort

--- a/scripts/mk/printvars.mk
+++ b/scripts/mk/printvars.mk
@@ -9,4 +9,4 @@ printvars: ## Print variable name and values
 
 .PHONY: printenvcfg
 printenvcfg: ## Print the environment the resulting exported environment
-	@env | grep -e ^DATABASE_ -e ^KAFKA_ -e ^APP_ -e ^WEB_ -e ^LOGGING_ -e ^CONFIG_PATH= | sort
+	@env | grep -P -e '^(APP|CONFIG_PATH|DATABASE|KAFKA|LOGGING|WEB)(_.*)?=' | sort


### PR DESCRIPTION
This new rule will help to know the configuration environment variables that are exported for the commands executed by the makefile.