### PR TITLE
fix: Changing expiration time to never

### DIFF
--- a/scripts/mk/container.mk
+++ b/scripts/mk/container.mk
@@ -47,7 +47,7 @@ registry-login:
 	$(CONTAINER_ENGINE) login -u "$(CONTAINER_REGISTRY_USER)" -p "$(CONTAINER_REGISTRY_TOKEN)" $(CONTAINER_REGISTRY)
 
 .PHONY: container-build
-container-build: QUAY_EXPIRATION ?= 1d
+container-build: QUAY_EXPIRATION ?= never
 container-build:  ## Build image CONTAINER_IMAGE from CONTAINERFILE using the CONTAINER_CONTEXT_DIR
 	$(USE_GO_CACHE) && mkdir -p $(shell go env GOCACHE) $(shell go env GOMODCACHE) || true
 	$(CONTAINER_ENGINE) build \

--- a/scripts/mk/private.example.mk
+++ b/scripts/mk/private.example.mk
@@ -24,7 +24,7 @@ export QUAY_LOGIN := $(firstword $(subst +, ,$(QUAY_USER)))
 # QUAY_REPOSITORY is used to compose the base image name when deploying into ephemeral
 # TODO Set your QUAY_REPOSITORY ; you have to create it and grant
 #      write permissions to the above robot account
-export QUAY_REPOSITORY :=
+export QUAY_REPOSITORY := 7d
 
 # TODO Update CONTAINER_IMAGE_BASE accoddingly to point out to your repository
 # This should point out to your repository


### PR DESCRIPTION
The images generated by the pipeline are deleted after 1d. This change fixes
the situation by setting the quay.expire-after label into the container images
by default to the value of 'never' which avoids the image being deleted. To let
the developer build its own images during the development lifecycle, that
value can be customized from the scripts/mk/private.example.mk template.