### PR TITLE
HMS-1832: update domain fixes

### DIFF
--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -318,6 +318,15 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 		return err
 	}
 
+	if data.DomainName != nil &&
+		currentData.DomainName != nil &&
+		*data.DomainName != *currentData.DomainName {
+		return internal_errors.NewHTTPErrorF(
+			http.StatusBadRequest,
+			"'domain_name' may not be changed",
+		)
+	}
+
 	if err = a.fillDomain(currentData, data); err != nil {
 		return err
 	}

--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -306,7 +306,7 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 	}
 
 	subscriptionManagerID := xrhid.Identity.System.CommonName
-	if err = a.isSubscriptionManagerIDAuthorizedToUpdate(
+	if err = ensureSubscriptionManagerIDAuthorizedToUpdate(
 		subscriptionManagerID,
 		currentData.IpaDomain.Servers,
 	); err != nil {

--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -301,7 +301,12 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 
 	// Load Domain data
 	if currentData, err = a.findIpaById(tx, orgID, domain_id); err != nil {
-		// FIXME It is not found it should return a 404 Status
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return internal_errors.NewHTTPErrorF(
+				http.StatusNotFound,
+				err.Error(),
+			)
+		}
 		return err
 	}
 

--- a/internal/handler/impl/domain_handler_private.go
+++ b/internal/handler/impl/domain_handler_private.go
@@ -42,7 +42,10 @@ func ensureSubscriptionManagerIDAuthorizedToUpdate(
 			return nil
 		}
 	}
-	return fmt.Errorf("'subscriptionManagerID' not found into the authorized list of rhel-idm servers")
+	return internal_errors.NewHTTPErrorF(
+		http.StatusForbidden,
+		"'subscriptionManagerID' not found into the authorized list of rhel-idm servers",
+	)
 }
 
 // fillDomain is a helper function to copy Ipa domain

--- a/internal/handler/impl/domain_handler_private.go
+++ b/internal/handler/impl/domain_handler_private.go
@@ -25,7 +25,7 @@ func (a *application) findIpaById(tx *gorm.DB, orgId string, UUID uuid.UUID) (da
 	return data, nil
 }
 
-func (a *application) isSubscriptionManagerIDAuthorizedToUpdate(
+func ensureSubscriptionManagerIDAuthorizedToUpdate(
 	subscriptionManagerID string,
 	servers []model.IpaServer,
 ) error {

--- a/internal/handler/impl/domain_handler_private.go
+++ b/internal/handler/impl/domain_handler_private.go
@@ -25,29 +25,6 @@ func (a *application) findIpaById(tx *gorm.DB, orgId string, UUID uuid.UUID) (da
 	return data, nil
 }
 
-// existsHostInServers verify that the given fqdn exists into the list of
-// IpaServer.
-// fqdn is the fqdn of the host to check.
-// servers is the slice of IpaServer that is defined for the IPA domain.
-// Return nil if the fqdn succesfully match with some item into the list of
-// servers, else return an error.
-func (a *application) existsHostInServers(
-	fqdn string,
-	servers []model.IpaServer,
-) error {
-	if servers == nil {
-		return fmt.Errorf("'servers' cannot be nil")
-	}
-
-	for i := range servers {
-		if servers[i].FQDN == fqdn {
-			return nil
-		}
-	}
-
-	return fmt.Errorf("'fqdn' not found into the list of IPA servers")
-}
-
 func (a *application) isSubscriptionManagerIDAuthorizedToUpdate(
 	subscriptionManagerID string,
 	servers []model.IpaServer,

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
-	"github.com/openlyinc/pointy"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
@@ -142,30 +141,6 @@ func (r *domainRepository) UpdateAgent(
 		data.DomainUuid,
 	); err != nil {
 		return err
-	}
-
-	if data.DomainName != nil {
-		currentDomain.DomainName = data.DomainName
-	} else {
-		currentDomain.DomainName = pointy.String("")
-	}
-
-	if data.Title != nil {
-		currentDomain.Title = data.Title
-	} else {
-		currentDomain.Title = pointy.String("")
-	}
-
-	if data.Description != nil {
-		currentDomain.Description = data.Description
-	} else {
-		currentDomain.Description = pointy.String("")
-	}
-
-	if data.AutoEnrollmentEnabled != nil {
-		currentDomain.AutoEnrollmentEnabled = data.AutoEnrollmentEnabled
-	} else {
-		currentDomain.AutoEnrollmentEnabled = pointy.Bool(false)
 	}
 
 	if err = db.Omit(clause.Associations).


### PR DESCRIPTION
A series of commits addressing HMS-1832.  Recommended to review each commit in sequence, rather than the whole PR diff all at once.

**Why no tests?**  The behavioural changes are mainly at the handler level, and there is no easy way to test that at this time.  Following discussions with @avisiedo , we propose to implement a "smoke test" framework in a (near) future sprint.  It can make it easy to test server behaviour via the service HTTP API, playing out the various scenarios and asserting that response statuses and payloads match expectations.  When this is implemented, it will be straightforward to test the behaviour in this PR - and I shall implement the tests!

```
commit 0d90e0b0e32c8a1c08d37d84fafde46d16253b26
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Tue Oct 31 16:36:53 2023 +1000

    remove unused func

commit 0ef981b34fb8904e51de77234dc4d69d360e6d15
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Tue Oct 31 16:40:34 2023 +1000

    refactor: clarify update authorization check
    
    Rename the function `isSubscriptionManagerIDAuthorizedToUpdate` to
    `ensureSubscriptionManagerIDAuthorizedToUpdate`.  The old name makes
    it seems like it would return a `bool`, when in fact it return `nil`
    on success or an error if there is a problem.
    
    Also convert it from an object method to a bare function, because
    the `application` was unused.

commit fba23dc54c26d88be90935295585f8a4ba691d89
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Tue Oct 31 17:06:08 2023 +1000

    HMS-1832 fix: 403 when server not allowed to update domain
    
    To update a domain, the server (i.e. its RHSM ID) must already exist
    in the domain being updated.  When a client violates this condition,
    the server currently responds 500 Internal Server Error.  Make it
    return 403 Forbidden instead.

commit 86b71c5f42680415e92fa91c619af6e89155a378
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Tue Oct 31 17:06:08 2023 +1000

    HMS-1832 fix: update domain: 404 when not found
    
    When an agent updates a domain (`PUT /domains/{uuid}`), if the
    domain is not found in the current org, the server currently
    responds 500 Internal Server Error.  Make it return 404 Not Found
    instead.

commit 4a169608cde0dde4ace4e4639ff53ab40d071b2a
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Wed Nov 1 16:59:07 2023 +1000

    HMS-1832 fix: prevent changing domain name
    
    Detect if client is attempting to change the domain name.  Return an
    error if so.
    
    Also remove processing related to Title, Description and
    AutoEnrollmentEnabled fields.  These fields do not appear in the
    UpdateDomainAgentRequest payload type.

commit 47b252aa1d33788d0989450bab428c0bc4cd3163
Author: Fraser Tweedale <ftweedal@redhat.com>
Date:   Wed Nov 1 16:59:07 2023 +1000

    HMS-1832 refactor: clean up database operations
    
    Simplify the database operations in the `UpdateAgent` operation.
    
    First, the handler already "merged" the old and new data, so there
    is no need to query (`FindByID`) the target record again.
    
    Second, the model object already has the primary key (`id`) set, so
    remove the unnecessary `Where` clause.
    
    Third, in `updateIpaDomain()`, after the (cascading) deletion of the
    previous associations, simply use `Create` *without*
    `Omit(clause.Associations)`.  This recursively inserts the new or
    updated associations and avoids the manual iteration and insertion
    of the child server, certificate and location objects.
    
    Unfortunately, I could not find a way to avoid the explicit deletion
    of the existing associations.  I tried many permutations but in each
    case, the old associations were persisting and resulting in
    duplicated and/or obsolete values.\
```