### PR TITLE
HMS-3190 feat: Show VCS information on app startup

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -30,6 +30,7 @@ func startSignalHandler(c context.Context) (context.Context, context.CancelFunc)
 
 func main() {
 	wg := &sync.WaitGroup{}
+	logger.LogBuildInfo("idmscv-backend")
 	cfg := config.Get()
 	logger.InitLogger(cfg)
 	db := datastore.NewDB(cfg)

--- a/scripts/mk/go-rules.mk
+++ b/scripts/mk/go-rules.mk
@@ -37,8 +37,10 @@ $(BIN) $(TOOLS_BIN):
 
 # export CGO_ENABLED
 # $(BIN)/%: CGO_ENABLED=0
+# Build by path, not by referring to main.go. It's required to bake VCS
+# information into binary, see golang/go#51279.
 $(BIN)/%: cmd/%/main.go $(BIN)
-	go build $(MOD_VENDOR) -o "$@" "$<"
+	go build -C $(dir $<) $(MOD_VENDOR) -buildvcs=true -o "$(CURDIR)/$@" .
 
 $(TOOLS_BIN)/%: $(TOOLS_DEPS)
 	cd tools && GOBIN="$(PROJECT_DIR)/tools/bin" go install $(shell grep $(notdir $@) tools/tools.go | awk '{print $$2}')


### PR DESCRIPTION
The service now shows version, git commit revision / time stamp, and dirty flag on startup. The information is provided by `runtime/debug` package since Golang 1.18.

`go build` bakes the VCS information into the binary if-and-only-if the main module is references by path to a directory.