### PR TITLE
HMS-2714 fix description and title validation

### DIFF
--- a/internal/infrastructure/middleware/validate_api.go
+++ b/internal/infrastructure/middleware/validate_api.go
@@ -262,6 +262,7 @@ func RequestResponseValidatorWithConfig(config *RequestResponseValidatorConfig) 
 				if err != nil {
 					c.Response().Header().Set(echo.HeaderContentType, "text/plain")
 					c.String(http.StatusBadRequest, err.Error())
+					return nil // stop processing
 				}
 			}
 

--- a/internal/infrastructure/middleware/validate_api_test.go
+++ b/internal/infrastructure/middleware/validate_api_test.go
@@ -91,6 +91,32 @@ MII..
 	assert.EqualError(t, err, "Failed to decode CA certificate")
 }
 
+func TestCheckUtf8SingleLine(t *testing.T) {
+	var err error
+
+	err = checkUtf8SingleLine("This is an invalid utf-8 string\xF1")
+	assert.EqualError(t, err, "not a valid utf-8 string")
+
+	err = checkUtf8SingleLine("This is an invalid title\n")
+	assert.EqualError(t, err, "invalid code point: U+000A")
+
+	err = checkUtf8SingleLine("This a valid title")
+	assert.NoError(t, err)
+}
+
+func TestCheckUtf8MultiLine(t *testing.T) {
+	var err error
+
+	err = checkUtf8MultiLine("\n\r\t\v\fThis is an invalid utf-8 string\xF1")
+	assert.EqualError(t, err, "not a valid utf-8 string")
+
+	err = checkUtf8MultiLine("\n\r\t\v\fThis is an invalid title\x02")
+	assert.EqualError(t, err, "invalid code point: U+0002")
+
+	err = checkUtf8MultiLine("\n\r\t\v\fThis a valid title")
+	assert.NoError(t, err)
+}
+
 func TestInitOpenAPIFormats(t *testing.T) {
 	InitOpenAPIFormats()
 }


### PR DESCRIPTION
The validation regexes for the description and title fields are too
restrictive.  Reasonable values are rejected.

Instead, use callback validators to check that the string values
(which are byte sequences) are valid UTF-8, and they do not contain
control characters (except the description field allows Carriage
Return, Line Feed, and Horizontal Tab).

ALSO

Currently input validation failure does NOT cause processing to
stop.  If somehow the backend operation succeed, that can result in
a 400 Bad Request response, but the target backend operation
completed and database modifications potentially performed.
Also, the normal response data gets appended to the error message.

Update the validation middleware to stop processing when an input
validation error occurs, after setting the response status and body
content (error message).  As a result, no further processing will be
performed.
