### PR TITLE
HMS-1832: refactor: PUT /domains/:domain_id using upserts (defered)

### DIFF
--- a/docs/dev/01-service-api.md
+++ b/docs/dev/01-service-api.md
@@ -355,4 +355,6 @@ field:
 ## References
 
 - Public APIs: https://console.redhat.com/docs/api
+- Situation with GORM and related objects when updating:
+  https://github.com/go-gorm/gorm/issues/3487
 

--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -327,18 +327,14 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 		)
 	}
 
-	if err = a.fillDomain(currentData, data); err != nil {
-		return err
-	}
-
-	if err = a.domain.repository.UpdateAgent(tx, orgID, currentData); err != nil {
+	if err = a.domain.repository.UpdateAgent(tx, orgID, currentData, data); err != nil {
 		return err
 	}
 	if err = tx.Commit().Error; err != nil {
 		return tx.Error
 	}
 
-	if output, err = a.domain.presenter.UpdateAgent(currentData); err != nil {
+	if output, err = a.domain.presenter.UpdateAgent(data); err != nil {
 		return err
 	}
 

--- a/internal/handler/impl/domain_handler_private.go
+++ b/internal/handler/impl/domain_handler_private.go
@@ -123,6 +123,7 @@ func (a *application) fillDomainUser(
 }
 
 func (a *application) fillDomainIpa(target *model.Ipa, source *model.Ipa) error {
+	target.Model = source.Model
 	if source.RealmName != nil {
 		target.RealmName = pointy.String(*source.RealmName)
 	}

--- a/internal/interface/repository/domain_repository.go
+++ b/internal/interface/repository/domain_repository.go
@@ -24,7 +24,7 @@ type DomainRepository interface {
 	FindByID(db *gorm.DB, orgID string, UUID uuid.UUID) (output *model.Domain, err error)
 	DeleteById(db *gorm.DB, orgID string, UUID uuid.UUID) (err error)
 	Register(db *gorm.DB, orgID string, data *model.Domain) (err error)
-	UpdateAgent(db *gorm.DB, orgID string, data *model.Domain) (err error)
+	UpdateAgent(db *gorm.DB, orgID string, oldData *model.Domain, newData *model.Domain) (err error)
 	UpdateUser(db *gorm.DB, orgID string, data *model.Domain) (err error)
 	CreateDomainToken(key []byte, validity time.Duration, orgID string, domainType public.DomainType) (token *DomainRegToken, err error)
 }

--- a/internal/test/mock/interface/repository/domain_repository.go
+++ b/internal/test/mock/interface/repository/domain_repository.go
@@ -134,13 +134,13 @@ func (_m *DomainRepository) Register(db *gorm.DB, orgID string, data *model.Doma
 	return r0
 }
 
-// UpdateAgent provides a mock function with given fields: db, orgID, data
-func (_m *DomainRepository) UpdateAgent(db *gorm.DB, orgID string, data *model.Domain) error {
-	ret := _m.Called(db, orgID, data)
+// UpdateAgent provides a mock function with given fields: db, orgID, oldData, newData
+func (_m *DomainRepository) UpdateAgent(db *gorm.DB, orgID string, oldData *model.Domain, newData *model.Domain) error {
+	ret := _m.Called(db, orgID, oldData, newData)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, *model.Domain) error); ok {
-		r0 = rf(db, orgID, data)
+	if rf, ok := ret.Get(0).(func(*gorm.DB, string, *model.Domain, *model.Domain) error); ok {
+		r0 = rf(db, orgID, oldData, newData)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -420,12 +420,12 @@ func (r *domainRepository) createIpaDomain(
 	return nil
 }
 
-func (r *domainRepository) ipaFillUpdateAgentReminders(oldData *model.Domain, newData *model.Domain) (remCerts []uint, remServers []uint, remLocations []uint) {
+func (r *domainRepository) ipaFillUpdateAgentRemainders(oldData *model.Domain, newData *model.Domain) (remCerts []uint, remServers []uint, remLocations []uint) {
 	remCerts = nil
 	remServers = nil
 	remLocations = nil
 
-	// Check cert reminders
+	// Check cert remainders
 	OldLenCerts := len(oldData.IpaDomain.CaCerts)
 	NewLenCerts := len(newData.IpaDomain.CaCerts)
 	if OldLenCerts > NewLenCerts {
@@ -435,7 +435,7 @@ func (r *domainRepository) ipaFillUpdateAgentReminders(oldData *model.Domain, ne
 		}
 	}
 
-	// Check servers reminders
+	// Check servers remainders
 	OldLenServers := len(oldData.IpaDomain.Servers)
 	NewLenServers := len(newData.IpaDomain.Servers)
 	if OldLenServers > NewLenServers {
@@ -445,7 +445,7 @@ func (r *domainRepository) ipaFillUpdateAgentReminders(oldData *model.Domain, ne
 		}
 	}
 
-	// Check location reminders
+	// Check location remainders
 	OldLenLocations := len(oldData.IpaDomain.Locations)
 	NewLenLocations := len(newData.IpaDomain.Locations)
 	if OldLenLocations > NewLenLocations {
@@ -458,7 +458,7 @@ func (r *domainRepository) ipaFillUpdateAgentReminders(oldData *model.Domain, ne
 }
 
 func (r *domainRepository) ipaFillUpdateAgent(oldData *model.Domain, newData *model.Domain) (remCerts []uint, remServers []uint, remLocations []uint, err error) {
-	remCerts, remServers, remLocations = r.ipaFillUpdateAgentReminders(oldData, newData)
+	remCerts, remServers, remLocations = r.ipaFillUpdateAgentRemainders(oldData, newData)
 
 	newData.Model = oldData.Model
 	newData.IpaDomain.Model = oldData.IpaDomain.Model

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -404,49 +404,6 @@ func (s *Suite) TestUpdateAgent() {
 	require.NoError(t, err)
 }
 
-func (s *Suite) helperTestUpdateUser(stage int, data *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
-	if stage == 0 {
-		return
-	}
-	if stage < 0 {
-		panic("'stage' cannot be lower than 0")
-	}
-	if stage > 2 {
-		panic("'stage' cannot be greater than 3")
-	}
-
-	s.mock.MatchExpectationsInOrder(true)
-	for i := 1; i <= stage; i++ {
-		switch i {
-		case 1:
-			if i == stage && expectedErr != nil {
-				s.helperTestFindByID(1, data, mock, expectedErr)
-			} else {
-				s.helperTestFindByID(5, data, mock, nil)
-			}
-		case 2: // Update
-			expectExec := mock.ExpectExec(regexp.QuoteMeta(`UPDATE "domains" SET "auto_enrollment_enabled"=$1,"description"=$2,"title"=$3 WHERE (org_id = $4 AND domain_uuid = $5) AND "domains"."deleted_at" IS NULL AND "id" = $6`)).
-				WithArgs(
-					data.AutoEnrollmentEnabled,
-					data.Description,
-					data.Title,
-
-					data.OrgId,
-					data.DomainUuid,
-					data.ID,
-				)
-			if i == stage && expectedErr != nil {
-				expectExec.WillReturnError(expectedErr)
-			} else {
-				expectExec.WillReturnResult(
-					driver.RowsAffected(1))
-			}
-		default:
-			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
-		}
-	}
-}
-
 func (s *Suite) helperTestUpdateIpaDomain(stage int, data *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
 	if stage == 0 {
 		return
@@ -1193,6 +1150,49 @@ func (s *Suite) TestFindByID() {
 	assert.Equal(t, data.DomainName, domain.DomainName)
 	assert.Equal(t, data.DomainUuid, domain.DomainUuid)
 	assert.Equal(t, data.Type, domain.Type)
+}
+
+func (s *Suite) helperTestUpdateUser(stage int, data *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
+	if stage == 0 {
+		return
+	}
+	if stage < 0 {
+		panic("'stage' cannot be lower than 0")
+	}
+	if stage > 2 {
+		panic("'stage' cannot be greater than 3")
+	}
+
+	s.mock.MatchExpectationsInOrder(true)
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			if i == stage && expectedErr != nil {
+				s.helperTestFindByID(1, data, mock, expectedErr)
+			} else {
+				s.helperTestFindByID(5, data, mock, nil)
+			}
+		case 2: // Update
+			expectExec := mock.ExpectExec(regexp.QuoteMeta(`UPDATE "domains" SET "auto_enrollment_enabled"=$1,"description"=$2,"title"=$3 WHERE (org_id = $4 AND domain_uuid = $5) AND "domains"."deleted_at" IS NULL AND "id" = $6`)).
+				WithArgs(
+					data.AutoEnrollmentEnabled,
+					data.Description,
+					data.Title,
+
+					data.OrgId,
+					data.DomainUuid,
+					data.ID,
+				)
+			if i == stage && expectedErr != nil {
+				expectExec.WillReturnError(expectedErr)
+			} else {
+				expectExec.WillReturnResult(
+					driver.RowsAffected(1))
+			}
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
 }
 
 func (s *Suite) TestUpdateUser() {

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -240,7 +240,7 @@ func (s *Suite) TestCreateIpaDomain() {
 	assert.NoError(t, err)
 }
 
-func (s *Suite) helperTestUpdateAgentReminders(stage int, oldData *model.Domain, newData *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
+func (s *Suite) helperTestUpdateAgentRemainders(stage int, oldData *model.Domain, newData *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
 	if stage == 0 {
 		return
 	}
@@ -479,14 +479,14 @@ func (s *Suite) TestUpdateAgent() {
 	require.EqualError(t, err, "error at UpdateAgent")
 	require.NoError(t, s.mock.ExpectationsWereMet())
 
-	// Success scenario with no reminders
+	// Success scenario with no remainders
 	s.helperTestUpdateAgent(5, oldData, newData1, s.mock, nil)
 	err = s.repository.UpdateAgent(s.DB, orgID, oldData, newData1)
 	require.NoError(t, err)
 	require.NoError(t, s.mock.ExpectationsWereMet())
 
-	// Success scenario with reminders
-	s.helperTestUpdateAgentReminders(4, oldData, newData2, s.mock, nil)
+	// Success scenario with remainders
+	s.helperTestUpdateAgentRemainders(4, oldData, newData2, s.mock, nil)
 	err = s.repository.UpdateAgent(s.DB, orgID, oldData, newData2)
 	require.NoError(t, err)
 	require.NoError(t, s.mock.ExpectationsWereMet())
@@ -1225,7 +1225,7 @@ func (s *Suite) TestCheckCommonAndDataUpdateAgent() {
 	assert.NoError(t, err)
 }
 
-func (s *Suite) TestIpaFillUpdateAgentReminders() {
+func (s *Suite) TestIpaFillUpdateAgentRemainders() {
 	t := s.T()
 
 	var (
@@ -1503,12 +1503,12 @@ func (s *Suite) TestIpaFillUpdateAgentReminders() {
 		}
 	)
 
-	remCerts, remServers, remLocations = s.repository.ipaFillUpdateAgentReminders(oldData, newData1)
+	remCerts, remServers, remLocations = s.repository.ipaFillUpdateAgentRemainders(oldData, newData1)
 	assert.Equal(t, 0, len(remCerts))
 	assert.Equal(t, 0, len(remServers))
 	assert.Equal(t, 0, len(remLocations))
 
-	remCerts, remServers, remLocations = s.repository.ipaFillUpdateAgentReminders(oldData, newData2)
+	remCerts, remServers, remLocations = s.repository.ipaFillUpdateAgentRemainders(oldData, newData2)
 	assert.Equal(t, 1, len(remCerts))
 	assert.Equal(t, 1, len(remServers))
 	assert.Equal(t, 1, len(remLocations))

--- a/test/data/http/update-rhel-idm-domain.json
+++ b/test/data/http/update-rhel-idm-domain.json
@@ -2,20 +2,20 @@
   "domain_name": "mydomain.example",
   "domain_type": "rhel-idm",
   "rhel-idm": {
-    "realm_name": "MYDOMAIN.EXAMPLE",
+    "realm_name": "UPDATE-MYDOMAIN.EXAMPLE",
     "servers": [
       {
-        "fqdn": "ipaserver.mydomain.example",
+        "fqdn": "update-ipaserver.mydomain.example",
         "subscription_manager_id": "{{subscription_manager_id}}",
-        "location": "boston",
+        "location": "update-europe",
         "ca_server": true,
         "hcc_enrollment_server": true,
         "hcc_update_server": true,
         "pkinit_server": true
       },
       {
-        "fqdn": "server2.mydomain.example",
-        "subscription_manager_id": "6f324116-b3d2-11ed-8a37-482ae3863d30",
+        "fqdn": "update-server2.mydomain.example",
+        "subscription_manager_id": "46004b9e-79a7-11ee-b52d-482ae3863d30",
         "ca_server": false,
         "hcc_enrollment_server": false,
         "hcc_update_server": false,
@@ -24,9 +24,9 @@
     ],
     "ca_certs": [
       {
-        "nickname": "MYDOMAIN.EXAMPLE IPA CA",
-        "issuer": "CN=Certificate Authority, O=MYDOMAIN.EXAMPLE",
-        "subject": "CN=My Domain, O=MYDOMAIN.EXAMPLE",
+        "nickname": "UPDATE-MYDOMAIN.EXAMPLE IPA CA",
+        "issuer": "CN=Certificate Authority, O=UPDATE-MYDOMAIN.EXAMPLE",
+        "subject": "CN=My Domain, O=UPDATE-MYDOMAIN.EXAMPLE",
         "serial_number": "1",
         "not_before": "2023-01-31T13:23:36Z",
         "not_after": "2023-01-31T13:23:36Z",
@@ -35,12 +35,12 @@
     ],
     "locations": [
       {
-        "name": "europe",
-        "description": "Europe data center"
+        "name": "update-europe",
+        "description": "Updated europe data center"
       }
     ],
     "realm_domains": [
-      "mydomain.example"
+      "update-mydomain.example"
     ]
   }
 }


### PR DESCRIPTION
(defered)

This change try to enhance how the PUT /domains/:domain_id endpoints works with the database layer, so to enhance the operations with the database, by using upserts and deleting only when necessary the remaining records for certificates, servers and locations.

TODO
- [x] Rebase