### PR TITLE
tests: Test scripts lookup ORG_ID in env

### DIFF
--- a/test/scripts/ephe-domains-delete.sh
+++ b/test/scripts/ephe-domains-delete.sh
@@ -17,7 +17,7 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
 export X_RH_IDM_VERSION="$( base64 -w0 <<< '{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}' )"
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"

--- a/test/scripts/ephe-domains-patch.sh
+++ b/test/scripts/ephe-domains-patch.sh
@@ -17,7 +17,7 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 unset X_RH_IDM_REGISTRATION_TOKEN
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"

--- a/test/scripts/ephe-domains-register.sh
+++ b/test/scripts/ephe-domains-register.sh
@@ -17,7 +17,7 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"

--- a/test/scripts/ephe-domains-token.sh
+++ b/test/scripts/ephe-domains-token.sh
@@ -6,6 +6,6 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
 ./scripts/curl.sh -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/ephe-domains-update.sh
+++ b/test/scripts/ephe-domains-update.sh
@@ -17,7 +17,7 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 unset X_RH_IDM_REGISTRATION_TOKEN
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"

--- a/test/scripts/ephe-hostconf.sh
+++ b/test/scripts/ephe-hostconf.sh
@@ -17,7 +17,7 @@ CREDS="${CREDS}:$( oc get secrets/env-${NAMESPACE}-keycloak -o jsonpath='{.data.
 export CREDS
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
+export X_RH_FAKE_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
 BASE_URL="https://$( oc get routes -l app=idmsvc-backend -o jsonpath='{.items[0].spec.host}' )/api/idmsvc/v1"
 ./scripts/curl.sh -i -X POST -d '{}' "${BASE_URL}/host-conf/${INVENTORY_ID}/${FQDN}"

--- a/test/scripts/local-domains-delete.sh
+++ b/test/scripts/local-domains-delete.sh
@@ -11,7 +11,7 @@ function error {
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
 export X_RH_IDM_VERSION="$( base64 -w0 <<< '{"ipa-hcc": "0.7", "ipa": "4.10.0-8.el9_1"}' )"

--- a/test/scripts/local-domains-list.sh
+++ b/test/scripts/local-domains-list.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION

--- a/test/scripts/local-domains-patch.sh
+++ b/test/scripts/local-domains-patch.sh
@@ -12,7 +12,7 @@ function error {
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="$( ./bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
 BASE_URL="http://localhost:8000/api/idmsvc/v1"

--- a/test/scripts/local-domains-populate.py
+++ b/test/scripts/local-domains-populate.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import base64
+import os
 import random
 import string
 import subprocess
@@ -18,7 +19,7 @@ HEADER_X_RH_INSIGHTS_REQUEST_ID = "X-Rh-Insights-Request-Id"
 HEADER_X_RH_IDM_VERSION = "X-Rh-Idm-Version"
 HEADER_X_RH_IDM_REGISTRATION_TOKEN = "X-Rh-Idm-Registration-Token"
 
-DEFAULT_ORG_ID = "12345"
+DEFAULT_ORG_ID = os.environ.get("ORG_ID", "12345")
 
 class xrhidgen:
     """Wrapper to call ./tools/bin/xrhidgen binary and get a x-rh-identity header"""
@@ -51,7 +52,7 @@ class xrhidgen:
         if self.xrhidgen_type is None or self.xrhidgen_type == '':
             sys.exit("'xrhidgen_type' is None")
         options.append(self.xrhidgen_type)
-        # ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system
+        # ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system
         options.extend(self.extra_args)
         options.extend(args)
         output = subprocess.check_output(options)

--- a/test/scripts/local-domains-read.sh
+++ b/test/scripts/local-domains-read.sh
@@ -9,7 +9,7 @@ function error {
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 BASE_URL="http://localhost:8000/api/idmsvc/v1"

--- a/test/scripts/local-domains-register.sh
+++ b/test/scripts/local-domains-register.sh
@@ -11,7 +11,7 @@ function error {
 TOKEN="$1"
 [ "${TOKEN}" != "" ] || error "TOKEN is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'

--- a/test/scripts/local-domains-token.sh
+++ b/test/scripts/local-domains-token.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 BASE_URL="http://localhost:8000/api/idmsvc/v1"

--- a/test/scripts/local-domains-update.sh
+++ b/test/scripts/local-domains-update.sh
@@ -12,7 +12,7 @@ function error {
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64 -w0 )"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'

--- a/test/scripts/local-hostconf.sh
+++ b/test/scripts/local-hostconf.sh
@@ -11,7 +11,7 @@ FQDN="$2"
 [ "${INVENTORY_ID}" != "" ] || error "INVENTORY_ID is empty"
 [ "${FQDN}" != "" ] || error "FQDN is empty"
 
-export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
+export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} system -cn "3f35fc7f-079c-4940-92ed-9fdc8694a0f3" -cert-type system | base64 -w0 )"
 export X_RH_IDM_VERSION='{"ipa-hcc": "0.9", "ipa": "4.10.0-8.el9_1", "os-release-id": "rhel", "os-release-version-id": "9.1"}'
 unset X_RH_FAKE_IDENTITY
 unset CREDS

--- a/test/scripts/local-openapi.sh
+++ b/test/scripts/local-openapi.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id 12345 user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
+# export X_RH_IDENTITY="$( ./tools/bin/xrhidgen -org-id ${ORG_ID:-12345} user -is-active=true -is-org-admin=true -user-id test -username test | base64 -w0 )"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION


### PR DESCRIPTION
Tests scripts in `test/scripts` were using a hard-coded organization id for XRHID header. The scripts are now looking up `ORG_ID` in environment and fall back to `12345` test org.

The improvement allows testing with different organization ids.