### PR TITLE
fix: add org_id to the options

### DIFF
--- a/scripts/mk/lint.mk
+++ b/scripts/mk/lint.mk
@@ -4,3 +4,7 @@ install-pre-commit: $(PRE_COMMIT)
 .PHONY: lint
 lint: $(PRE_COMMIT) $(GOLANGCI_LINT)
 	PATH=$(TOOLS_BIN):$${PATH} $(PYTHON_VENV)/bin/pre-commit run --all-files --verbose
+
+.PHONY: shellcheck
+shellcheck:
+	shellcheck -x -s bash -P test/scripts/ test/scripts/*.sh test/scripts/*.inc

--- a/test/scripts/common.inc
+++ b/test/scripts/common.inc
@@ -1,0 +1,49 @@
+#
+# Include file with common parts shared for local and ephemeral
+#
+
+# Troubleshooting:
+# - Run with DEBUG=1 to see some traces from curl.sh wrapper
+#   $ DEBUG=1 ./test/scripts/local-domain-token.sh
+# - Run with more verbose by:
+#   $ DEBUG=1 bash -xv ./test/scripts/local-domain-token.sh
+
+function error {
+    local err=$?
+    printf "ERROR: %s\n" "$*" >&2
+    exit $err
+}
+
+ORG_ID="${ORG_ID:-12345}"
+
+export IDENTITY_USER=""   # Use $(identity_user)
+export IDENTITY_SYSTEM="" # Use $(identity_system)
+export IDM_VERSION=""     # Use $(idm_version)
+
+SRCDIR="$(dirname "${BASH_SOURCE[0]}")"
+# shellcheck disable=SC2034  # ignore unused variable
+BASEDIR="$(dirname "$(dirname "${SRCDIR}")")"
+REPOBASEDIR="$(git rev-parse --show-toplevel)"
+export REPOBASEDIR
+export XRHIDGEN="${REPOBASEDIR}/tools/bin/xrhidgen"
+
+if [[ ! -x "${XRHIDGEN}" ]]; then
+    error "${XRHIDGEN} is missing, run 'make install-tools'"
+    exit 2
+fi
+
+function identity_user() {
+    "${XRHIDGEN}" -org-id "${ORG_ID}" user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0
+}
+export -f identity_user     # Needed for making it available in sub-shells
+
+function identity_system() {
+    "${XRHIDGEN}" -org-id "${ORG_ID}" system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0
+}
+export -f identity_system   # Needed for making it available in sub-shells
+
+function idm_version() {
+    IDM_VERSION='{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}'
+    printf "%s" "${IDM_VERSION}"
+}
+export -f idm_version

--- a/test/scripts/common.inc
+++ b/test/scripts/common.inc
@@ -15,10 +15,8 @@ function error {
 }
 
 ORG_ID="${ORG_ID:-12345}"
-
-export IDENTITY_USER=""   # Use $(identity_user)
-export IDENTITY_SYSTEM="" # Use $(identity_system)
-export IDM_VERSION=""     # Use $(idm_version)
+# shellcheck disable=SC2034
+IDM_VERSION='{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}'
 
 SRCDIR="$(dirname "${BASH_SOURCE[0]}")"
 # shellcheck disable=SC2034  # ignore unused variable
@@ -32,18 +30,10 @@ if [[ ! -x "${XRHIDGEN}" ]]; then
     exit 2
 fi
 
-function identity_user() {
+identity_user() {
     "${XRHIDGEN}" -org-id "${ORG_ID}" user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0
 }
-export -f identity_user     # Needed for making it available in sub-shells
 
-function identity_system() {
+identity_system() {
     "${XRHIDGEN}" -org-id "${ORG_ID}" system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0
 }
-export -f identity_system   # Needed for making it available in sub-shells
-
-function idm_version() {
-    IDM_VERSION='{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}'
-    printf "%s" "${IDM_VERSION}"
-}
-export -f idm_version

--- a/test/scripts/ephe-domains-delete.sh
+++ b/test/scripts/ephe-domains-delete.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# make ephemeral-db-cli <<< "select domain_uuid from domains order by id desc limit 1;\\q"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
-export X_RH_IDM_VERSION="$( base64 -w0 <<< '{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}' )"
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X DELETE "${BASE_URL}/domains/${UUID}"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-delete.sh
+++ b/test/scripts/ephe-domains-delete.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
@@ -10,6 +9,7 @@ UUID="$1"
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-list.sh
+++ b/test/scripts/ephe-domains-list.sh
@@ -1,12 +1,9 @@
 #!/bin/bash
+set -eo pipefail
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
-unset X_RH_FAKE_IDENTITY
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i "${BASE_URL}/domains"
-
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"

--- a/test/scripts/ephe-domains-list.sh
+++ b/test/scripts/ephe-domains-list.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"

--- a/test/scripts/ephe-domains-patch.sh
+++ b/test/scripts/ephe-domains-patch.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# make ephemeral-db-cli <<< "select domain_uuid from domains order by id desc limit 1;\\q"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
 unset X_RH_IDM_REGISTRATION_TOKEN
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X PATCH -d @<( cat test/data/http/patch-rhel-idm-domain.json | sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' ) "${BASE_URL}/domains/${UUID}"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-patch.sh
+++ b/test/scripts/ephe-domains-patch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
@@ -10,6 +9,7 @@ UUID="$1"
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
 unset X_RH_IDM_REGISTRATION_TOKEN
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-read.sh
+++ b/test/scripts/ephe-domains-read.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
@@ -9,4 +8,5 @@ UUID="$1"
 
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-read.sh
+++ b/test/scripts/ephe-domains-read.sh
@@ -1,21 +1,12 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-unset X_RH_FAKE_IDENTITY
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-
-./scripts/curl.sh -i "${BASE_URL}/domains/${UUID}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-register.sh
+++ b/test/scripts/ephe-domains-register.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 TOKEN="$1"
@@ -10,6 +9,7 @@ TOKEN="$1"
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"

--- a/test/scripts/ephe-domains-register.sh
+++ b/test/scripts/ephe-domains-register.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# ephe-domains-token.sh
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 TOKEN="$1"
 [ "${TOKEN}" != "" ] || error "TOKEN is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d @<( cat "test/data/http/register-rhel-idm-domain.json" | sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' ) "${BASE_URL}/domains"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"

--- a/test/scripts/ephe-domains-token.sh
+++ b/test/scripts/ephe-domains-token.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/ephe-domains-token.sh
+++ b/test/scripts/ephe-domains-token.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
+set -eo pipefail
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/ephe-domains-update.sh
+++ b/test/scripts/ephe-domains-update.sh
@@ -1,24 +1,15 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# make ephemeral-db-cli <<< "select domain_uuid from domains order by id desc limit 1;\\q"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
 unset X_RH_IDM_REGISTRATION_TOKEN
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X PUT -d @<( cat test/data/http/update-rhel-idm-domain.json | sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' ) "${BASE_URL}/domains/${UUID}"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X PUT -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/update-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-update.sh
+++ b/test/scripts/ephe-domains-update.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 UUID="$1"
@@ -10,6 +9,7 @@ UUID="$1"
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
 unset X_RH_IDM_REGISTRATION_TOKEN
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X PUT -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/update-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X PUT -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/update-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-hostconf.sh
+++ b/test/scripts/ephe-hostconf.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 INVENTORY_ID=$"$1"
@@ -11,6 +10,7 @@ FQDN="$2"
 
 unset X_RH_IDENTITY
 export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"

--- a/test/scripts/ephe-hostconf.sh
+++ b/test/scripts/ephe-hostconf.sh
@@ -1,23 +1,16 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$*" >&2
-    exit $err
-}
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 INVENTORY_ID=$"$1"
-FQDN="$2"
 [ "${INVENTORY_ID}" != "" ] || error "INVENTORY_ID is empty"
+FQDN="$2"
 [ "${FQDN}" != "" ] || error "FQDN is empty"
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
-
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_system)}"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"

--- a/test/scripts/ephe-openapi.sh
+++ b/test/scripts/ephe-openapi.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
+set -eo pipefail
 
-export NAMESPACE="$(oc project -q)"
-CREDS="$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
-CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
-export CREDS
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
 unset X_RH_FAKE_IDENTITY
-BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
-./scripts/curl.sh -i "${BASE_URL}/openapi.json"
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"

--- a/test/scripts/ephe-openapi.sh
+++ b/test/scripts/ephe-openapi.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
 unset X_RH_FAKE_IDENTITY
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"

--- a/test/scripts/ephe.inc
+++ b/test/scripts/ephe.inc
@@ -1,0 +1,21 @@
+#
+# Include for common parts for ephemeral environment shared between all the scripts
+#
+# NOTE: Be aware that curl.sh wrapper set options based in the environment
+#       variables that has value when it is invoked, and set an environment
+#       variable could change the behave on how the request is formed.
+#
+# See: ./scripts/curl.sh
+#
+source "$(dirname "${BASH_SOURCE[0]}")/common.inc"
+
+NAMESPACE="$(oc project -q)"
+export NAMESPACE
+
+username="$( oc get secrets/env-"${NAMESPACE}"-keycloak -o jsonpath='{.data.defaultUsername}' | base64 -d )"
+password="$( oc get secrets/env-"${NAMESPACE}"-keycloak -o jsonpath='{.data.defaultPassword}' | base64 -d )"
+CREDS="${username}:${password}"
+export CREDS
+
+# shellcheck disable=SC2034  # ignore unused variable
+BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"

--- a/test/scripts/local-domains-delete.sh
+++ b/test/scripts/local-domains-delete.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
@@ -11,4 +10,5 @@ export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
 unset X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-delete.sh
+++ b/test/scripts/local-domains-delete.sh
@@ -1,19 +1,14 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# make db-cli <<< "select domain_uuid from domains order by id desc limit 1;\\q"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
-export X_RH_IDM_VERSION="$( base64 -w0 <<< '{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}' )"
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i -X DELETE "${BASE_URL}/domains/${UUID}"
+unset X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X DELETE "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-list.sh
+++ b/test/scripts/local-domains-list.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
+set -eo pipefail
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
+
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i "${BASE_URL}/domains"
-
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"

--- a/test/scripts/local-domains-list.sh
+++ b/test/scripts/local-domains-list.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"

--- a/test/scripts/local-domains-patch.sh
+++ b/test/scripts/local-domains-patch.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# make db-cli <<< "select domain_uuid from domains order by id desc limit 1;\\q"
-# make db-cli <<< "select token from ipas order by id desc limit 1;\\q"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i -X PATCH -d @<( cat "test/data/http/patch-rhel-idm-domain.json" | sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" ) "${BASE_URL}/domains/${UUID}"
+"${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-patch.sh
+++ b/test/scripts/local-domains-patch.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
@@ -10,4 +9,5 @@ UUID="$1"
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
-"${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X PATCH -d @<(sed -e "s/{{createDomain.response.body.domain_id}}/${UUID}/g" < "${REPOBASEDIR}/test/data/http/patch-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-populate.py
+++ b/test/scripts/local-domains-populate.py
@@ -8,6 +8,7 @@ import sys
 import uuid
 import requests
 import json
+import os
 
 
 CONTENT_TYPE = "application/json"
@@ -18,7 +19,7 @@ HEADER_X_RH_INSIGHTS_REQUEST_ID = "X-Rh-Insights-Request-Id"
 HEADER_X_RH_IDM_VERSION = "X-Rh-Idm-Version"
 HEADER_X_RH_IDM_REGISTRATION_TOKEN = "X-Rh-Idm-Registration-Token"
 
-DEFAULT_ORG_ID = "12345"
+DEFAULT_ORG_ID = os.environ.get("ORG_ID", "12345")
 
 class xrhidgen:
     """Wrapper to call ./tools/bin/xrhidgen binary and get a x-rh-identity header"""
@@ -51,7 +52,6 @@ class xrhidgen:
         if self.xrhidgen_type is None or self.xrhidgen_type == '':
             sys.exit("'xrhidgen_type' is None")
         options.append(self.xrhidgen_type)
-        # ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system
         options.extend(self.extra_args)
         options.extend(args)
         output = subprocess.check_output(options)

--- a/test/scripts/local-domains-read.sh
+++ b/test/scripts/local-domains-read.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
@@ -10,4 +9,5 @@ UUID="$1"
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-read.sh
+++ b/test/scripts/local-domains-read.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$*" >&2
-    exit $err
-}
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i "${BASE_URL}/domains/${UUID}"
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-domains-register.sh
+++ b/test/scripts/local-domains-register.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 TOKEN="$1"
@@ -10,6 +9,7 @@ TOKEN="$1"
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_system)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"

--- a/test/scripts/local-domains-register.sh
+++ b/test/scripts/local-domains-register.sh
@@ -1,19 +1,15 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$1" >&2
-    exit $err
-}
-
-# local-domains-token.sh
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 TOKEN="$1"
 [ "${TOKEN}" != "" ] || error "TOKEN is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_system)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d @<( cat "test/data/http/register-rhel-idm-domain.json" | sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' ) "${BASE_URL}/domains"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/register-rhel-idm-domain.json") "${BASE_URL}/domains"

--- a/test/scripts/local-domains-token.sh
+++ b/test/scripts/local-domains-token.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/local-domains-token.sh
+++ b/test/scripts/local-domains-token.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
+set -eo pipefail
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
+
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/local-domains-update.sh
+++ b/test/scripts/local-domains-update.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"
@@ -10,6 +9,7 @@ UUID="$1"
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_system)}"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
-X_RH_IDM_VERSION="$(idm_version)"
+X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION
-"${REPOBASEDIR}/scripts/curl.sh" -i -X PUT -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/update-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X PUT -d @<(sed -e 's/{{subscription_manager_id}}/6f324116-b3d2-11ed-8a37-482ae3863d30/g' < "${REPOBASEDIR}/test/data/http/update-rhel-idm-domain.json") "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/local-hostconf.sh
+++ b/test/scripts/local-hostconf.sh
@@ -1,19 +1,17 @@
 #!/bin/bash
+set -eo pipefail
 
-function error {
-    local err=$?
-    printf "%s\n" "$*" >&2
-    exit $err
-}
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 INVENTORY_ID=$"$1"
 FQDN="$2"
 [ "${INVENTORY_ID}" != "" ] || error "INVENTORY_ID is empty"
 [ "${FQDN}" != "" ] || error "FQDN is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
-export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+X_RH_IDM_VERSION="$(idm_version)"
+export X_RH_IDM_VERSION
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"
+"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"

--- a/test/scripts/local-hostconf.sh
+++ b/test/scripts/local-hostconf.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 INVENTORY_ID=$"$1"
@@ -10,8 +9,8 @@ FQDN="$2"
 [ "${FQDN}" != "" ] || error "FQDN is empty"
 
 export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
-X_RH_IDM_VERSION="$(idm_version)"
 export X_RH_IDM_VERSION
 unset X_RH_FAKE_IDENTITY
 unset CREDS
-"${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"

--- a/test/scripts/local-openapi.sh
+++ b/test/scripts/local-openapi.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
+set -eo pipefail
 
-# export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
+
+unset X_RH_IDENTITY
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION
 BASE_URL="http://localhost:8000/api/idmsvc/v1"
-./scripts/curl.sh -i "${BASE_URL}/openapi.json"
-
+"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"

--- a/test/scripts/local-openapi.sh
+++ b/test/scripts/local-openapi.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 set -eo pipefail
 
-# shellcheck disable=SC1091
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 unset X_RH_IDENTITY
@@ -9,4 +8,5 @@ unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION
 BASE_URL="http://localhost:8000/api/idmsvc/v1"
-"${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/openapi.json"

--- a/test/scripts/local.inc
+++ b/test/scripts/local.inc
@@ -1,0 +1,7 @@
+#
+# Include file with common parts shared for local and ephemeral
+#
+source "$(dirname "${BASH_SOURCE[0]}")/common.inc"
+
+# shellcheck disable=SC2034  # ignore unused variable
+BASE_URL="http://localhost:8000/api/idmsvc/v1"


### PR DESCRIPTION
When we register a domain, we need to specify the org_id for the generated identity; the org_id we use here must match the org_id used when generating the token or the operation will fail with sign mismatching.

This change add a second option to specify the ORG_ID to be used for the identity.