### PR TITLE
compose: use correct account for healthcheck

### DIFF
--- a/deployments/backend-compose.yaml
+++ b/deployments/backend-compose.yaml
@@ -1,3 +1,4 @@
+### This file is used by ipa-hcc CI jobs
 ---
 version: "3.0"
 services:
@@ -8,6 +9,9 @@ services:
       - POSTGRES_DB=${DATABASE_NAME:-idmsvc-db}
       - POSTGRES_USER=${DATABASE_USER:-idmsvc-user}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-idmsvc-secret}
+      - PGDATABASE=${DATABASE_NAME:-idmsvc-db}
+      - PGUSER=${DATABASE_USER:-idmsvc-user}
+      - PGPASSWORD=${DATABASE_PASSWORD:-idmsvc-secret}
     ports:
       - ${DATABASE_EXTERNAL_PORT:-5432}:5432/tcp
     volumes:

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -25,6 +25,9 @@ services:
       - POSTGRES_DB=${DATABASE_NAME:-idmsvc-db}
       - POSTGRES_USER=${DATABASE_USER:-idmsvc-user}
       - POSTGRES_PASSWORD=${DATABASE_PASSWORD:-idmsvc-secret}
+      - PGDATABASE=${DATABASE_NAME:-idmsvc-db}
+      - PGUSER=${DATABASE_USER:-idmsvc-user}
+      - PGPASSWORD=${DATABASE_PASSWORD:-idmsvc-secret}
     ports:
       - ${DATABASE_EXTERNAL_PORT:-5432}:5432/tcp
     volumes:


### PR DESCRIPTION
The compose currently attempts to connect as the container user "root".  This role does not exist in the postgresql server.  The liveness test does succeed, but it fills the "log" (stdout) with annoying messages:

    ... FATAL:  role "root" does not exist

`pg_isready` recognises the standard *libpq* environment variables: https://www.postgresql.org/docs/16/libpq-envars.html.  Set the `PGDATABASE`, `PGUSER` and `PGPASSWORD` environment variables in the database container environment to ensure that the connect test uses a valid account.  As a result, the log output no longer contains the the above message every few seconds.