### PR TITLE
HMS-3138 fix: return 201 when a domain is registered

### DIFF
--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -245,7 +245,7 @@ func (a *application) RegisterDomain(
 		return err
 	}
 
-	return ctx.JSON(http.StatusOK, *output)
+	return ctx.JSON(http.StatusCreated, *output)
 }
 
 // UpdateDomain (PUT /domains/{uuid}) update the


### PR DESCRIPTION
Update the returned code by the RegisterDomain handler for a success domain registration, so it return a 201 Created, instead of a 200 Ok status code.