### PR TITLE
infra: Add make container-clean

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -2,6 +2,7 @@
 # This build the container image for the service
 ##
 FROM registry.access.redhat.com/ubi9/go-toolset:1.20 as builder
+LABEL idmsvc-backend=builder
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1
 WORKDIR /go/src/app
@@ -11,6 +12,7 @@ RUN make get-deps build
 
 
 FROM registry.access.redhat.com/ubi9/ubi:9.3-1361.1699548029
+LABEL idmsvc-backend=backend
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1
 RUN mkdir -p /opt/bin /opt/bin/scripts/db /opt/bin/configs

--- a/scripts/mk/container.mk
+++ b/scripts/mk/container.mk
@@ -56,9 +56,17 @@ container-build:  ## Build image CONTAINER_IMAGE from CONTAINERFILE using the CO
 	  -t "$(CONTAINER_IMAGE)" \
 	  $(CONTAINER_CONTEXT_DIR) \
 	  -f "$(CONTAINERFILE)"
+	@# prune builder container
+	$(CONTAINER_ENGINE) image prune --filter label=idmsvc-backend=builder --force
+
 .PHONY: container-push
 container-push:  ## Push image to remote registry
 	$(CONTAINER_ENGINE) push "$(CONTAINER_IMAGE)"
+
+.PHONY: container-clean
+container-clean:  ## Remove all local images with label=idmsvc-backend
+	$(CONTAINER_ENGINE) image prune --filter label=idmsvc-backend --force
+	$(CONTAINER_ENGINE) image list --filter label=idmsvc-backend --format "{{.ID}}" | xargs -r $(CONTAINER_ENGINE) image rm
 
 # TODO Indicate in the options the IP assigned to the postgres container
 # .PHONY: container-run


### PR DESCRIPTION
Our container images now have a label `idmsvc-backend` with value `builder` (for temporary Go builder container) or `backend` (for the actual backend container). The builder container is automatically pruned at the end of `make container-build`.

A new make target `container-clean` prunes and removes all local containers with a `idmsvc-backend` label.