### PR TITLE
infra: Regenerate API and mock from Dependabot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,12 +6,49 @@ on:
   - pull_request
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
+  dependabot:
+    if: "${{ github.event_name == 'pull_request' && startsWith(github.head_ref, 'dependabot/') }}"
+    runs-on: "ubuntu-latest"
+    container: golang:1.19
+    steps:
+      - uses: "actions/checkout@v4"
+        with:
+          submodules: recursive
+
+      - name: "Set git safe directory"
+        run: git config --system --add safe.directory $GITHUB_WORKSPACE
+
+      - name: "Regenerate API"
+        run: make generate-api
+
+      - name: "Regenerate mocks"
+        run: make generate-mock
+
+      - name: "Show diff"
+        run: git diff .
+
+      - name: Get last commit message
+        id: last-commit-message
+        run: |
+          echo "msg=$(git log -1 --pretty=%s)" >> $GITHUB_OUTPUT
+
+      # rewrite Dependabot commit to include auto-generated files
+      - uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: ${{ steps.last-commit-message.outputs.msg }}
+          commit_options: '--amend --no-edit'
+          push_options: '--force'
+          skip_fetch: true
+
   validate:
     runs-on: "ubuntu-latest"
     container: golang:1.19
+    if: ${{ always() }}
+    needs:
+      - dependabot
     steps:
       - uses: "actions/checkout@v4"
         with:


### PR DESCRIPTION
Use GHA to regenerate API and mock files, then rewrite Dependabot's commit.