### PR TITLE
fix: Misc ephemeral deployment fixes

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -31,9 +31,14 @@ make registry-login \
     CONTAINER_REGISTRY_TOKEN="${RH_REGISTRY_TOKEN}" \
     CONTAINER_REGISTRY="registry.redhat.io"
 
-# Build and push
-make container-build container-push \
+# Build container
+make container-build \
     CONTAINER_BUILD_OPTS=--no-cache \
+    CONTAINER_IMAGE_BASE="${IMAGE}" \
+    CONTAINER_IMAGE_TAG="${IMAGE_TAG}"
+
+# Push container to registry
+make container-push \
     CONTAINER_IMAGE_BASE="${IMAGE}" \
     CONTAINER_IMAGE_TAG="${IMAGE_TAG}"
 

--- a/test/scripts/ephe-domains-token.sh
+++ b/test/scripts/ephe-domains-token.sh
@@ -6,6 +6,6 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
 ./scripts/curl.sh -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"


### PR DESCRIPTION
`build_deploy.sh` runs container-push after container-build (fix for parallel builds with `MAKEFLAGS` env var)

`make ephemeral-deploy` creates secrets directory, `bonfire.yaml` from example, and fails if `secrets/private.mk` is missing.

`make ephemeral-build-deploy` fails if the `build_deploy.sh` script fails.

`ephe-domains-token.sh` uses correct XRHID identity type. Tokens are requested as user, not system.