### PR TITLE
fix: compose-up without configs/config.yaml

### DIFF
--- a/scripts/mk/compose.mk
+++ b/scripts/mk/compose.mk
@@ -17,6 +17,13 @@ COMPOSE_VARS_DATABASE=\
 	DATABASE_NAME="$(DATABASE_NAME)" \
 	DATABASE_EXTERNAL_PORT="$(DATABASE_EXTERNAL_PORT)"
 
+COMPOSE_VARS_DB_MIGRATE=\
+	DATABASE_USER="$(DATABASE_USER)" \
+	DATABASE_PASSWORD="$(DATABASE_PASSWORD)" \
+	DATABASE_NAME="$(DATABASE_NAME)" \
+	DATABASE_HOST="$(DATABASE_HOST)" \
+	DATABASE_PORT="$(DATABASE_EXTERNAL_PORT)"
+
 COMPOSE_VARS_KAFKA=\
 	KAFKA_CONFIG_DIR=$(KAFKA_CONFIG_DIR) \
 	KAFKA_DATA_DIR=$(KAFKA_DATA_DIR) \
@@ -33,9 +40,9 @@ COMPOSE_VARS= \
 .PHONY: compose-up
 compose-up: ## Start local infrastructure
 	$(COMPOSE_VARS) \
-	$(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) up -d
+	    $(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) up -d
 	$(MAKE) .compose-wait-db
-	$(MAKE) db-migrate-up
+	$(MAKE) $(COMPOSE_VARS_DB_MIGRATE) db-migrate-up
 
 .PHONY: .compose-wait-db
 .compose-wait-db:
@@ -48,22 +55,22 @@ compose-up: ## Start local infrastructure
 .PHONY: compose-down
 compose-down: ## Stop local infrastructure
 	$(COMPOSE_VARS) \
-	$(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) down --volumes
+	    $(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) down --volumes
 
 .PHONY: compose-build
 compose-build: ## Build the images at docker-compose.yaml
 	$(COMPOSE_VARS) \
-	$(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) build
+	    $(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) build
 
 .PHONY: compose-pull
 compose-pull: ## Pull images
 	$(COMPOSE_VARS) \
-	$(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) pull
+	    $(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) pull
 
 .PHONY: compose-logs
 compose-logs: ## Print out infrastructure logs
 	$(COMPOSE_VARS) \
-	$(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) logs
+	    $(CONTAINER_COMPOSE) -f $(COMPOSE_FILE) -p $(COMPOSE_PROJECT) logs
 
 .PHONY: compose-clean
 compose-clean: compose-down  ## Stop and clean local infrastructure


### PR DESCRIPTION
The `db migrate-up` step of `make compose-up` no longer fails when `configs/config.yaml` does not exist or has different settings.

Also indent some lines to indicate that it's a continuation line.