### PR TITLE
HMS-2694 feat: Host conf token MVP

### DIFF
--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -23,6 +23,7 @@ func (a *application) HostConf(
 		domain  *model.Domain
 		output  *public.HostConfResponse
 		options *interactor.HostConfOptions
+		hctoken public.HostToken
 		tx      *gorm.DB
 		xrhid   *identity.XRHID
 	)
@@ -48,13 +49,20 @@ func (a *application) HostConf(
 	); err != nil {
 		return err
 	}
+	if hctoken, err = a.host.repository.SignHostConfToken(
+		a.secrets.signingKeys,
+		options,
+		domain,
+	); err != nil {
+		return err
+	}
 
 	if tx.Commit(); tx.Error != nil {
 		return tx.Error
 	}
 
 	if output, err = a.host.presenter.HostConf(
-		domain,
+		domain, hctoken,
 	); err != nil {
 		return err
 	}

--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -8,9 +8,9 @@ import (
 )
 
 func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningKeysParams) error {
-	// TODO: Not Implemented
+	// TODO: hacky implementation
 	output := public.SigningKeysResponse{
-		Keys: []string{},
+		Keys: a.secrets.publicKeys,
 	}
 	return ctx.JSON(http.StatusOK, output)
 }

--- a/internal/interface/interactor/host_interactor.go
+++ b/internal/interface/interactor/host_interactor.go
@@ -2,15 +2,16 @@ package interactor
 
 import (
 	"github.com/google/uuid"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	api_public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
 
 type HostConfOptions struct {
 	OrgId       string
-	CommonName  string
-	InventoryId uuid.UUID
-	Fqdn        string
+	CommonName  public.SubscriptionManagerId
+	InventoryId public.HostId
+	Fqdn        public.Fqdn
 	DomainId    *uuid.UUID
 	DomainName  *string
 	DomainType  *api_public.DomainType

--- a/internal/interface/presenter/host_presenter.go
+++ b/internal/interface/presenter/host_presenter.go
@@ -6,5 +6,5 @@ import (
 )
 
 type HostPresenter interface {
-	HostConf(domain *model.Domain) (*public.HostConfResponse, error)
+	HostConf(domain *model.Domain, token public.HostToken) (*public.HostConfResponse, error)
 }

--- a/internal/interface/repository/host_repository.go
+++ b/internal/interface/repository/host_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"gorm.io/gorm"
@@ -9,4 +11,6 @@ import (
 // HostRepository interface
 type HostRepository interface {
 	MatchDomain(db *gorm.DB, options *interactor.HostConfOptions) (output *model.Domain, err error)
+	// TODO: hack, actual implementation will take gorm.DB argument
+	SignHostConfToken(privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (hctoken public.HostToken, err error)
 }

--- a/internal/test/mock/interface/presenter/host_presenter.go
+++ b/internal/test/mock/interface/presenter/host_presenter.go
@@ -14,25 +14,25 @@ type HostPresenter struct {
 	mock.Mock
 }
 
-// HostConf provides a mock function with given fields: domain
-func (_m *HostPresenter) HostConf(domain *model.Domain) (*public.HostConfResponseSchema, error) {
-	ret := _m.Called(domain)
+// HostConf provides a mock function with given fields: domain, token
+func (_m *HostPresenter) HostConf(domain *model.Domain, token string) (*public.HostConfResponseSchema, error) {
+	ret := _m.Called(domain, token)
 
 	var r0 *public.HostConfResponseSchema
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*model.Domain) (*public.HostConfResponseSchema, error)); ok {
-		return rf(domain)
+	if rf, ok := ret.Get(0).(func(*model.Domain, string) (*public.HostConfResponseSchema, error)); ok {
+		return rf(domain, token)
 	}
-	if rf, ok := ret.Get(0).(func(*model.Domain) *public.HostConfResponseSchema); ok {
-		r0 = rf(domain)
+	if rf, ok := ret.Get(0).(func(*model.Domain, string) *public.HostConfResponseSchema); ok {
+		r0 = rf(domain, token)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*public.HostConfResponseSchema)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*model.Domain) error); ok {
-		r1 = rf(domain)
+	if rf, ok := ret.Get(1).(func(*model.Domain, string) error); ok {
+		r1 = rf(domain, token)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/test/mock/interface/repository/host_repository.go
+++ b/internal/test/mock/interface/repository/host_repository.go
@@ -3,9 +3,11 @@
 package repository
 
 import (
+	jwk "github.com/lestrrat-go/jwx/v2/jwk"
 	interactor "github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
-	mock "github.com/stretchr/testify/mock"
 	gorm "gorm.io/gorm"
+
+	mock "github.com/stretchr/testify/mock"
 
 	model "github.com/podengo-project/idmsvc-backend/internal/domain/model"
 )
@@ -34,6 +36,30 @@ func (_m *HostRepository) MatchDomain(db *gorm.DB, options *interactor.HostConfO
 
 	if rf, ok := ret.Get(1).(func(*gorm.DB, *interactor.HostConfOptions) error); ok {
 		r1 = rf(db, options)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// SignHostConfToken provides a mock function with given fields: privs, options, domain
+func (_m *HostRepository) SignHostConfToken(privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (string, error) {
+	ret := _m.Called(privs, options, domain)
+
+	var r0 string
+	var r1 error
+	if rf, ok := ret.Get(0).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) (string, error)); ok {
+		return rf(privs, options, domain)
+	}
+	if rf, ok := ret.Get(0).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) string); ok {
+		r0 = rf(privs, options, domain)
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	if rf, ok := ret.Get(1).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) error); ok {
+		r1 = rf(privs, options, domain)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/test/variables.go
+++ b/internal/test/variables.go
@@ -27,6 +27,7 @@ const (
 )
 
 var (
+	DomainType   = public.RhelIdm
 	DomainUUID   = uuid.MustParse(DomainId)
 	RealmDomains = []string{DomainName, "otherdomain.test"}
 	Location1    = public.Location{
@@ -225,6 +226,7 @@ func BuildDomainModel(orgID string) *model.Domain {
 }
 
 var (
-	SystemXRHID = GetSystemXRHID(OrgId, Server1.CertCN, SystemAccountNr)
-	UserXRHID   = GetUserXRHID(OrgId, UserName, UserId, UserAccountNr, false)
+	SystemXRHID  = GetSystemXRHID(OrgId, Server1.CertCN, SystemAccountNr)
+	Client1XRHID = GetSystemXRHID(OrgId, Client1.CertCN, SystemAccountNr)
+	UserXRHID    = GetUserXRHID(OrgId, UserName, UserId, UserAccountNr, false)
 )

--- a/internal/usecase/interactor/host_interactor.go
+++ b/internal/usecase/interactor/host_interactor.go
@@ -3,6 +3,7 @@ package interactor
 import (
 	"fmt"
 
+	"github.com/google/uuid"
 	api_public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
@@ -15,7 +16,13 @@ func NewHostInteractor() interactor.HostInteractor {
 	return hostInteractor{}
 }
 
-func (i hostInteractor) HostConf(xrhid *identity.XRHID, inventoryId api_public.HostId, fqdn string, params *api_public.HostConfParams, body *api_public.HostConf) (*interactor.HostConfOptions, error) {
+func (i hostInteractor) HostConf(
+	xrhid *identity.XRHID,
+	inventoryId api_public.HostId,
+	fqdn api_public.Fqdn,
+	params *api_public.HostConfParams,
+	body *api_public.HostConf,
+) (*interactor.HostConfOptions, error) {
 	if xrhid == nil {
 		return nil, internal_errors.NilArgError("xrhid")
 	}
@@ -31,10 +38,14 @@ func (i hostInteractor) HostConf(xrhid *identity.XRHID, inventoryId api_public.H
 	if body == nil {
 		return nil, internal_errors.NilArgError("body")
 	}
+	cn, err := uuid.Parse(xrhid.Identity.System.CommonName)
+	if err != nil {
+		return nil, err
+	}
 
 	options := &interactor.HostConfOptions{
 		OrgId:       xrhid.Identity.OrgID,
-		CommonName:  xrhid.Identity.System.CommonName,
+		CommonName:  cn,
 		InventoryId: inventoryId,
 		Fqdn:        fqdn,
 		DomainId:    body.DomainId,

--- a/internal/usecase/interactor/host_interactor_test.go
+++ b/internal/usecase/interactor/host_interactor_test.go
@@ -9,6 +9,7 @@ import (
 	api_public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
+	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -23,38 +24,6 @@ func TestNewHostInteractor(t *testing.T) {
 }
 
 func TestHostConf(t *testing.T) {
-	const (
-		testCN         = "21258fc8-c755-11ed-afc4-482ae3863d30"
-		testOrgID      = "12345"
-		testFqdn       = "server.ipa.test"
-		testDomainId   = "0851e1d6-003f-11ee-adf4-482ae3863d30"
-		testDomainName = "ipa.test"
-	)
-	testInventoryId := uuid.MustParse("70d51c08-8831-4989-bca6-04d2c11a58e2")
-	testDomainUUID := uuid.MustParse(testDomainId)
-	testDomainType := api_public.DomainType(api_public.RhelIdm)
-
-	xrhidSystem := identity.XRHID{
-		Identity: identity.Identity{
-			OrgID: testOrgID,
-			Type:  "System",
-			System: identity.System{
-				CommonName: testCN,
-				CertType:   "system",
-			},
-		},
-	}
-	xrhidUser := identity.XRHID{
-		Identity: identity.Identity{
-			OrgID: testOrgID,
-			Type:  "User",
-			User:  identity.User{},
-			Internal: identity.Internal{
-				OrgID: testOrgID,
-			},
-		},
-	}
-
 	type TestCaseGiven struct {
 		XRHID       *identity.XRHID
 		InventoryId uuid.UUID
@@ -76,7 +45,7 @@ func TestHostConf(t *testing.T) {
 			Name: "nil 'xrhid'",
 			Given: TestCaseGiven{
 				XRHID:       nil,
-				InventoryId: testInventoryId,
+				InventoryId: test.Client1.InventoryUUID,
 				Fqdn:        "",
 				Params:      nil,
 				Body:        &api_public.HostConf{},
@@ -89,8 +58,8 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "'xrhid' wrong type",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidUser,
-				InventoryId: testInventoryId,
+				XRHID:       &test.UserXRHID,
+				InventoryId: test.Client1.InventoryUUID,
 				Fqdn:        "",
 				Params:      nil,
 				Body:        &api_public.HostConf{},
@@ -103,8 +72,8 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "empty fqdn",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidSystem,
-				InventoryId: testInventoryId,
+				XRHID:       &test.Client1XRHID,
+				InventoryId: test.Client1.InventoryUUID,
 				Fqdn:        "",
 				Params:      nil,
 				Body:        &api_public.HostConf{},
@@ -117,9 +86,9 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "'params' is nil",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidSystem,
-				InventoryId: testInventoryId,
-				Fqdn:        testFqdn,
+				XRHID:       &test.Client1XRHID,
+				InventoryId: test.Client1.InventoryUUID,
+				Fqdn:        test.Client1.Fqdn,
 				Params:      nil,
 				Body:        &api_public.HostConf{},
 			},
@@ -131,9 +100,9 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "nil for the 'body'",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidSystem,
-				InventoryId: testInventoryId,
-				Fqdn:        testFqdn,
+				XRHID:       &test.Client1XRHID,
+				InventoryId: test.Client1.InventoryUUID,
+				Fqdn:        test.Client1.Fqdn,
 				Params:      &api_public.HostConfParams{},
 				Body:        nil,
 			},
@@ -145,19 +114,19 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "valid call without params",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidSystem,
-				InventoryId: testInventoryId,
-				Fqdn:        testFqdn,
+				XRHID:       &test.Client1XRHID,
+				InventoryId: test.Client1.InventoryUUID,
+				Fqdn:        test.Client1.Fqdn,
 				Params:      &api_public.HostConfParams{},
 				Body:        &api_public.HostConf{},
 			},
 			Expected: TestCaseExpected{
 				Err: nil,
 				Out: &interactor.HostConfOptions{
-					OrgId:       testOrgID,
-					CommonName:  testCN,
-					InventoryId: testInventoryId,
-					Fqdn:        testFqdn,
+					OrgId:       test.OrgId,
+					CommonName:  test.Client1.CertUUID,
+					InventoryId: test.Client1.InventoryUUID,
+					Fqdn:        test.Client1.Fqdn,
 					DomainId:    nil,
 					DomainName:  nil,
 					DomainType:  nil,
@@ -167,26 +136,26 @@ func TestHostConf(t *testing.T) {
 		{
 			Name: "valid call with params",
 			Given: TestCaseGiven{
-				XRHID:       &xrhidSystem,
-				InventoryId: testInventoryId,
-				Fqdn:        testFqdn,
+				XRHID:       &test.Client1XRHID,
+				InventoryId: test.Client1.InventoryUUID,
+				Fqdn:        test.Client1.Fqdn,
 				Params:      &api_public.HostConfParams{},
 				Body: &api_public.HostConf{
-					DomainId:   &testDomainUUID,
-					DomainName: pointy.String(testDomainName),
-					DomainType: &testDomainType,
+					DomainId:   &test.DomainUUID,
+					DomainName: pointy.String(test.DomainName),
+					DomainType: &test.DomainType,
 				},
 			},
 			Expected: TestCaseExpected{
 				Err: nil,
 				Out: &interactor.HostConfOptions{
-					OrgId:       testOrgID,
-					CommonName:  testCN,
-					InventoryId: testInventoryId,
-					Fqdn:        testFqdn,
-					DomainId:    &testDomainUUID,
-					DomainName:  pointy.String(testDomainName),
-					DomainType:  &testDomainType,
+					OrgId:       test.OrgId,
+					CommonName:  test.Client1.CertUUID,
+					InventoryId: test.Client1.InventoryUUID,
+					Fqdn:        test.Client1.Fqdn,
+					DomainId:    &test.DomainUUID,
+					DomainName:  pointy.String(test.DomainName),
+					DomainType:  &test.DomainType,
 				},
 			},
 		},

--- a/internal/usecase/presenter/host_presenter.go
+++ b/internal/usecase/presenter/host_presenter.go
@@ -54,7 +54,7 @@ func (p *hostPresenter) fillRhelIdm(domain *model.Domain, response *public.HostC
 	return nil
 }
 
-func (p *hostPresenter) HostConf(domain *model.Domain) (*public.HostConfResponse, error) {
+func (p *hostPresenter) HostConf(domain *model.Domain, token public.HostToken) (*public.HostConfResponse, error) {
 	var err error
 
 	if domain == nil {
@@ -70,6 +70,7 @@ func (p *hostPresenter) HostConf(domain *model.Domain) (*public.HostConfResponse
 		DomainId:              domain.DomainUuid,
 		DomainName:            *domain.DomainName,
 		DomainType:            domainType,
+		Token:                 &token,
 	}
 
 	switch *domain.Type {

--- a/internal/usecase/presenter/host_presenter_test.go
+++ b/internal/usecase/presenter/host_presenter_test.go
@@ -69,6 +69,7 @@ func TestHostConf(t *testing.T) {
 
 	type TestCaseGiven struct {
 		Input  *model.Domain
+		Token  string
 		Output *public.HostConfResponse
 	}
 	type TestCaseExpected struct {
@@ -171,6 +172,7 @@ func TestHostConf(t *testing.T) {
 						RealmDomains: pq.StringArray{testDomain},
 					},
 				},
+				Token: "token",
 			},
 			Expected: TestCaseExpected{
 				Err: nil,
@@ -186,6 +188,7 @@ func TestHostConf(t *testing.T) {
 						},
 						RealmName: testRealm,
 					},
+					Token: pointy.String("token"),
 				},
 			},
 		},
@@ -193,7 +196,7 @@ func TestHostConf(t *testing.T) {
 	for _, testCase := range testCases {
 		t.Log(testCase.Name)
 		obj := &hostPresenter{cfg: test.GetTestConfig()}
-		output, err := obj.HostConf(testCase.Given.Input)
+		output, err := obj.HostConf(testCase.Given.Input, testCase.Given.Token)
 		if testCase.Expected.Err != nil {
 			require.Error(t, err)
 			assert.Equal(t, testCase.Expected.Err.Error(), err.Error())
@@ -221,6 +224,9 @@ func TestHostConf(t *testing.T) {
 			assert.Equal(t,
 				testCase.Expected.Output.RhelIdm.EnrollmentServers,
 				output.RhelIdm.EnrollmentServers)
+			assert.Equal(t,
+				testCase.Expected.Output.Token,
+				output.Token)
 		}
 	}
 }

--- a/test/scripts/ephe-signing-keys.sh
+++ b/test/scripts/ephe-signing-keys.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
+
+unset X_RH_IDENTITY
+unset X_RH_FAKE_IDENTITY
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/signing_keys"

--- a/test/scripts/local-hostconf.sh
+++ b/test/scripts/local-hostconf.sh
@@ -8,7 +8,7 @@ FQDN="$2"
 [ "${INVENTORY_ID}" != "" ] || error "INVENTORY_ID is empty"
 [ "${FQDN}" != "" ] || error "FQDN is empty"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_system)}"
 export X_RH_IDM_VERSION
 unset X_RH_FAKE_IDENTITY
 unset CREDS

--- a/test/scripts/local-signing-keys.sh
+++ b/test/scripts/local-signing-keys.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
+
+unset X_RH_IDENTITY
+unset X_RH_FAKE_IDENTITY
+unset CREDS
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/signing_keys"


### PR DESCRIPTION
Implement minimal host conf token and signing JWK.

A private ECDSA key is genenerated from a hard-coded seed and the JWK is
stored in memory. In the future, the ECDSA key will be generated from a
random source and the JWK stored in the database.

The `GET /signing_keys` endpoint returns the public JWK.

The `POST /host-conf` endpoint now returns a signed token.


Signed-off-by: Christian Heimes <cheimes@redhat.com>