### PR TITLE
feat: IPA client install with mkhomedir and subid

### DIFF
--- a/internal/usecase/presenter/host_presenter.go
+++ b/internal/usecase/presenter/host_presenter.go
@@ -52,7 +52,8 @@ func (p *hostPresenter) fillRhelIdm(domain *model.Domain, response *public.HostC
 		EnrollmentServers: servers,
 		RealmName:         *domain.IpaDomain.RealmName,
 		// TODO: hard-coded value for testing and demonstration
-		AutomountLocation: pointy.String("default"),
+		IpaClientInstallArgs: &[]string{"--mkhomedir", "--subid"},
+		AutomountLocation:    pointy.String("default"),
 	}
 	return nil
 }


### PR DESCRIPTION
Add `--mkhomedir` and `--subid` options to `ipa-client-install` for demo. This configures mkhomedir oddjob and SSSD's subordinate ID provider.