### PR TITLE
HMS-2595 fix: GET signing_keys dummy

### DIFF
--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -1,12 +1,16 @@
 package impl
 
 import (
-	"errors"
+	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 )
 
 func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningKeysParams) error {
-	return errors.New("TODO: Not Implemented")
+	// TODO: Not Implemented
+	output := public.SigningKeysResponse{
+		Keys: []string{},
+	}
+	return ctx.JSON(http.StatusOK, output)
 }


### PR DESCRIPTION
The GET `signing_keys` route now returns an empty result set instead of an error. The change is necessary to unbreak integration testing of`ipa-hcc`.