### PR TITLE
HMS-3414 build: update ephemeral cluster

### DIFF
--- a/scripts/mk/ephemeral.mk
+++ b/scripts/mk/ephemeral.mk
@@ -7,6 +7,8 @@ ifeq (,$(APP_NAME))
 $(error APP_NAME is empty; did you miss to set APP_NAME=my-app at your scripts/mk/variables.mk)
 endif
 
+CLUSTER ?= crc-eph.r9lp.p1.openshiftapps.com
+
 APP_COMPONENT ?= backend
 
 # Set the default duration for the namespace reservation and extension
@@ -79,7 +81,7 @@ ephemeral-login: .old-ephemeral-login ## Help in login to the ephemeral cluster
 
 .PHONY: .old-ephemeral-login
 .old-ephemeral-login:
-	xdg-open "https://oauth-openshift.apps.c-rh-c-eph.8p0c.p1.openshiftapps.com/oauth/token/request"
+	xdg-open "https://oauth-openshift.apps.$(CLUSTER)/oauth/token/request"
 	@echo "- Login with github"
 	@echo "- Do click on 'Display Token'"
 	@echo "- Copy 'Log in with this token' command"

--- a/scripts/mk/private.example.mk
+++ b/scripts/mk/private.example.mk
@@ -60,3 +60,6 @@ APP_TOKEN_EXPIRATION_SECONDS ?= 7200
 # extending the reservation.
 #
 # DURATION ?= 4h
+
+# Cluster to use for development purpose
+CLUSTER ?= crc-eph.r9lp.p1.openshiftapps.com


### PR DESCRIPTION
Update to use the new ephemeral cluster and to quickly change to even another cluster if it were necessary just providing the CLUSTER variable from the command line to the make invokation or updating our makefile customizations.