### PR TITLE
HMS-3154 test: read domain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,29 @@ permissions:
 
 jobs:
   validate:
+    # https://docs.github.com/en/actions/using-containerized-services/creating-postgresql-service-containers
+    services:
+      postgres:
+        # https://hub.docker.com/_/postgres/
+        image: postgres:13
+        env:
+          POSTGRES_USERNAME: postgres
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     runs-on: "ubuntu-latest"
     container: golang:1.20
+    env:
+      DATABASE_HOST: postgres
+      DATABASE_PORT: 5432
+      DATABASE_USER: postgres
+      DATABASE_NAME: postgres
+      DATABASE_PASSWORD: postgres
     steps:
       - uses: "actions/checkout@v4"
         with:
@@ -55,7 +76,10 @@ jobs:
         run: go vet $(go list ./... | grep -v /vendor/)
 
       - name: Run tests
-        run: make test
+        run: |
+          cp -vf configs/config.ci.yaml configs/config.yaml
+          make db-migrate-up
+          make test
 
       - name: Process coverage report
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ tmp.*/**
 
 configs/**
 !configs/config.example.yaml
+!configs/config.ci.yaml
 !configs/bonfire.example.yaml
 
 # File generated when running unit tests

--- a/configs/config.ci.yaml
+++ b/configs/config.ci.yaml
@@ -1,0 +1,82 @@
+---
+logging:
+  level: info   # The normal level in production
+  # level: trace  # Will display the sql statements, usefult for development
+  # level: debug
+  # Set to false to get a json output for the log
+  console: true
+
+web:
+  port: 8000
+
+database:
+  host: localhost
+  port: 5432
+  user: postgres
+  password: postgres
+  name: postgres
+
+kafka:
+  auto:
+    offset:
+      reset: latest
+    commit:
+      interval:
+        ms: 5000
+  bootstrap:
+    servers: localhost:9092
+  group:
+    id: idmsvc
+  message:
+    send:
+      max:
+        retries: 15
+  request:
+    timeout:
+      ms: 30000
+    required:
+      acks: -1
+  retry:
+    backoff:
+      ms: 100
+  timeout: 10000
+  topics:
+    - platform.idmsvc.introspect
+  # sasl:
+  #   username: someusername
+  #   passowrd: somepassword
+  #   mechanism: somemechanism
+  #   protocol: someprotocol
+
+# cloudwatch:
+#   region:
+#   group:
+#   stream:
+#   key:
+#   secret:
+#   session:
+# options:
+#   paged_rpm_inserts_limit: 100
+metrics:
+  path: "/metrics"
+  port: 9000
+
+clients:
+  inventory:
+    base_url: http://localhost:8010/api/inventory/v1
+
+app:
+  # Token expiration time in seconds
+  # default: 2 hours
+  token_expiration_seconds: 7200
+  # The pagination default limit for the first list request
+  pagination_default_limit: 10
+  # The pagination max limit to avoid bigger values and long requests
+  pagination_max_limit: 100
+  # Allow to inject a system identity for development propose
+  accept_x_rh_fake_identity: false
+  # Validate API requests and response against the openapi specification
+  validate_api: true
+  # main secret for various MAC and encryptions like domain registration
+  # token and encrypted private JWKs. "random" generates an ephemeral secret.
+  secret: random

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to HMS IDM
+# Contributing to idmsvc-backend
 
 ## Getting Started
 
 The repository is using [Github flow](https://docs.github.com/en/get-started/quickstart/github-flow).
 
-- Fork the repository in your namespace.
+- [Fork](https://github.com/podengo-project/idmsvc-backend/fork) the repository in your namespace.
 - Clone the repository locally.
-- Create a branch.
+- Create a branch: `git checkout -b my-cool-changes`
 - Add changes:
   - If you change the api, run `make generate-api`.
   - If you add/update golang interfaces, run `make generate-mock`
@@ -14,10 +14,8 @@ The repository is using [Github flow](https://docs.github.com/en/get-started/qui
 - Check everything build: `make build`
 - Check locally by using: `make compose-clean compose-up run`
 - Check it deploys and works in ephemeral by: `make ephemeral-deploy`
-- Add unit tests, if your change add a new interface, generate the mocks.
-  by `make generate-mocks`; they will be generated at `internal/test/mock`
-  package. See [TESTING.md](./dev/TESTING.md).
-- Check unit tests and linters are pasing by `make test lint`
+- Add tests. See [TESTING.md](./dev/TESTING.md).
+- Check everything is ok: `make compose-clean clean build lint vet compose-up test`
 - Rebase and push your changes, and create a MR or PR.
 - Update changes from the review until you get an ACK.
 - Merge your changes :)

--- a/docs/dev/01-service-api.md
+++ b/docs/dev/01-service-api.md
@@ -227,6 +227,7 @@ for the interface, it seems logic to add the implementations at:
 ## Adding a new `myres` resource to my public api
 
 - Add the data model at: `internal/domain/model/myres.go`
+- Add a builder for the API Rest involved at: `internal/test/builder`
 - Generate the migration scripts by: `make build && ./bin/db-tool new myres`
 - Fill the migration scripts at: `scripts/db/migrations/`
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/lib/pq v1.10.9
 	github.com/oapi-codegen/runtime v1.1.0
 	github.com/openlyinc/pointy v1.2.1
+	github.com/pioz/faker v1.7.3
 	github.com/prometheus/client_golang v1.17.0
 	github.com/qri-io/jsonschema v0.2.1
 	github.com/redhatinsights/app-common-go v1.6.7

--- a/go.sum
+++ b/go.sum
@@ -235,6 +235,8 @@ github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/perimeterx/marshmallow v1.1.5 h1:a2LALqQ1BlHM8PZblsDdidgv1mWi1DgC2UmX50IvK2s=
 github.com/perimeterx/marshmallow v1.1.5/go.mod h1:dsXbUu8CRzfYP5a87xpp0xq9S3u0Vchtcl8we9tYaXw=
+github.com/pioz/faker v1.7.3 h1:Tez8Emuq0UN+/d6mo3a9m/9ZZ/zdfJk0c5RtRatrceM=
+github.com/pioz/faker v1.7.3/go.mod h1:xSpay5w/oz1a6+ww0M3vfpe40pSIykeUPeWEc3TvVlc=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/internal/test/assert/domain.go
+++ b/internal/test/assert/domain.go
@@ -1,0 +1,151 @@
+package assert
+
+import (
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// AssertDomain asserts that the expected domain with the current domain value without
+// consider the domain id field and without consider the gorm.Model data.
+// t the current test in progress.
+// expected is the expected domain.
+// current is the current resulting domain that should match with the expectation.
+func AssertDomain(t *testing.T, expected *public.Domain, current *public.Domain) {
+	if expected == current {
+		return
+	}
+	require.NotNil(t, expected)
+	require.NotNil(t, current)
+
+	assert.Equal(t, expected.DomainId, current.DomainId)
+	assert.Equal(t, expected.Title, current.Title)
+	assert.Equal(t, expected.Description, current.Description)
+	assert.Equal(t, expected.AutoEnrollmentEnabled, current.AutoEnrollmentEnabled)
+	require.Equal(t, expected.DomainType, current.DomainType)
+	if current.DomainType == "" {
+		return
+	}
+	switch current.DomainType {
+	case public.RhelIdm:
+		AssertDomainIpa(t, expected.RhelIdm, current.RhelIdm)
+	default:
+		t.Errorf("body.DomainType has an unexpected value")
+	}
+}
+
+// AssertDomainIpa asserts the current domain ipa data match the expectation
+// without consider the gorm.Model data.
+// t represents the current test.
+// expected represents the expected domain ipa values.
+// current represents the resulting domain ipa values.
+func AssertDomainIpa(t *testing.T, expected *public.DomainIpa, current *public.DomainIpa) {
+	require.NotNil(t, expected)
+	require.NotNil(t, current)
+
+	assert.Equal(t, expected.RealmName, current.RealmName)
+	assert.Equal(t, expected.RealmDomains, current.RealmDomains)
+	AssertLocations(t, expected.Locations, current.Locations)
+	AssertServers(t, expected.Servers, current.Servers)
+	AssertCaCerts(t, expected.CaCerts, expected.CaCerts)
+	require.NotNil(t, len(expected.Locations), len(current.Locations))
+	for i := range expected.Locations {
+		assert.Equal(t, expected.Locations[i], current.Locations[i])
+	}
+	AssertAutomountLocations(t, expected.AutomountLocations, current.AutomountLocations)
+}
+
+// AssertLocations asserts the current slice of Locations match
+// the slice of expected ones.
+// t represents the current test.
+// expected represents the expected slice of Location values.
+// current represents the resulting slice of Location values.
+func AssertLocations(t *testing.T, expected []public.Location, current []public.Location) {
+	if expected == nil && nil == current {
+		return
+	}
+	require.Equal(t, len(expected), len(current))
+	foundEquals := 0
+	for i := range expected {
+		for j := range current {
+			if expected[i].Name == current[j].Name &&
+				expected[i].Description != nil && current[j].Description != nil &&
+				*expected[i].Description == *current[j].Description {
+				foundEquals++
+			}
+		}
+	}
+	assert.Equal(t, foundEquals, len(current))
+}
+
+// AssertServers asserts the current slice of public.DomainIpaServer match
+// the slice of expected ones.
+// t represents the current test.
+// expected represents the expected slice of public.DomainIpaServer values.
+// current represents the resulting slice of public.DomainIpaServer values.
+func AssertServers(t *testing.T, expected []public.DomainIpaServer, current []public.DomainIpaServer) {
+	if expected == nil && current == nil {
+		return
+	}
+	require.Equal(t, len(expected), len(current))
+	for i := range expected {
+		for j := range current {
+			if expected[i].Fqdn == current[j].Fqdn {
+				assert.Equal(t, expected[i].CaServer, current[j].CaServer)
+				assert.Equal(t, expected[i].HccEnrollmentServer, current[j].HccEnrollmentServer)
+				assert.Equal(t, expected[i].HccUpdateServer, current[j].HccUpdateServer)
+				assert.Equal(t, expected[i].PkinitServer, current[j].PkinitServer)
+				assert.Equal(t, expected[i].SubscriptionManagerId, current[j].SubscriptionManagerId)
+				assert.Equal(t, expected[i].Location, current[j].Location)
+			}
+		}
+	}
+}
+
+// AssertCaCerts asserts the current slice of public.Certificate match
+// the slice of expected ones.
+// t represents the current test.
+// expected represents the expected slice of public.Certificate values.
+// current represents the resulting slice of public.Certificate values.
+func AssertCaCerts(t *testing.T, expected []public.Certificate, current []public.Certificate) {
+	require.NotNil(t, expected)
+	require.NotNil(t, current)
+	require.Equal(t, len(expected), len(current))
+
+	for i := range expected {
+		for j := range current {
+			if expected[i].Issuer == current[j].Issuer && expected[i].SerialNumber == current[j].SerialNumber {
+				assert.Equal(t, expected[i].Issuer, current[j].Issuer)
+				assert.Equal(t, expected[i].Nickname, current[j].Nickname)
+				assert.Equal(t, expected[i].NotAfter, current[j].NotAfter)
+				assert.Equal(t, expected[i].NotBefore, current[j].NotBefore)
+				assert.Equal(t, expected[i].Pem, current[j].Pem)
+				assert.Equal(t, expected[i].Subject, current[i].Subject)
+			}
+		}
+	}
+}
+
+// AssertAutomountLocations asserts the current slice for automount locations with
+// the slice of expected ones.
+// t represents the current test.
+// expected represents the expected slice of strings or nil.
+// current represents the resulting slice of strings or nil.
+func AssertAutomountLocations(t *testing.T, expected *[]string, current *[]string) {
+	if expected == current {
+		return
+	}
+	require.NotNil(t, expected, current)
+	require.Equal(t, len(*expected), len(*current))
+	countEquals := 0
+	for i := range *expected {
+		for j := range *current {
+			if (*expected)[i] == (*current)[j] {
+				countEquals++
+			}
+		}
+	}
+	require.Equal(t, countEquals, len(*current))
+}

--- a/internal/test/builder/api/builder_domain.go
+++ b/internal/test/builder/api/builder_domain.go
@@ -1,0 +1,61 @@
+package api
+
+import (
+	"github.com/google/uuid"
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+)
+
+type Domain interface {
+	Build() *public.Domain
+	WithDomainID(value *uuid.UUID) Domain
+	WithAutoEnrollmentEnabled(value *bool) Domain
+	WithDescription(value *string) Domain
+	WithTitle(value *string) Domain
+	WithRhelIdm(value *public.DomainIpa) Domain
+}
+
+type domain public.Domain
+
+func NewDomain(domainName string) Domain {
+	domainID := uuid.New()
+	return &domain{
+		DomainId:              &domainID,
+		AutoEnrollmentEnabled: builder_helper.GenRandPointyBool(),
+		Description:           pointy.String(builder_helper.GenRandParagraph(0)),
+		DomainName:            domainName,
+		DomainType:            public.RhelIdm,
+		Title:                 pointy.String(domainName),
+		RhelIdm:               NewRhelIdmDomain(domainName).Build(),
+	}
+}
+
+func (b *domain) Build() *public.Domain {
+	return (*public.Domain)(b)
+}
+
+func (b *domain) WithDomainID(value *uuid.UUID) Domain {
+	b.DomainId = value
+	return b
+}
+
+func (b *domain) WithAutoEnrollmentEnabled(value *bool) Domain {
+	b.AutoEnrollmentEnabled = value
+	return b
+}
+
+func (b *domain) WithDescription(value *string) Domain {
+	b.Description = value
+	return b
+}
+
+func (b *domain) WithTitle(value *string) Domain {
+	b.Title = value
+	return b
+}
+
+func (b *domain) WithRhelIdm(value *public.DomainIpa) Domain {
+	b.RhelIdm = value
+	return b
+}

--- a/internal/test/builder/api/builder_domain_rhel_idm.go
+++ b/internal/test/builder/api/builder_domain_rhel_idm.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"strings"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+)
+
+type RhelIdmDomain interface {
+	Build() *public.DomainIpa
+	WithRealmDomains(values []string) RhelIdmDomain
+	AddRealmDomain(value string) RhelIdmDomain
+	WithCaCerts(values []public.Certificate) RhelIdmDomain
+	AddCaCert(value public.Certificate) RhelIdmDomain
+	WithLocations(values []public.Location) RhelIdmDomain
+	AddLocation(value public.Location) RhelIdmDomain
+	WithServers(values []public.DomainIpaServer) RhelIdmDomain
+	AddServer(value public.DomainIpaServer) RhelIdmDomain
+	WithAutomounLocations(values *[]string) RhelIdmDomain
+	AddAutomountLocation(value string) RhelIdmDomain
+}
+
+type rhelIdmDomain public.DomainIpa
+
+func NewRhelIdmDomain(domainName string) RhelIdmDomain {
+	data := &rhelIdmDomain{
+		RealmName:          strings.ToUpper(domainName),
+		RealmDomains:       []string{domainName},
+		CaCerts:            []public.Certificate{},
+		Locations:          []public.Location{},
+		Servers:            []public.DomainIpaServer{},
+		AutomountLocations: nil,
+	}
+	// TODO Implement to fill some random values
+	data.CaCerts = append(data.CaCerts,
+		NewCertificate(data.RealmName).
+			Build(),
+	)
+	locationLabel := builder_helper.GenRandLocationLabel()
+	data.Locations = append(data.Locations,
+		NewLocation().
+			WithName(locationLabel).
+			WithDescription(locationLabel).
+			Build(),
+	)
+	data.Servers = append(data.Servers,
+		NewDomainIpaServer(builder_helper.GenRandFQDNWithDomain(domainName)).
+			Build(),
+	)
+	// TODO Add some AutomountLocation
+	return data
+}
+
+func (b *rhelIdmDomain) Build() *public.DomainIpa {
+	return (*public.DomainIpa)(b)
+}
+
+func (b *rhelIdmDomain) WithRealmDomains(values []string) RhelIdmDomain {
+	b.RealmDomains = values
+	return b
+}
+
+func (b *rhelIdmDomain) AddRealmDomain(value string) RhelIdmDomain {
+	b.RealmDomains = append(b.RealmDomains, value)
+	return b
+}
+
+func (b *rhelIdmDomain) WithCaCerts(values []public.Certificate) RhelIdmDomain {
+	b.CaCerts = values
+	return b
+}
+
+func (b *rhelIdmDomain) AddCaCert(value public.Certificate) RhelIdmDomain {
+	b.CaCerts = append(b.CaCerts, value)
+	return b
+}
+
+func (b *rhelIdmDomain) WithLocations(values []public.Location) RhelIdmDomain {
+	b.Locations = values
+	return b
+}
+
+func (b *rhelIdmDomain) AddLocation(value public.Location) RhelIdmDomain {
+	b.Locations = append(b.Locations, value)
+	return b
+}
+
+func (b *rhelIdmDomain) WithServers(values []public.DomainIpaServer) RhelIdmDomain {
+	b.Servers = values
+	return b
+}
+
+func (b *rhelIdmDomain) AddServer(value public.DomainIpaServer) RhelIdmDomain {
+	b.Servers = append(b.Servers, value)
+	return b
+}
+
+func (b *rhelIdmDomain) WithAutomounLocations(values *[]string) RhelIdmDomain {
+	b.AutomountLocations = values
+	return b
+}
+
+func (b *rhelIdmDomain) AddAutomountLocation(value string) RhelIdmDomain {
+	if b.AutomountLocations == nil {
+		b.AutomountLocations = &[]string{}
+	}
+	*b.AutomountLocations = append(*b.AutomountLocations, value)
+	return b
+}

--- a/internal/test/builder/api/builder_domain_rhel_idm_ca_cert.go
+++ b/internal/test/builder/api/builder_domain_rhel_idm_ca_cert.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"strconv"
+	"time"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+)
+
+type Certificate interface {
+	Build() public.Certificate
+	WithIssuer(value string) Certificate
+	WithNickname(value string) Certificate
+	WithNotAfter(value time.Time) Certificate
+	WithNotBefore(value time.Time) Certificate
+	WithSerialNumber(value string) Certificate
+	WithSubject(value string) Certificate
+	WithPem(value string) Certificate
+}
+
+type certificate public.Certificate
+
+func NewCertificate(realm string) Certificate {
+	notBefore := builder_helper.GenPastNearTime(1 * time.Hour)
+	notAfter := builder_helper.GenPastNearTime(1 * time.Hour)
+	return &certificate{
+		// TODO Add random function for the issuer
+		Issuer: builder_helper.GenIssuerWithRealm(
+			"An Issuer", realm),
+		// TODO Fill correctly this field
+		Nickname:  "My Test Certificate",
+		NotAfter:  notAfter,
+		NotBefore: notBefore,
+		// TODO Is a UUID a valid serial number in a certificate?
+		// SerialNumber: uuid.NewString(),
+		SerialNumber: strconv.Itoa(int(builder_helper.GenRandNum(1, 99999999))),
+		// TODO Add random function for the subject
+		Subject: builder_helper.GenSubjectWithRealm(
+			"A Subject", realm),
+		Pem: builder_helper.GenPemCertificate(),
+	}
+}
+
+func (b *certificate) Build() public.Certificate {
+	return public.Certificate(*b)
+}
+
+func (b *certificate) SetIssuer(value string) Certificate {
+	b.Issuer = value
+	return b
+}
+
+func (b *certificate) SetNickname(value string) Certificate {
+	return b
+}
+
+func (b *certificate) SetNotAfte(value time.Duration) Certificate {
+	b.SetNotAfte(value)
+	return b
+}
+
+func (b *certificate) WithIssuer(value string) Certificate {
+	b.Issuer = value
+	return b
+}
+
+func (b *certificate) WithNickname(value string) Certificate {
+	b.Nickname = value
+	return b
+}
+
+func (b *certificate) WithNotAfter(value time.Time) Certificate {
+	b.NotAfter = value
+	return b
+}
+func (b *certificate) WithNotBefore(value time.Time) Certificate {
+	b.NotBefore = value
+	return b
+}
+
+func (b *certificate) WithSerialNumber(value string) Certificate {
+	b.SerialNumber = value
+	return b
+}
+
+func (b *certificate) WithSubject(value string) Certificate {
+	b.Subject = value
+	return b
+}
+
+func (b *certificate) WithPem(value string) Certificate {
+	b.Pem = value
+	return b
+}

--- a/internal/test/builder/api/builder_domain_rhel_idm_location.go
+++ b/internal/test/builder/api/builder_domain_rhel_idm_location.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+)
+
+type Location interface {
+	Build() public.Location
+	WithName(value string) Location
+	WithDescription(value string) Location
+}
+
+type location public.Location
+
+func NewLocation() Location {
+	return &location{}
+}
+
+func (b *location) Build() public.Location {
+	return public.Location(*b)
+}
+
+func (b *location) WithName(value string) Location {
+	b.Name = value
+	return b
+}
+
+func (b *location) WithDescription(value string) Location {
+	b.Description = pointy.String(value)
+	return b
+}

--- a/internal/test/builder/api/builder_domain_rhel_idm_server.go
+++ b/internal/test/builder/api/builder_domain_rhel_idm_server.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"github.com/google/uuid"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+)
+
+type DomainIpaServer interface {
+	Build() public.DomainIpaServer
+	// TODO Add methods and implement them as they are needed
+	// With...() DomainIpaServer
+}
+
+type domainIpaServer public.DomainIpaServer
+
+func NewDomainIpaServer(fqdn string) DomainIpaServer {
+	subscriptionManagerID := &uuid.UUID{}
+	*subscriptionManagerID = uuid.New()
+	return &domainIpaServer{
+		Fqdn:                  fqdn,
+		CaServer:              builder_helper.GenRandBool(),
+		HccEnrollmentServer:   builder_helper.GenRandBool(),
+		HccUpdateServer:       builder_helper.GenRandBool(),
+		PkinitServer:          builder_helper.GenRandBool(),
+		Location:              nil,
+		SubscriptionManagerId: subscriptionManagerID,
+	}
+}
+
+func (b *domainIpaServer) Build() public.DomainIpaServer {
+	return public.DomainIpaServer(*b)
+}

--- a/internal/test/builder/api/builder_rhid.go
+++ b/internal/test/builder/api/builder_rhid.go
@@ -1,0 +1,8 @@
+package api
+
+var authType = []string{
+	"basic-auth", // User: See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json#L51
+	"jwt-auth",   // User: See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json#L51
+	"cert-auth",  // System: See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json#L113
+	"uhc-auth",   // System: See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json#L113
+}

--- a/internal/test/builder/api/builder_system_xrhid.go
+++ b/internal/test/builder/api/builder_system_xrhid.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+type SystemXRHID interface {
+	Build() identity.XRHID
+	WithAccountNumber(value string) SystemXRHID
+	WithEmployeeAccountNumber(value string) SystemXRHID
+	WithOrgID(value string) SystemXRHID
+	WithAuthType(value string) SystemXRHID
+
+	WithCommonName(value string) SystemXRHID
+	WithCertType(value string) SystemXRHID
+}
+
+type systemXRHID identity.XRHID
+
+// NewSystemXRHID create a new builder to get a XRHID for a user
+func NewSystemXRHID() SystemXRHID {
+	var orgID = strconv.Itoa(int(builder_helper.GenRandNum(1, 100000)))
+	// See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json
+	return &systemXRHID{
+		Identity: identity.Identity{
+			AccountNumber:         strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			EmployeeAccountNumber: strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			OrgID:                 orgID,
+			Type:                  "System",
+			AuthType:              authType[int(builder_helper.GenRandNum(0, 1))],
+			Internal: identity.Internal{
+				OrgID:    orgID,
+				AuthTime: float32(time.Now().Sub(time.Time{})),
+			},
+			System: identity.System{
+				CommonName: uuid.NewString(),
+				CertType:   "system",
+			},
+		},
+	}
+}
+
+func (b *systemXRHID) Build() identity.XRHID {
+	return identity.XRHID(*b)
+}
+
+func (b *systemXRHID) WithOrgID(value string) SystemXRHID {
+	b.Identity.OrgID = value
+	b.Identity.Internal.OrgID = value
+	return b
+}
+
+func (b *systemXRHID) WithAuthType(value string) SystemXRHID {
+	switch value {
+	case authType[0]:
+		b.Identity.AuthType = value
+		return b
+	case authType[1]:
+		b.Identity.AuthType = value
+		return b
+	default:
+		panic(fmt.Sprintf("value='%s' is not valid", value))
+	}
+}
+
+func (b *systemXRHID) WithAccountNumber(value string) SystemXRHID {
+	b.Identity.AccountNumber = value
+	return b
+}
+
+func (b *systemXRHID) WithEmployeeAccountNumber(value string) SystemXRHID {
+	b.Identity.EmployeeAccountNumber = value
+	return b
+}
+
+// --- Start specific System data
+
+func (b *systemXRHID) WithCommonName(value string) SystemXRHID {
+	b.Identity.System.CommonName = value
+	return b
+}
+
+func (b *systemXRHID) WithCertType(value string) SystemXRHID {
+	b.Identity.System.CertType = value
+	return b
+}

--- a/internal/test/builder/api/builder_user_xrhid.go
+++ b/internal/test/builder/api/builder_user_xrhid.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+)
+
+type UserXRHID interface {
+	Build() identity.XRHID
+	WithAccountNumber(value string) UserXRHID
+	WithEmployeeAccountNumber(value string) UserXRHID
+	WithOrgID(value string) UserXRHID
+	WithAuthType(value string) UserXRHID
+
+	WithUserID(value string) UserXRHID
+	WithUsername(value string) UserXRHID
+	WithEmail(value string) UserXRHID
+	WithActive(value bool) UserXRHID
+	// TODO Add more methods as they are needed
+}
+
+type userXRHID identity.XRHID
+
+// NewUserXRHID create a new builder to get a XRHID for a user
+func NewUserXRHID() UserXRHID {
+	orgID := strconv.Itoa(int(builder_helper.GenRandNum(1, 100000)))
+	firstName := builder_helper.GenRandFirstName()
+	lastName := builder_helper.GenRandLastName()
+	username := fmt.Sprintf("%s.%s",
+		strings.ToLower(firstName),
+		strings.ToLower(lastName),
+	)
+	userID := builder_helper.GenRandUserID()
+	email := fmt.Sprintf("%s@acme.test", username)
+
+	// See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/schema.json
+	return &userXRHID{
+		Identity: identity.Identity{
+			AccountNumber:         strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			EmployeeAccountNumber: strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			OrgID:                 orgID,
+			Type:                  "User",
+			AuthType:              authType[int(builder_helper.GenRandNum(0, 1))],
+			Internal: identity.Internal{
+				OrgID:    orgID,
+				AuthTime: float32(time.Now().Sub(time.Time{})),
+			},
+			User: identity.User{
+				UserID:    userID,
+				Username:  username,
+				FirstName: firstName,
+				LastName:  lastName,
+				Email:     email,
+				Active:    builder_helper.GenRandBool(),
+			},
+		},
+	}
+}
+
+func (b *userXRHID) Build() identity.XRHID {
+	return identity.XRHID(*b)
+}
+
+func (b *userXRHID) WithOrgID(value string) UserXRHID {
+	b.Identity.OrgID = value
+	b.Identity.Internal.OrgID = value
+	return b
+}
+
+func (b *userXRHID) WithAuthType(value string) UserXRHID {
+	switch value {
+	case authType[0]:
+		b.Identity.AuthType = value
+		return b
+	case authType[1]:
+		b.Identity.AuthType = value
+		return b
+	default:
+		panic(fmt.Sprintf("value='%s' is not valid", value))
+	}
+}
+
+func (b *userXRHID) WithAccountNumber(value string) UserXRHID {
+	b.Identity.AccountNumber = value
+	return b
+}
+
+func (b *userXRHID) WithEmployeeAccountNumber(value string) UserXRHID {
+	b.Identity.EmployeeAccountNumber = value
+	return b
+}
+
+// --- Start specific User data
+
+func (b *userXRHID) WithUserID(value string) UserXRHID {
+	b.Identity.User.UserID = value
+	return b
+}
+
+func (b *userXRHID) WithUsername(value string) UserXRHID {
+	b.Identity.User.Username = value
+	return b
+}
+
+func (b *userXRHID) WithEmail(value string) UserXRHID {
+	b.Identity.User.Email = value
+	return b
+}
+
+func (b *userXRHID) WithActive(value bool) UserXRHID {
+	b.Identity.User.Active = value
+	return b
+}

--- a/internal/test/builder/doc.go
+++ b/internal/test/builder/doc.go
@@ -1,0 +1,86 @@
+// Package builder to help on building data models.
+//
+// This package implement several builders to reduce boileplate
+// when we are coding tests for the service, which include any
+// kind of tests.
+//
+// TL;DR
+//
+// Builder pattern is used.
+//
+// Long history, an initial builder pattern with a wrong approach
+// was considered initially, where for each field of the wrapped
+// struct to build, it was added a flag field to don't generate
+// information for that fields; it was discarded because it was
+// adding too much boilerplate to implement new builders.
+//
+// After was considered a different implementation by using the
+// golang options patter, which was generating some random data
+// for the wrapped builder struct, and overriding the information
+// by calling the slice of options funtions provided.
+// This was discarded because still the golang options pattern
+// was adding too much boilerplate to add new builders; additionally
+// it was evoking name conflicts with the options for other new
+// strutcs, so that was makin a bit difficult to get good semantic
+// as the builder functionality is increased for all the different
+// structs.
+//
+// Finally it was get back to the Build pattern, but removing the
+// flags for each provided field which reduce the boilerplate; with
+// this approach we create a random initial object, override the
+// fields to customize. It is easy to compose complex builder by
+// using composition, and the semantic allow to use the builder
+// in a very readable way, letting the code to speak by itself.
+//
+// ```golang
+//
+//	type MyType interface {
+//		Build() model.MyType
+//		WithFieldName1(value int64) MyType
+//	}
+//
+//	type myType struct {
+//		model.MyType
+//	}
+//
+//	func NewMyType() MyType {
+//		return &model.MyType {
+//			FieldName1: GenRandNum(0, 10000),
+//		}
+//	}
+//
+//	func (b *myType) Buid() MyTpye {
+//		return b.MyType
+//	}
+//
+//	func (b *myType) WithFieldName1(value int64) MyType {
+//		b.MyType.FiledName1 = value
+//		return b
+//	}
+//
+// ```
+//
+// The below would be the minimal; we can see that generate some
+// random data, and we override the fields as we call method
+// members of the builder, finally we call Build() method to get
+// the generated data. Now the above example would be used as the
+// below.
+//
+// ```golang
+//
+//	func TestMyTypeCase1(t *testify.Testing) {
+//		o := builder.NewMyType().WithFieldName1(45)
+//	}
+//
+// ```
+//
+// Into the above leverage example we see how the semantic
+// referencing the package and using the specific factory
+// make the code speak by itself.
+//
+// TODO The current approach match a repetitive pattern for every
+// builder that maybe a tool could implement to generate the code
+// given the gorm database model; but this would be for the future.
+// The tool indicated would allow to generate the builder boilerplate
+// and keep it on sync with the model changes.
+package builder

--- a/internal/test/builder/helper/helper.go
+++ b/internal/test/builder/helper/helper.go
@@ -1,0 +1,296 @@
+package helper
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/openlyinc/pointy"
+	"github.com/pioz/faker"
+)
+
+// GenRandNum generate a random number >= min and <= max interval.
+// min is the lower boundary interval including the value.
+// max is the higher boundary interval including the value.
+func GenRandNum(min, max int64) int64 {
+	return faker.Int64InRange(min, max+1)
+}
+
+// GenPastNearTime generate a past timestamp not further than delta.
+// delta is the duration that set the threshold for the time.
+// Return a time.Time for the expected interval.
+func GenPastNearTime(delta time.Duration) time.Time {
+	var value int64 = GenRandNum(0, int64(delta))
+	return time.Now().UTC().Add(time.Duration(value) * -1)
+}
+
+// GenFutureNearTimeUTC generate a past timestamp not further than delta.
+// delta is the duration that set the threshold for the time.
+// Return a time.Time for the expected interval.
+func GenFutureNearTimeUTC(delta time.Duration) time.Time {
+	var value int64 = GenRandNum(0, int64(delta))
+	return time.Now().UTC().Add(time.Duration(value))
+}
+
+// GenBetweenTimeUTC generate a timestamp between the given parameters
+// as earlier as 'begin' and before 'end'.
+// delta is the duration that set the threshold for the time.
+// Return a time.Time for the expected interval.
+func GenBetweenTimeUTC(begin time.Time, end time.Time) time.Time {
+	return faker.TimeInRange(begin, end).UTC()
+}
+
+// GenRandString generate a random string from the letters set
+// with length n.
+// letters the set of letters to use.
+// n the length of the string.
+// Return a random string.
+func GenRandString(letters []rune, n int) string {
+	s := make([]rune, n)
+	for i := range s {
+		s[i] = letters[GenRandNum(0, int64(len(letters)-1))]
+	}
+	return string(s)
+}
+
+// GenRandDomainLabel generate a random label according to RFC1035
+// Return the string representing a valid domain label.
+func GenRandDomainLabel() string {
+	// See: https://www.rfc-editor.org/rfc/rfc1035
+	//
+	// <domain> ::= <subdomain> | " "
+	// <subdomain> ::= <label> | <subdomain> "." <label>
+	// <label> ::= <letter> [ [ <ldh-str> ] <let-dig> ]
+	// <ldh-str> ::= <let-dig-hyp> | <let-dig-hyp> <ldh-str>
+	// <let-dig-hyp> ::= <let-dig> | "-"
+	// <let-dig> ::= <letter> | <digit>
+	// <letter> ::= any one of the 52 alphabetic characters A through Z in
+	// upper case and a through z in lower case
+	// <digit> ::= any one of the ten digits 0 through 9
+	//
+	letDigHyp := []rune("abcdefghijklmnopqrstuvwxyz0123456789-")
+	letDig := []rune("abcdefghijklmnopqrstuvwxyz0123456789")
+	letter := []rune("abcdefghijklmnopqrstuvwxyz")
+	len := GenRandNum(1, 63)
+	if len == 1 {
+		return GenRandString(letter, 1)
+	}
+	if len == 2 {
+		return GenRandString(letter, 1) + GenRandString(letDig, 1)
+	}
+	return GenRandString(letter, 1) + GenRandString(letDigHyp, int(len-2)) + GenRandString(letDig, 1)
+}
+
+// GenRandDomainName generate a random domain name for testing
+// using .test as defined at RFC 6761
+// level is >= 2 and <= 4.
+// Return a domain name
+func GenRandDomainName(level int) string {
+	if level < 2 || level > 4 {
+		panic(fmt.Errorf("'level' must be in [2..4] range"))
+	}
+	labels := make([]string, level)
+	for i := 0; i < level-1; i++ {
+		label := GenRandDomainLabel()
+		labels[i] = label
+	}
+	labels[level-1] = "test"
+	return strings.Join(labels, ".")
+}
+
+// GenRandFQDNWithDomain Generate a random FQDN for the given domain.
+// domain is the domain that belong the returned FQDN
+// Return a FQDN string representation.
+func GenRandFQDNWithDomain(domain string) string {
+	return strings.Join([]string{GenRandDomainLabel(), domain}, ".")
+}
+
+// GenRandFQDN Generate a random FQDN using a random 3 level domain name.
+// Return a string value.
+func GenRandFQDN() string {
+	return GenRandDomainName(3)
+}
+
+// GenRandBool generate a random boolean.
+// Return a bool value.
+func GenRandBool() bool {
+	return faker.Bool()
+}
+
+// GenRandUserID Generate a random UUID.
+// Return a string.
+func GenRandUserID() string {
+	return uuid.NewString()
+}
+
+// GenRandUsername generate a random username.
+// Return a string.
+func GenRandUsername() string {
+	return strings.Join([]string{
+		strings.ToLower(GenRandFirstName()),
+		strings.ToLower(GenRandLastName()),
+	}, ".")
+}
+
+// GenRandFirstName generate a random first name.
+// Return a string.
+func GenRandFirstName() string {
+	return faker.FirstName()
+}
+
+// GenRandLastName generate a random last name.
+// Return a string.
+func GenRandLastName() string {
+	return faker.LastName()
+}
+
+// GenRandEmail generate a random email.
+// Return a string.
+func GenRandEmail() string {
+	return strings.Join([]string{GenRandUsername(), faker.Domain()}, "@")
+}
+
+// GenRandPointyBool generate a random bool pointer.
+// Return nil, or a bool pointer.
+func GenRandPointyBool() *bool {
+	if faker.Bool() {
+		return pointy.Bool(faker.Bool())
+	}
+	return nil
+}
+
+// GenRandParagraph generate a random paragraph.
+// Return a multiline string.
+func GenRandParagraph(n int) string {
+	if n == 0 {
+		n = int(GenRandNum(3, 10))
+	}
+	return faker.ArticleWithParagraphCount(n)
+}
+
+// GenPemCertificate currently return a static PEM certificate.
+func GenPemCertificate() string {
+	// TODO Implement this generator
+	return `-----BEGIN CERTIFICATE-----
+MIIOOjCCDSKgAwIBAgIRAIs+mCLMW+1cCl7dwvqQLe4wDQYJKoZIhvcNAQELBQAw
+RjELMAkGA1UEBhMCVVMxIjAgBgNVBAoTGUdvb2dsZSBUcnVzdCBTZXJ2aWNlcyBM
+TEMxEzARBgNVBAMTCkdUUyBDQSAxQzMwHhcNMjMxMDIzMTExODI0WhcNMjQwMTE1
+MTExODIzWjAXMRUwEwYDVQQDDAwqLmdvb2dsZS5jb20wWTATBgcqhkjOPQIBBggq
+hkjOPQMBBwNCAARFkJP4ajCGcFu/dhDICgGR1D8gXKRbXr+9snEjrW23dyYy8ECV
+0dSw/xRprfep7Tstl4B58Yv/idte6cxHVTKVo4IMGzCCDBcwDgYDVR0PAQH/BAQD
+AgeAMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYE
+FAwF+qpbtYBZSyha62gYCxXYB/HZMB8GA1UdIwQYMBaAFIp0f6+Fze6VzT2c0OJG
+FPNxNR0nMGoGCCsGAQUFBwEBBF4wXDAnBggrBgEFBQcwAYYbaHR0cDovL29jc3Au
+cGtpLmdvb2cvZ3RzMWMzMDEGCCsGAQUFBzAChiVodHRwOi8vcGtpLmdvb2cvcmVw
+by9jZXJ0cy9ndHMxYzMuZGVyMIIJzQYDVR0RBIIJxDCCCcCCDCouZ29vZ2xlLmNv
+bYIWKi5hcHBlbmdpbmUuZ29vZ2xlLmNvbYIJKi5iZG4uZGV2ghUqLm9yaWdpbi10
+ZXN0LmJkbi5kZXaCEiouY2xvdWQuZ29vZ2xlLmNvbYIYKi5jcm93ZHNvdXJjZS5n
+b29nbGUuY29tghgqLmRhdGFjb21wdXRlLmdvb2dsZS5jb22CCyouZ29vZ2xlLmNh
+ggsqLmdvb2dsZS5jbIIOKi5nb29nbGUuY28uaW6CDiouZ29vZ2xlLmNvLmpwgg4q
+Lmdvb2dsZS5jby51a4IPKi5nb29nbGUuY29tLmFygg8qLmdvb2dsZS5jb20uYXWC
+DyouZ29vZ2xlLmNvbS5icoIPKi5nb29nbGUuY29tLmNvgg8qLmdvb2dsZS5jb20u
+bXiCDyouZ29vZ2xlLmNvbS50coIPKi5nb29nbGUuY29tLnZuggsqLmdvb2dsZS5k
+ZYILKi5nb29nbGUuZXOCCyouZ29vZ2xlLmZyggsqLmdvb2dsZS5odYILKi5nb29n
+bGUuaXSCCyouZ29vZ2xlLm5sggsqLmdvb2dsZS5wbIILKi5nb29nbGUucHSCEiou
+Z29vZ2xlYWRhcGlzLmNvbYIPKi5nb29nbGVhcGlzLmNughEqLmdvb2dsZXZpZGVv
+LmNvbYIMKi5nc3RhdGljLmNughAqLmdzdGF0aWMtY24uY29tgg9nb29nbGVjbmFw
+cHMuY26CESouZ29vZ2xlY25hcHBzLmNughFnb29nbGVhcHBzLWNuLmNvbYITKi5n
+b29nbGVhcHBzLWNuLmNvbYIMZ2tlY25hcHBzLmNugg4qLmdrZWNuYXBwcy5jboIS
+Z29vZ2xlZG93bmxvYWRzLmNughQqLmdvb2dsZWRvd25sb2Fkcy5jboIQcmVjYXB0
+Y2hhLm5ldC5jboISKi5yZWNhcHRjaGEubmV0LmNughByZWNhcHRjaGEtY24ubmV0
+ghIqLnJlY2FwdGNoYS1jbi5uZXSCC3dpZGV2aW5lLmNugg0qLndpZGV2aW5lLmNu
+ghFhbXBwcm9qZWN0Lm9yZy5jboITKi5hbXBwcm9qZWN0Lm9yZy5jboIRYW1wcHJv
+amVjdC5uZXQuY26CEyouYW1wcHJvamVjdC5uZXQuY26CF2dvb2dsZS1hbmFseXRp
+Y3MtY24uY29tghkqLmdvb2dsZS1hbmFseXRpY3MtY24uY29tghdnb29nbGVhZHNl
+cnZpY2VzLWNuLmNvbYIZKi5nb29nbGVhZHNlcnZpY2VzLWNuLmNvbYIRZ29vZ2xl
+dmFkcy1jbi5jb22CEyouZ29vZ2xldmFkcy1jbi5jb22CEWdvb2dsZWFwaXMtY24u
+Y29tghMqLmdvb2dsZWFwaXMtY24uY29tghVnb29nbGVvcHRpbWl6ZS1jbi5jb22C
+FyouZ29vZ2xlb3B0aW1pemUtY24uY29tghJkb3VibGVjbGljay1jbi5uZXSCFCou
+ZG91YmxlY2xpY2stY24ubmV0ghgqLmZscy5kb3VibGVjbGljay1jbi5uZXSCFiou
+Zy5kb3VibGVjbGljay1jbi5uZXSCDmRvdWJsZWNsaWNrLmNughAqLmRvdWJsZWNs
+aWNrLmNughQqLmZscy5kb3VibGVjbGljay5jboISKi5nLmRvdWJsZWNsaWNrLmNu
+ghFkYXJ0c2VhcmNoLWNuLm5ldIITKi5kYXJ0c2VhcmNoLWNuLm5ldIIdZ29vZ2xl
+dHJhdmVsYWRzZXJ2aWNlcy1jbi5jb22CHyouZ29vZ2xldHJhdmVsYWRzZXJ2aWNl
+cy1jbi5jb22CGGdvb2dsZXRhZ3NlcnZpY2VzLWNuLmNvbYIaKi5nb29nbGV0YWdz
+ZXJ2aWNlcy1jbi5jb22CF2dvb2dsZXRhZ21hbmFnZXItY24uY29tghkqLmdvb2ds
+ZXRhZ21hbmFnZXItY24uY29tghhnb29nbGVzeW5kaWNhdGlvbi1jbi5jb22CGiou
+Z29vZ2xlc3luZGljYXRpb24tY24uY29tgiQqLnNhZmVmcmFtZS5nb29nbGVzeW5k
+aWNhdGlvbi1jbi5jb22CFmFwcC1tZWFzdXJlbWVudC1jbi5jb22CGCouYXBwLW1l
+YXN1cmVtZW50LWNuLmNvbYILZ3Z0MS1jbi5jb22CDSouZ3Z0MS1jbi5jb22CC2d2
+dDItY24uY29tgg0qLmd2dDItY24uY29tggsybWRuLWNuLm5ldIINKi4ybWRuLWNu
+Lm5ldIIUZ29vZ2xlZmxpZ2h0cy1jbi5uZXSCFiouZ29vZ2xlZmxpZ2h0cy1jbi5u
+ZXSCDGFkbW9iLWNuLmNvbYIOKi5hZG1vYi1jbi5jb22CFGdvb2dsZXNhbmRib3gt
+Y24uY29tghYqLmdvb2dsZXNhbmRib3gtY24uY29tgh4qLnNhZmVudXAuZ29vZ2xl
+c2FuZGJveC1jbi5jb22CDSouZ3N0YXRpYy5jb22CFCoubWV0cmljLmdzdGF0aWMu
+Y29tggoqLmd2dDEuY29tghEqLmdjcGNkbi5ndnQxLmNvbYIKKi5ndnQyLmNvbYIO
+Ki5nY3AuZ3Z0Mi5jb22CECoudXJsLmdvb2dsZS5jb22CFioueW91dHViZS1ub2Nv
+b2tpZS5jb22CCyoueXRpbWcuY29tggthbmRyb2lkLmNvbYINKi5hbmRyb2lkLmNv
+bYITKi5mbGFzaC5hbmRyb2lkLmNvbYIEZy5jboIGKi5nLmNuggRnLmNvggYqLmcu
+Y2+CBmdvby5nbIIKd3d3Lmdvby5nbIIUZ29vZ2xlLWFuYWx5dGljcy5jb22CFiou
+Z29vZ2xlLWFuYWx5dGljcy5jb22CCmdvb2dsZS5jb22CEmdvb2dsZWNvbW1lcmNl
+LmNvbYIUKi5nb29nbGVjb21tZXJjZS5jb22CCGdncGh0LmNuggoqLmdncGh0LmNu
+ggp1cmNoaW4uY29tggwqLnVyY2hpbi5jb22CCHlvdXR1LmJlggt5b3V0dWJlLmNv
+bYINKi55b3V0dWJlLmNvbYIUeW91dHViZWVkdWNhdGlvbi5jb22CFioueW91dHVi
+ZWVkdWNhdGlvbi5jb22CD3lvdXR1YmVraWRzLmNvbYIRKi55b3V0dWJla2lkcy5j
+b22CBXl0LmJlggcqLnl0LmJlghphbmRyb2lkLmNsaWVudHMuZ29vZ2xlLmNvbYIb
+ZGV2ZWxvcGVyLmFuZHJvaWQuZ29vZ2xlLmNughxkZXZlbG9wZXJzLmFuZHJvaWQu
+Z29vZ2xlLmNughhzb3VyY2UuYW5kcm9pZC5nb29nbGUuY24wIQYDVR0gBBowGDAI
+BgZngQwBAgEwDAYKKwYBBAHWeQIFAzA8BgNVHR8ENTAzMDGgL6AthitodHRwOi8v
+Y3Jscy5wa2kuZ29vZy9ndHMxYzMvbW9WRGZJU2lhMmsuY3JsMIIBAgYKKwYBBAHW
+eQIEAgSB8wSB8ADuAHUASLDja9qmRzQP5WoC+p0w6xxSActW3SyB2bu/qznYhHMA
+AAGLXHjeOgAABAMARjBEAiA5xkLry/jLvTgkNitDIuFmwVuL3SVofIIa9S9BX0aA
+lQIgWnF3vOB4zocZKrj1Ou4RgpTEZslWMbTi36QHOmI2rc8AdQDuzdBk1dsazsVc
+t520zROiModGfLzs3sNRSFlGcR+1mwAAAYtceN4RAAAEAwBGMEQCIGNaR2SEb6Eg
+AXBGxhriVs6xEmMSfNl+gxHXsAT1D26qAiB/nSwVTXKptImly3Nj1RlIBQ49kG6p
+LVjwM7pFTFFHgDANBgkqhkiG9w0BAQsFAAOCAQEA2zTHxu4FM4XJYuFVpYaFR+Rt
+4j27U4UZ/ju4CyY1h8PozUgpap6bKvsknfpltdaoHPqMBg7XdSX1hXpVJctAxPp/
+QgC6mYTlLGIk095lqyWYYH1HR/kf7VSBJDy8KYx44WliqK3kleYxbnz6BqEa8z9P
+0bILW8KvHyZt5tPYBvV2R42gueVgnJT9Kht3Pv0ZblajN0Ium+S03sDdMYT4nsKU
+5agIfeiO/nIgF14Zn+zKg0ilSZzum8pB0UgENi5CsowoNyOkdXOcIGMfOvy6hhXc
+kE32lJu4gVL1W2fSeii8K9y7pMGNUMbV+h2sF24EGxP5zlhruE2lJGRgONjFpA==
+-----END CERTIFICATE-----`
+}
+
+// GenRandLocationLabel generate a random location label.
+// Return a string with the label value.
+func GenRandLocationLabel() string {
+	// FIXME HMS-3152 If '-' is accepted add here and update middleware
+	// regular expression
+	set := []string{
+		"europe", "boston", "france", "australia", "india",
+		"brasil", "africa", "china",
+	}
+	return faker.Pick(set...)
+}
+
+// GenRandLocationDescription generate a random description
+// by adding " location" to a random location label.
+// Return a string with the description.
+func GenRandLocationDescription() string {
+	return fmt.Sprintf("%s location", GenRandLocationLabel())
+}
+
+// GenIssuerWithRealm generate a certificate issuer for the
+// given issuer and realm.
+// issuer is a string describing the certificate issuer, for instance "Verisign".
+// realm is the domain realm that the certificate is issuer belongs to.
+// Return a string with the issuer string.
+func GenIssuerWithRealm(issuer string, realm string) string {
+	// TODO To be reviewed
+	result := fmt.Sprintf("CN=%s", issuer)
+	for _, item := range strings.Split(realm, ".") {
+		result = fmt.Sprintf("%s, DC=%s", result, item)
+	}
+	return result
+}
+
+// GenSubjectWithRealm generate a certificate subject for the
+// given subject and realm.
+// subject is a string describing the certificate subject, for instance "My Site".
+// realm is the domain realm that the certificate is issued for.
+// Return a string with the subject string.
+func GenSubjectWithRealm(subject string, realm string) string {
+	// TODO To be reviewed
+	return GenIssuerWithRealm(subject, realm)
+}

--- a/internal/test/builder/model/builder_domain.go
+++ b/internal/test/builder/model/builder_domain.go
@@ -1,0 +1,129 @@
+package model
+
+import (
+	"strconv"
+
+	"github.com/google/uuid"
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"gorm.io/gorm"
+)
+
+const (
+	// MinOrgID the minimal org id for random values
+	minOrgID = 1
+	// MaxOrgID the maximum org id for random values
+	maxOrgID = 999999
+)
+
+// Domain is a builder to fill model.Domain structures
+// with random data to make life easier during the tests.
+type Domain interface {
+	Build() *model.Domain
+	WithModel(value gorm.Model) Domain
+	WithOrgID(value string) Domain
+	WithDomainUUID(value uuid.UUID) Domain
+	WithTitle(value *string) Domain
+	WithDescription(value *string) Domain
+	WithAutoEnrollmentEnabled(value *bool) Domain
+	WithIpaDomain(value *model.Ipa) Domain
+}
+
+// domain is the specific builder implementation
+type domain struct {
+	model.Domain
+}
+
+// NewDomain create a new builder for mode.Domain data.
+// Return the Domain builder interface.
+func NewDomain(gormModel gorm.Model) Domain {
+	var autoEnrollmentEnabled *bool
+	var title *string
+	var description *string
+	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+	switch builder_helper.GenRandNum(1, 3) % 3 {
+	case 1:
+		autoEnrollmentEnabled = pointy.Bool(false)
+	case 2:
+		autoEnrollmentEnabled = pointy.Bool(true)
+	case 3:
+		autoEnrollmentEnabled = nil
+	default:
+		panic("something went wrong for random AutoEnrollmentEnabled")
+	}
+
+	switch builder_helper.GenRandNum(1, 2) % 2 {
+	case 1:
+		title = pointy.String(builder_helper.GenRandString(letters, int(builder_helper.GenRandNum(5, 20))))
+	case 2:
+		title = nil
+	default:
+		panic("something went wrong for random title")
+	}
+
+	switch builder_helper.GenRandNum(1, 2) % 2 {
+	case 1:
+		description = pointy.String(builder_helper.GenRandString(letters, int(builder_helper.GenRandNum(10, 300))))
+	case 2:
+		description = nil
+	default:
+		panic("something went wrong for random title")
+	}
+
+	return &domain{
+		Domain: model.Domain{
+			Model:                 gormModel,
+			OrgId:                 strconv.Itoa(int(builder_helper.GenRandNum(minOrgID, maxOrgID))),
+			DomainUuid:            uuid.New(),
+			DomainName:            pointy.String(builder_helper.GenRandDomainName(2)),
+			AutoEnrollmentEnabled: autoEnrollmentEnabled,
+			Title:                 title,
+			Description:           description,
+			Type:                  pointy.Uint(model.DomainTypeIpa),
+			IpaDomain:             NewIpaDomain().Build(),
+		},
+	}
+}
+
+// Build generate the mode.Domain instance based into
+// the current inputs and random data to fill the gaps.
+// Return the generated model.Domain instance.
+func (b *domain) Build() *model.Domain {
+	return &b.Domain
+}
+
+func (b *domain) WithModel(value gorm.Model) Domain {
+	b.Model = value
+	return b
+}
+
+func (b *domain) WithOrgID(value string) Domain {
+	b.OrgId = value
+	return b
+}
+
+func (b *domain) WithAutoEnrollmentEnabled(value *bool) Domain {
+	b.AutoEnrollmentEnabled = value
+	return b
+}
+
+func (b *domain) WithDomainUUID(value uuid.UUID) Domain {
+	b.DomainUuid = value
+	return b
+}
+
+func (b *domain) WithTitle(value *string) Domain {
+	b.Title = value
+	return b
+}
+
+func (b *domain) WithDescription(value *string) Domain {
+	b.Description = value
+	return b
+}
+
+func (b *domain) WithIpaDomain(value *model.Ipa) Domain {
+	b.IpaDomain = value
+	return b
+}

--- a/internal/test/builder/model/builder_ipa.go
+++ b/internal/test/builder/model/builder_ipa.go
@@ -1,0 +1,82 @@
+package model
+
+import (
+	"strings"
+
+	"github.com/lib/pq"
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"gorm.io/gorm"
+)
+
+type IpaDomain interface {
+	Build() *model.Ipa
+	WithModel(value gorm.Model) IpaDomain
+	WithCaCerts(value []model.IpaCert) IpaDomain
+	WithServers(value []model.IpaServer) IpaDomain
+	WithLocations(value []model.IpaLocation) IpaDomain
+	WithRealmName(value *string) IpaDomain
+	WithRealmDomains(value pq.StringArray) IpaDomain
+}
+
+type ipaDomain struct {
+	IpaDomain *model.Ipa
+}
+
+func NewIpaDomain() IpaDomain {
+	var (
+		certs        []model.IpaCert
+		locations    []model.IpaLocation
+		servers      []model.IpaServer
+		realmName    *string
+		realmDomains pq.StringArray = pq.StringArray{}
+	)
+	realmName = pointy.String(strings.ToUpper(builder_helper.GenRandDomainName(2)))
+	if realmName != nil {
+		realmDomains = pq.StringArray{*realmName}
+	}
+	return &ipaDomain{
+		IpaDomain: &model.Ipa{
+			Model:        NewModel().Build(),
+			CaCerts:      certs,
+			Servers:      servers,
+			Locations:    locations,
+			RealmName:    realmName,
+			RealmDomains: realmDomains,
+		},
+	}
+}
+
+func (b *ipaDomain) Build() *model.Ipa {
+	return b.IpaDomain
+}
+
+func (b *ipaDomain) WithModel(value gorm.Model) IpaDomain {
+	b.IpaDomain.Model = value
+	return b
+}
+func (b *ipaDomain) WithCaCerts(value []model.IpaCert) IpaDomain {
+	b.IpaDomain.CaCerts = value
+	return b
+}
+
+func (b *ipaDomain) WithServers(value []model.IpaServer) IpaDomain {
+	b.IpaDomain.Servers = value
+	return b
+}
+
+func (b *ipaDomain) WithLocations(value []model.IpaLocation) IpaDomain {
+	b.IpaDomain.Locations = value
+	return b
+}
+
+func (b *ipaDomain) WithRealmName(value *string) IpaDomain {
+	b.IpaDomain.RealmName = value
+	return b
+}
+
+func (b *ipaDomain) WithRealmDomains(value pq.StringArray) IpaDomain {
+	b.IpaDomain.RealmDomains = value
+	return b
+}

--- a/internal/test/builder/model/builder_ipa_server.go
+++ b/internal/test/builder/model/builder_ipa_server.go
@@ -1,0 +1,103 @@
+package model
+
+import (
+	"github.com/google/uuid"
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"gorm.io/gorm"
+)
+
+type IpaServer interface {
+	Build() model.IpaServer
+	WithIpaID(value uint) IpaServer
+	WithFQDN(value string) IpaServer
+	WithRHSMID(value *string) IpaServer
+	WithLocation(value *string) IpaServer
+	WithCaServer(value bool) IpaServer
+	WithHCCEnrollmentServer(value bool) IpaServer
+	WithHCCUpdateServer(value bool) IpaServer
+	WithPKInitServer(value bool) IpaServer
+	// IpaID               uint
+	// FQDN                string
+	// RHSMId              *string `gorm:"unique;column:rhsm_id"`
+	// Location            *string
+	// CaServer            bool
+	// HCCEnrollmentServer bool
+	// HCCUpdateServer     bool
+	// PKInitServer        bool
+}
+
+type ipaServer struct {
+	IpaServer model.IpaServer
+}
+
+func NewIpaServer(gormModel gorm.Model) IpaServer {
+	var (
+		rhsmID   *string
+		location *string
+	)
+	if builder_helper.GenRandBool() {
+		rhsmID = pointy.String(uuid.NewString())
+	}
+	if builder_helper.GenRandBool() {
+		location = pointy.String(builder_helper.GenRandDomainLabel())
+	}
+	return &ipaServer{
+		IpaServer: model.IpaServer{
+			Model:               gormModel,
+			IpaID:               0,
+			FQDN:                builder_helper.GenRandFQDN(),
+			RHSMId:              rhsmID,
+			Location:            location,
+			CaServer:            builder_helper.GenRandBool(),
+			HCCEnrollmentServer: builder_helper.GenRandBool(),
+			HCCUpdateServer:     builder_helper.GenRandBool(),
+			PKInitServer:        builder_helper.GenRandBool(),
+		},
+	}
+}
+
+func (b *ipaServer) Build() model.IpaServer {
+	return b.IpaServer
+}
+
+func (b *ipaServer) WithIpaID(value uint) IpaServer {
+	b.IpaServer.IpaID = value
+	return b
+}
+
+func (b *ipaServer) WithFQDN(value string) IpaServer {
+	b.IpaServer.FQDN = value
+	return b
+}
+
+func (b *ipaServer) WithRHSMID(value *string) IpaServer {
+	b.IpaServer.RHSMId = value
+	return b
+}
+
+func (b *ipaServer) WithLocation(value *string) IpaServer {
+	b.IpaServer.Location = value
+	return b
+}
+
+func (b *ipaServer) WithCaServer(value bool) IpaServer {
+	b.IpaServer.CaServer = value
+	return b
+}
+
+func (b *ipaServer) WithHCCEnrollmentServer(value bool) IpaServer {
+	b.IpaServer.HCCEnrollmentServer = value
+	return b
+}
+
+func (b *ipaServer) WithHCCUpdateServer(value bool) IpaServer {
+	b.IpaServer.HCCUpdateServer = value
+	return b
+}
+
+func (b *ipaServer) WithPKInitServer(value bool) IpaServer {
+	b.IpaServer.PKInitServer = value
+	return b
+}

--- a/internal/test/builder/model/builder_model.go
+++ b/internal/test/builder/model/builder_model.go
@@ -1,0 +1,66 @@
+package model
+
+// FIXME Change the option pattern by a Builder pattern
+//       this is, instead of using 'With...' that could
+//       evoke name colisions, add the custom methods that
+//       override the values to the ModelBuilder
+
+import (
+	"time"
+
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"gorm.io/gorm"
+)
+
+// GormModel is the builder for the
+type GormModel interface {
+	Build() gorm.Model
+	WithID(value uint) GormModel
+	WithCreatedAt(value time.Time) GormModel
+	WithUpdatedAt(value time.Time) GormModel
+	WithDeletedAt(value gorm.DeletedAt) GormModel
+}
+
+// gormModel is the specific builder implementation
+type gormModel struct {
+	gorm.Model
+}
+
+// NewModel generate a gorm.Model with random information
+// overrided by the customized options.
+func NewModel() GormModel {
+	var genCreatedAt = builder_helper.GenPastNearTime(time.Hour * 24 * 10)
+	var genUpdatedAt = builder_helper.GenBetweenTimeUTC(genCreatedAt, time.Now())
+
+	return &gormModel{
+		Model: gorm.Model{
+			ID:        uint(builder_helper.GenRandNum(0, 2^63)),
+			CreatedAt: genCreatedAt,
+			UpdatedAt: genUpdatedAt,
+		},
+	}
+}
+
+func (b *gormModel) Build() gorm.Model {
+	return b.Model
+}
+
+func (b *gormModel) WithID(value uint) GormModel {
+	b.Model.ID = value
+	return b
+}
+
+func (b *gormModel) WithCreatedAt(value time.Time) GormModel {
+	b.CreatedAt = value
+	return b
+}
+
+func (b *gormModel) WithUpdatedAt(value time.Time) GormModel {
+	b.Model.UpdatedAt = value
+	return b
+}
+
+func (b *gormModel) WithDeletedAt(value gorm.DeletedAt) GormModel {
+	b.DeletedAt = value
+	return b
+}

--- a/internal/test/smoke/doc.go
+++ b/internal/test/smoke/doc.go
@@ -1,0 +1,11 @@
+// Package smoke contains all the smoke test for the service
+//
+// By smoke test we refers to application requests that get a success
+// response for a normal execution of the service, so we check the thinks
+// work as expected in normal situations.
+//
+// If you are thinking a failure and error situations to be covered
+// then you will be looking at `internal/test/integration` package
+// where you will define the remaining tests to evoque error situations
+// and validate they are correctly covered and managed by the application.
+package smoke

--- a/internal/test/smoke/list_test.go
+++ b/internal/test/smoke/list_test.go
@@ -1,0 +1,163 @@
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SuiteTokenCreate is the suite token for smoke tests at /api/idmsvc/v1/domains/token
+type SuiteListDomains struct {
+	SuiteBase
+	Domains []*public.Domain
+}
+
+// BodyFuncListResponse is the function that wrap
+type BodyFuncListDomainsResponse func(t *testing.T, body *public.ListDomainsResponse) error
+
+// WrapBodyFuncListResponse allow to implement custom body expectations for the specific type of the response.
+// expected is the specific BodyFuncDomain for Domain type
+// Returns a BodyFunc that wrap the generic expectation function.
+func WrapBodyFuncListDomainsResponse(expected BodyFuncListDomainsResponse) BodyFunc {
+	if expected == nil {
+		return func(t *testing.T, body []byte) bool {
+			return len(body) == 0
+		}
+	}
+	return func(t *testing.T, body []byte) bool {
+		// Unserialize the response to the expected type
+		var data public.ListDomainsResponse
+		if err := json.Unmarshal(body, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error unmarshalling body:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+
+		// Run body expectetion on the unserialized data
+		if err := expected(t, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error in body response:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+
+		return true
+	}
+}
+
+func (s *SuiteListDomains) SetupTest() {
+	s.SuiteBase.SetupTest()
+
+	s.Domains = []*public.Domain{}
+	for i := 1; i < 50; i++ {
+		domainName := fmt.Sprintf("domain%d.test", i)
+		domain, err := s.RegisterIpaDomain(builder_api.NewDomain(domainName).Build())
+		if err != nil {
+			s.FailNow("error creating ")
+		}
+		s.Domains = append(s.Domains, domain)
+	}
+}
+
+func (s *SuiteListDomains) TearDownTest() {
+	for i := range s.Domains {
+		s.Domains[i] = nil
+	}
+	s.Domains = nil
+
+	s.SuiteBase.TearDownTest()
+}
+
+func (s *SuiteListDomains) TestListDomains() {
+	t := s.T()
+	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
+	req, err := http.NewRequest(http.MethodGet, s.DefaultPublicBaseURL()+"/domains", nil)
+	require.NoError(t, err)
+	q := req.URL.Query()
+	q.Add("offset", "0")
+	q.Add("limit", "10")
+	url1 := req.URL.String() + "?" + q.Encode()
+	q.Set("offset", "40")
+	q.Set("limit", "10")
+	url2 := req.URL.String() + "?" + q.Encode()
+	domainName := builder_helper.GenRandDomainName(2)
+
+	// Prepare the tests
+	testCases := []TestCase{
+		{
+			Name: "TestListDomains: offset=0&limit=10",
+			Given: TestCaseGiven{
+				Method: http.MethodGet,
+				URL:    url1,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            {xrhidEncoded},
+				},
+				Body: builder_api.NewDomain(domainName).Build(),
+			},
+			Expected: TestCaseExpect{
+				// FIXME It must be http.StatusCreated
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					// FIXME Avoid hardcode the key name of the header
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            nil,
+					// TODO Check format for X-Rh-Idm-Version
+				},
+				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {
+					require.NotNil(t, body)
+					assert.Equal(t, 10, body.Meta.Limit)
+					assert.Equal(t, 0, body.Meta.Offset)
+					assert.Equal(t, int64(49), body.Meta.Count)
+					return nil
+				}),
+			},
+		},
+		{
+			Name: "TestListDomains: offset=40&limit=10",
+			Given: TestCaseGiven{
+				Method: http.MethodGet,
+				URL:    url2,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            {xrhidEncoded},
+				},
+				Body: builder_api.NewDomain(domainName).Build(),
+			},
+			Expected: TestCaseExpect{
+				// FIXME It must be http.StatusCreated
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					// FIXME Avoid hardcode the key name of the header
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            nil,
+					// TODO Check format for X-Rh-Idm-Version
+				},
+				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {
+					require.NotNil(t, body)
+					assert.Equal(t, 10, body.Meta.Limit)
+					assert.Equal(t, 40, body.Meta.Offset)
+					// FIXME Review the metadata to return
+					// assert.Equal(t, int64(49), body.Meta.Count)
+					assert.Equal(t, 9, len(body.Data))
+					// TODO
+					return nil
+				}),
+			},
+		},
+	}
+
+	// Execute the test cases
+	s.RunTestCases(testCases)
+}

--- a/internal/test/smoke/read_test.go
+++ b/internal/test/smoke/read_test.go
@@ -1,0 +1,88 @@
+package smoke
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	test_assert "github.com/podengo-project/idmsvc-backend/internal/test/assert"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/stretchr/testify/assert"
+)
+
+// SuiteReadDomain is the suite to validate the smoke test when read domain endpoint at GET /api/idmsvc/v1/domains/:domain_id
+type SuiteReadDomain struct {
+	SuiteBase
+	Domains []*public.Domain
+}
+
+func (s *SuiteReadDomain) SetupTest() {
+	s.SuiteBase.SetupTest()
+
+	var (
+		domainName string
+		domain     *public.Domain
+		err        error
+		i          int
+	)
+
+	// Domain 1 in OrgID1
+	i = 0
+	s.Domains = []*public.Domain{}
+	domainName = fmt.Sprintf("domain%d.test", i)
+	domain, err = s.RegisterIpaDomain(builder_api.NewDomain(domainName).Build())
+	if err != nil {
+		s.FailNow("error creating ")
+	}
+	s.Domains = append(s.Domains, domain)
+}
+
+func (s *SuiteReadDomain) TearDownTest() {
+	for i := range s.Domains {
+		s.Domains[i] = nil
+	}
+	s.Domains = nil
+
+	s.SuiteBase.TearDownTest()
+}
+
+func (s *SuiteReadDomain) TestReadDomain() {
+	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
+	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId)
+	domainName := builder_helper.GenRandDomainName(2)
+
+	// Prepare the tests
+	testCases := []TestCase{
+		{
+			Name: "TestReadDomain",
+			Given: TestCaseGiven{
+				Method: http.MethodGet,
+				URL:    url,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            {xrhidEncoded},
+				},
+				Body: builder_api.NewDomain(domainName).Build(),
+			},
+			Expected: TestCaseExpect{
+				// FIXME It must be http.StatusCreated
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            nil,
+				},
+				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
+					test_assert.AssertDomain(t, s.Domains[0], body)
+					assert.Equal(t, s.Domains[0].DomainId, body.DomainId)
+					return nil
+				}),
+			},
+		},
+	}
+
+	// Execute the test cases
+	s.RunTestCases(testCases)
+}

--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -1,0 +1,159 @@
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SuiteTokenCreate is the suite token for smoke tests at /api/idmsvc/v1/domains/token
+type SuiteRegisterDomain struct {
+	SuiteBase
+	token *public.DomainRegTokenResponse
+}
+
+// BodyFuncDomainResponse is the function that wrap
+type BodyFuncDomainResponse func(t *testing.T, body *public.Domain) error
+
+// WrapBodyFuncDomainResponse allow to implement custom body expectations for the specific type of the response.
+// expected is the specific BodyFuncDomain for Domain type
+// Returns a BodyFunc that wrap the generic expectation function.
+func WrapBodyFuncDomainResponse(expected BodyFuncDomainResponse) BodyFunc {
+	if expected == nil {
+		return func(t *testing.T, body []byte) bool {
+			return len(body) == 0
+		}
+	}
+	return func(t *testing.T, body []byte) bool {
+		// Unserialize the response to the expected type
+		var data public.Domain
+		if err := json.Unmarshal(body, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error unmarshalling body:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+
+		// Run body expectetion on the unserialized data
+		if err := expected(t, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error in body response:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+
+		return true
+	}
+}
+
+func (s *SuiteRegisterDomain) SetupTest() {
+	var err error
+
+	s.SuiteBase.SetupTest()
+
+	// Get a token for the registration
+	if s.token, err = s.CreateToken(); err != nil {
+		s.FailNow("Error creating a token for registering a rhel-idm domain", "%s", err.Error())
+	}
+}
+
+func (s *SuiteRegisterDomain) TearDownTest() {
+	s.SuiteBase.TearDownTest()
+}
+
+func (s *SuiteRegisterDomain) TestRegisterDomain() {
+	xrhidEncoded := header.EncodeXRHID(&s.SystemXRHID)
+	url := s.DefaultPublicBaseURL() + "/domains"
+	domainName := builder_helper.GenRandDomainName(2)
+	bodyRequest := builder_api.
+		NewDomain(domainName).
+		Build()
+
+	// Prepare the tests
+	testCases := []TestCase{
+		{
+			Name: "TestRegisterDomain rhel-idm",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				URL:    url,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id":    {"test_token"},
+					"X-Rh-Identity":               {xrhidEncoded},
+					"X-Rh-Idm-Registration-Token": {s.token.DomainToken},
+					"X-Rh-Idm-Version": {
+						header.EncodeXRHIDMVersion(
+							header.NewXRHIDMVersion(
+								"v1.0.0",
+								"4.19.0",
+								"redhat-9.3",
+								"9.3",
+							),
+						),
+					},
+				},
+				Body: bodyRequest,
+			},
+			Expected: TestCaseExpect{
+				StatusCode: http.StatusCreated,
+				Header: http.Header{
+					// FIXME Avoid hardcode the key name of the header
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            nil,
+				},
+				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
+					require.NotNil(t, body)
+					require.NotNil(t, body.DomainId)
+					assert.Equal(t, bodyRequest.DomainName, body.DomainName)
+					assert.Equal(t, bodyRequest.DomainType, body.DomainType)
+
+					if bodyRequest.Title != nil {
+						require.NotNil(t, body.Title)
+						assert.Equal(t, *bodyRequest.Title, *body.Title)
+					} else {
+						assert.Nil(t, body.Title)
+					}
+
+					require.NotNil(t, body.Description)
+					assert.Equal(t, "", *body.Description)
+
+					require.NotNil(t, body.AutoEnrollmentEnabled)
+					assert.True(t, *body.AutoEnrollmentEnabled)
+
+					// Check rhel-idm
+					if bodyRequest != nil {
+						require.NotNil(t, body.RhelIdm)
+						assert.Equal(t, bodyRequest.RhelIdm.RealmName, body.RhelIdm.RealmName)
+						assert.Equal(t, bodyRequest.RhelIdm.RealmDomains, body.RhelIdm.RealmDomains)
+						if bodyRequest.RhelIdm.AutomountLocations != nil && *bodyRequest.RhelIdm.AutomountLocations != nil && len(*bodyRequest.RhelIdm.AutomountLocations) > 0 {
+							assert.Equal(t, *bodyRequest.RhelIdm.AutomountLocations, body.RhelIdm.AutomountLocations)
+						}
+						if bodyRequest.RhelIdm.Locations != nil && len(bodyRequest.RhelIdm.Locations) > 0 {
+							assert.Equal(t, bodyRequest.RhelIdm.Locations, body.RhelIdm.Locations)
+						} else {
+							assert.Condition(t, func() (success bool) {
+								return body.RhelIdm.Locations == nil || len(body.RhelIdm.Locations) == 0
+							})
+						}
+						assert.Equal(t, bodyRequest.RhelIdm.CaCerts, body.RhelIdm.CaCerts)
+						assert.Equal(t, bodyRequest.RhelIdm.Servers, body.RhelIdm.Servers)
+					}
+
+					return nil
+				}),
+			},
+		},
+	}
+
+	// Execute the test cases
+	s.RunTestCases(testCases)
+}

--- a/internal/test/smoke/suite_test.go
+++ b/internal/test/smoke/suite_test.go
@@ -416,7 +416,7 @@ func TearDownSignalHandler() {
 
 func TestSuite(t *testing.T) {
 	// TODO Add here your test suites
-	// suite.Run(t, new(SuiteTokenCreate))
+	suite.Run(t, new(SuiteTokenCreate))
 	// suite.Run(t, new(SuiteRegisterDomain))
 	// suite.Run(t, new(SuiteDomainUpdateUser))
 	// suite.Run(t, new(SuiteDomainUpdateAgent))

--- a/internal/test/smoke/suite_test.go
+++ b/internal/test/smoke/suite_test.go
@@ -179,7 +179,7 @@ func (s *SuiteBase) RegisterIpaDomain(domain *public.Domain) (*public.Domain, er
 		return nil, fmt.Errorf("failure when %s %s: %w", http.MethodPost, url, err)
 	}
 	// FIXME This should be http.StatusCreated instead of StatusOK
-	if resp.StatusCode != http.StatusOK {
+	if resp.StatusCode != http.StatusCreated {
 		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
 	}
 	var data []byte
@@ -417,7 +417,7 @@ func TearDownSignalHandler() {
 func TestSuite(t *testing.T) {
 	// TODO Add here your test suites
 	suite.Run(t, new(SuiteTokenCreate))
-	// suite.Run(t, new(SuiteRegisterDomain))
+	suite.Run(t, new(SuiteRegisterDomain))
 	// suite.Run(t, new(SuiteDomainUpdateUser))
 	// suite.Run(t, new(SuiteDomainUpdateAgent))
 	// suite.Run(t, new(SuiteDomainRead))

--- a/internal/test/smoke/suite_test.go
+++ b/internal/test/smoke/suite_test.go
@@ -1,0 +1,426 @@
+package smoke
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/datastore"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/service"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	"github.com/podengo-project/idmsvc-backend/internal/usecase/client"
+	"github.com/redhatinsights/platform-go-middlewares/identity"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"gorm.io/gorm"
+
+	service_impl "github.com/podengo-project/idmsvc-backend/internal/infrastructure/service/impl"
+)
+
+// SuiteBase represents the base Suite to be used for smoke tests, this
+// start the services before run the smoke tests.
+// TODO the smoke tests cannot be executed in parallel yet, an alternative
+// for them would be to use specific http and metrics service in one side,
+// and to use a specific OrgID per test by using a generator for it which
+// would provide data partition between the tests.
+type SuiteBase struct {
+	suite.Suite
+	cfg         *config.Config
+	OrgID       string
+	UserXRHID   identity.XRHID
+	SystemXRHID identity.XRHID
+
+	cancel context.CancelFunc
+	svc    service.ApplicationService
+	wg     *sync.WaitGroup
+	db     *gorm.DB
+}
+
+// SetupTest start the services and await until they are ready
+// for being used.
+func (s *SuiteBase) SetupTest() {
+	s.cfg = config.Get()
+	s.wg = &sync.WaitGroup{}
+	logger.InitLogger(s.cfg)
+	s.db = datastore.NewDB(s.cfg)
+
+	ctx, cancel := StartSignalHandler(context.Background())
+	s.cancel = cancel
+	inventory := client.NewHostInventory(s.cfg)
+	s.svc = service_impl.NewApplication(ctx, s.wg, s.cfg, s.db, inventory)
+	go func() {
+		if e := s.svc.Start(); e != nil {
+			panic(e)
+		}
+	}()
+	s.OrgID = strconv.Itoa(int(builder_helper.GenRandNum(1, 99999999)))
+	s.UserXRHID = builder_api.NewUserXRHID().WithOrgID(s.OrgID).WithActive(true).Build()
+	s.SystemXRHID = builder_api.NewSystemXRHID().WithOrgID(s.OrgID).Build()
+	s.WaitReady(s.cfg)
+}
+
+// TearDownTest Stop the services in an ordered way before every
+// smoke test executed.
+func (s *SuiteBase) TearDownTest() {
+	TearDownSignalHandler()
+	defer datastore.Close(s.db)
+	defer s.cancel()
+	s.svc.Stop()
+	s.wg.Wait()
+}
+
+// WaitReady poll the ready healthcheck until the response is http.StatusOK
+// cfg is the current configuration to use for the application.
+func (s *SuiteBase) WaitReady(cfg *config.Config) {
+	if cfg == nil {
+		panic("cfg is nil")
+	}
+	header := http.Header{}
+	for i := 0; i < 300; i++ {
+		resp, err := s.DoRequest(
+			http.MethodGet,
+			s.DefaultPrivateBaseURL()+"/readyz",
+			header,
+			nil,
+		)
+		if err == nil && resp.StatusCode == http.StatusOK {
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	panic("WaitReady didn't return after 30 seconds checking for it")
+}
+
+// CreateToken is a helper function to request a token to the API for registration
+// for a rhel-idm domain using the OrgID assigned to the unit test.
+// Return the token response or error.
+func (s *SuiteBase) CreateToken() (*public.DomainRegTokenResponse, error) {
+	var headers http.Header = http.Header{}
+	var resp *http.Response
+	var err error
+
+	url := s.DefaultPublicBaseURL() + "/domains/token"
+
+	headers.Add("X-Rh-Insights-Request-Id", "get_token")
+	headers.Add("X-Rh-Identity", header.EncodeXRHID(&s.UserXRHID))
+	if resp, err = s.DoRequest(
+		http.MethodPost,
+		url,
+		headers,
+		&public.DomainRegTokenRequest{
+			DomainType: "rhel-idm",
+		},
+	); err != nil {
+		return nil, fmt.Errorf("failure when POST %s: %w", url, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
+	}
+	var data []byte
+	data, err = io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failure when reading body for POST %s because an empty response", url)
+	}
+	var token *public.DomainRegTokenResponse = &public.DomainRegTokenResponse{}
+	err = json.Unmarshal(data, token)
+	if err != nil {
+		return nil, fmt.Errorf("failure when unmarshalling the information for POST %s", url)
+	}
+	return token, nil
+}
+
+// RegisterIpaDomain is a helper function to register a domain with the API
+// for a rhel-idm domain using the OrgID assigned to the unit test.
+// Return the token response or error.
+func (s *SuiteBase) RegisterIpaDomain(domain *public.Domain) (*public.Domain, error) {
+	var headers http.Header = http.Header{}
+	var resp *http.Response
+	var err error
+	var token *public.DomainRegTokenResponse = nil
+
+	if token, err = s.CreateToken(); err != nil {
+		s.FailNow("Error creating a token for registering a rhel-idm domain", "%s", err.Error())
+	}
+
+	url := s.DefaultPublicBaseURL() + "/domains"
+	headers.Add("X-Rh-Idm-Registration-Token", token.DomainToken)
+	headers.Add("X-Rh-Insights-Request-Id", "get_token")
+	headers.Add("X-Rh-Identity", header.EncodeXRHID(&s.SystemXRHID))
+	headers.Add("X-Rh-Idm-Version", header.EncodeXRHIDMVersion(&header.XRHIDMVersion{
+		IPAHCCVersion:      "1.0.0",
+		IPAVersion:         "4.19.0",
+		OSReleaseID:        "9.3",
+		OSReleaseVersionID: "redhat-9.3",
+	}))
+	if resp, err = s.DoRequest(
+		http.MethodPost,
+		url,
+		headers,
+		domain,
+	); err != nil {
+		return nil, fmt.Errorf("failure when %s %s: %w", http.MethodPost, url, err)
+	}
+	// FIXME This should be http.StatusCreated instead of StatusOK
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
+	}
+	var data []byte
+	data, err = io.ReadAll(resp.Body)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failure when reading body for POST %s because an empty response", url)
+	}
+	var createdDomain *public.Domain = &public.Domain{}
+	err = json.Unmarshal(data, createdDomain)
+	if err != nil {
+		return nil, fmt.Errorf("failure when unmarshalling the information for %s %s", http.MethodPost, url)
+	}
+	return createdDomain, nil
+}
+
+// RunTestCase run test for one specific testcase
+func (s *SuiteBase) RunTestCase(testCase *TestCase) {
+	t := s.T()
+
+	var (
+		body []byte
+		resp *http.Response
+		err  error
+	)
+
+	// GIVEN testCase
+	bodyCount := 0
+	if testCase.Given.Body != nil {
+		bodyCount++
+	}
+	if testCase.Given.BodyBytes != nil {
+		bodyCount++
+	}
+	if bodyCount > 1 {
+		t.Errorf("Given Body and BodyBytes are exclusive between them.")
+	}
+	bodyCount = 0
+	if testCase.Expected.Body != nil {
+		bodyCount++
+	}
+	if testCase.Expected.BodyFunc != nil {
+		bodyCount++
+	}
+	if testCase.Expected.BodyBytes != nil {
+		bodyCount++
+	}
+	if bodyCount > 1 {
+		t.Errorf("Expected Body, BodyFunc and BodyBytes are exclusive between them.")
+	}
+
+	// WHEN
+	resp, err = s.DoRequest(testCase.Given.Method, testCase.Given.URL, testCase.Given.Header, testCase.Given.Body)
+
+	// THEN
+
+	// Check no error
+	require.NoError(t, err)
+	if resp != nil {
+		body, err = io.ReadAll(resp.Body)
+		defer resp.Body.Close()
+		require.NoError(t, err)
+	}
+
+	// Check response status code
+	require.Equal(t, testCase.Expected.StatusCode, resp.StatusCode)
+
+	// Check response headers
+	t.Log("Checking response headers")
+	for key := range testCase.Expected.Header {
+		expectedValue := fmt.Sprintf("%s: %s", key, testCase.Expected.Header.Get(key))
+		currentValue := fmt.Sprintf("%s: %s", key, resp.Header.Get(key))
+		assert.Equal(t, expectedValue, currentValue)
+	}
+
+	// Check response body
+	if bodyCount == 0 && len(body) == 0 {
+		return
+	}
+	if testCase.Expected.Body != nil {
+		assert.Equal(t, testCase.Expected.Body, body)
+	}
+	if testCase.Expected.BodyFunc != nil {
+		assert.True(t, testCase.Expected.BodyFunc(t, body))
+	}
+	if testCase.Expected.BodyBytes != nil {
+		assert.Equal(t, testCase.Expected.BodyBytes, body)
+	}
+}
+
+// RunTestCases run a slice of test cases.
+// testCases is the list of test cases to be executed.
+func (s *SuiteBase) RunTestCases(testCases []TestCase) {
+	t := s.T()
+	for i := range testCases {
+		t.Log(testCases[i].Name)
+		s.RunTestCase(&testCases[i])
+	}
+}
+
+// DefaultPublicBaseURL retrieve the public base endpoint URL.
+// Return for the URL for the current configuration.
+func (s *SuiteBase) DefaultPublicBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d/api/idmsvc/v1", s.cfg.Web.Port)
+}
+
+// DefaultPrivateBaseURL retrieve the private base endpoint URL.
+// Return for the URL for the current configuration.
+func (s *SuiteBase) DefaultPrivateBaseURL() string {
+	return fmt.Sprintf("http://localhost:%d/private", s.cfg.Web.Port)
+}
+
+// DoRequest execute a http request against a url using headers and the body specified.
+// method is the HTTP method to use for the request.
+// url is the to reach out.
+// header represents the request headers.
+// body is any golang type to be marshalled or a Reader interface (TODO future).
+// Return the http.Response object and nil when the endpoint is reached out,
+// or nil and a non error when some non API situation happens trying to reach
+// out the endpoint.
+func (s *SuiteBase) DoRequest(method string, url string, header http.Header, body any) (*http.Response, error) {
+	var reader io.Reader = nil
+	client := &http.Client{}
+
+	if body != nil {
+		// TODO add type assert so if a Reader interface
+		// is provided, it will be used directly; this will
+		// allow to wrong body to check for integration tests
+		_body, err := json.Marshal(body)
+		if err != nil {
+			return nil, err
+		}
+		if len(_body) > 0 {
+			reader = bytes.NewReader(_body)
+		}
+	} else {
+		reader = bytes.NewBufferString("")
+	}
+
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range header {
+		req.Header.Set(key, strings.Join(value, "; "))
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
+}
+
+type BodyFunc func(t *testing.T, body []byte) bool
+
+// TestCaseGiven represents the requirements for the smoke test to implement.
+type TestCaseGiven struct {
+	// Method represents the http method for the request.
+	Method string
+	// URL represents the url for the route to test.
+	URL string
+	// Header represents the set of header of the request.
+	Header http.Header
+	// Body represents a golang type to be marshalled before send the request;
+	// this field exclude the BodyBytes field.
+	Body any
+	// BodyBytes represents a specific buffer for the request body; this
+	// field exlude the Body field. This works for bad formed json documents,
+	// and other scenarios where Body does not fit.
+	BodyBytes []byte
+}
+
+// TestCaseExpect represents the expected response for a smoke test.
+type TestCaseExpect struct {
+	// StatusCode represents the http status code expected.
+	StatusCode int
+	// Header represents the expected http response headers.
+	Header http.Header
+	// Body represent an API type struct that after marshall should match the
+	// returned response; this could be a situation, because the order of the
+	// properties could not match. It is useful only when the property order
+	// is deterministic, else use BodyFunc.
+	Body any
+	// BodyBytes represent a specific bytes returned on the expectations.
+	BodyBytes []byte
+	// BodyFunc represent a custom function that will return nil or error
+	// to check some specifc body unserialized. This option exclude Body and
+	// BodyBytes and is useful when we want expectations based on a
+	// valid json document, but it is not a perfect fit of the Body.
+	BodyFunc BodyFunc
+}
+
+// TestCase represents a test case for the smoke test
+type TestCase struct {
+	// Name represents a string to be printed out which will be displayed
+	// in case of a failure happens.
+	Name string
+	// Given represents the given specification for the test case.
+	Given TestCaseGiven
+	// Expected represents the expected result for the operations.
+	Expected TestCaseExpect
+}
+
+// StartSignalHandler set up the signal handler. This method MUST NOT
+// be called several times, as that make no deterministic which signal
+// handler will receive the call.
+// c is the golang context associated, if it is nil a new background
+// context is used.
+// Return the cancel context generated that will called on exit and
+// the cancel function associted to the context.
+// See: https://pkg.go.dev/os/signal
+func StartSignalHandler(c context.Context) (context.Context, context.CancelFunc) {
+	if c == nil {
+		c = context.Background()
+	}
+	ctx, cancel := context.WithCancel(c)
+	go func() {
+		exit := make(chan os.Signal, 1)
+		signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		<-exit
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+// TearDownSignalHandler reset the signal handlers
+func TearDownSignalHandler() {
+	signal.Reset(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+}
+
+func TestSuite(t *testing.T) {
+	// TODO Add here your test suites
+	// suite.Run(t, new(SuiteTokenCreate))
+	// suite.Run(t, new(SuiteRegisterDomain))
+	// suite.Run(t, new(SuiteDomainUpdateUser))
+	// suite.Run(t, new(SuiteDomainUpdateAgent))
+	// suite.Run(t, new(SuiteDomainRead))
+	// suite.Run(t, new(SuiteListDomains))
+	// suite.Run(t, new(SuiteDomainDelete))
+}

--- a/internal/test/smoke/suite_test.go
+++ b/internal/test/smoke/suite_test.go
@@ -421,6 +421,6 @@ func TestSuite(t *testing.T) {
 	// suite.Run(t, new(SuiteDomainUpdateUser))
 	// suite.Run(t, new(SuiteDomainUpdateAgent))
 	// suite.Run(t, new(SuiteDomainRead))
-	// suite.Run(t, new(SuiteListDomains))
+	suite.Run(t, new(SuiteListDomains))
 	// suite.Run(t, new(SuiteDomainDelete))
 }

--- a/internal/test/smoke/token_test.go
+++ b/internal/test/smoke/token_test.go
@@ -1,0 +1,115 @@
+package smoke
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"github.com/stretchr/testify/require"
+)
+
+// SuiteTokenCreate is the suite token for smoke tests at /api/idmsvc/v1/domains/token
+type SuiteTokenCreate struct {
+	SuiteBase
+}
+
+// BodyFuncTokenResponse is the function that wrap
+type BodyFuncTokenResponse func(t *testing.T, expect *public.DomainRegTokenResponse) error
+
+// WrapBodyFuncTokenResponse allow to implement custom body expectations for the specific type of the response.
+// expected is the specific BodyFuncTokenResponse for DomainRegTokenResponse type
+// Returns a BodyFunc that wrap the generic expectation function.
+func WrapBodyFuncTokenResponse(expected BodyFuncTokenResponse) BodyFunc {
+	// To allow a generic interface for any body response type
+	// I have to use `body []byte`; I cannot use `any` because
+	// the response type is particular for the endpoint.
+	// That means the input to the function is not in a golang
+	// structure; to let the tests to be defined with less boilerplate,
+	// every response type would implement a wrapper function like
+	// this, which unmarshall the bytes, and call to the more specific
+	// custom body function.
+	if expected == nil {
+		return func(t *testing.T, body []byte) bool {
+			return len(body) == 0
+		}
+	}
+	return func(t *testing.T, body []byte) bool {
+		// Unserialize the response to the expected type
+		var data public.DomainRegTokenResponse
+		if err := json.Unmarshal(body, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error unmarshalling body:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+		// Run body expectetion on the unserialized data
+		if err := expected(t, &data); err != nil {
+			require.Fail(t, fmt.Sprintf("Error in body response:\n"+
+				"error: %q",
+				err.Error(),
+			))
+			return false
+		}
+		return true
+	}
+}
+
+// Specific expectation method that fit BodyFuncTokenResponse
+func (s *SuiteTokenCreate) bodyExpectationTestToken(t *testing.T, body *public.DomainRegTokenResponse) error {
+	if body.DomainToken == "" {
+		return fmt.Errorf("'domain_token' is empty")
+	}
+
+	if body.DomainType != "rhel-idm" {
+		return fmt.Errorf("'domain_type' is not rhel-idm")
+	}
+
+	if body.DomainId == (uuid.UUID{}) {
+		return fmt.Errorf("'domain_id' is empty")
+	}
+
+	if body.Expiration <= int(time.Now().Unix()) {
+		return fmt.Errorf("'expiration' is in the past")
+	}
+
+	return nil
+}
+
+func (s *SuiteTokenCreate) TestToken() {
+	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
+
+	// Prepare the tests
+	testCases := []TestCase{
+		{
+			Name: "TestToken",
+			Given: TestCaseGiven{
+				Method: http.MethodPost,
+				URL:    s.DefaultPublicBaseURL() + "/domains/token",
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            {xrhidEncoded},
+				},
+				Body: public.DomainRegTokenRequest{
+					DomainType: "rhel-idm",
+				},
+			},
+			Expected: TestCaseExpect{
+				StatusCode: http.StatusOK,
+				Header: http.Header{
+					"X-Rh-Insights-Request-Id": {"test_token"},
+					"X-Rh-Identity":            nil,
+				},
+				BodyFunc: WrapBodyFuncTokenResponse(s.bodyExpectationTestToken),
+			},
+		},
+	}
+
+	// Execute the test cases
+	s.RunTestCases(testCases)
+}

--- a/internal/usecase/interactor/domain_interactor_test.go
+++ b/internal/usecase/interactor/domain_interactor_test.go
@@ -419,7 +419,7 @@ func TestRegisterIpa(t *testing.T) {
 	}
 	for _, testCase := range testCases {
 		t.Log(testCase.Name)
-		i := NewDomainInteractor()
+		i := domainInteractor{}
 		orgID, clientVersion, output, err := i.Register(
 			testCase.Given.Secret,
 			testCase.Given.XRHID,

--- a/scripts/mk/compose.mk
+++ b/scripts/mk/compose.mk
@@ -4,8 +4,10 @@
 
 ifeq (podman,$(CONTAINER_ENGINE))
 CONTAINER_COMPOSE ?= podman-compose
+CONTAINER_DATABASE_NAME ?= $(COMPOSE_PROJECT)_database_1
 else
 CONTAINER_COMPOSE ?= docker-compose
+CONTAINER_DATABASE_NAME ?= $(COMPOSE_PROJECT)-database-1
 endif
 
 COMPOSE_FILE ?= $(PROJECT_DIR)/deployments/docker-compose.yaml
@@ -53,7 +55,7 @@ compose-up: ## Start local infrastructure
 .PHONY: .compose-wait-db
 .compose-wait-db:
 	@printf "Waiting database"; \
-	while [ "$$( $(CONTAINER_ENGINE) container inspect --format '{{$(CONTAINER_HEALTH_PATH)}}' "$(COMPOSE_PROJECT)_database_1" )" != "healthy" ]; \
+	while [ "$$( $(CONTAINER_ENGINE) container inspect --format '{{$(CONTAINER_HEALTH_PATH)}}' "$(CONTAINER_DATABASE_NAME)" )" != "healthy" ]; \
 	do sleep 1; printf "."; \
 	done; \
 	printf "\n"


### PR DESCRIPTION
This change implements a smoke test to read a rhel-idm domain information.

It adds a new `internal/test/assert` package with several assert functions to make life easier when checking the `public.Domain` structure for the test, so the main check of the tests are more clear and readable, and will reduce code duplication.

It depends on #42 