### PR TITLE
HMS-3430 fix: add rbac dependency

### DIFF
--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -18,7 +18,7 @@ objects:
       # FIXME Update dependencies when integration with rbac is made
       # dependencies: ["rbac"]
       # https://consoledot.pages.redhat.com/clowder/dev/providers/dependencies.html
-      dependencies: []
+      dependencies: ["rbac"]
 
       # https://consoledot.pages.redhat.com/clowder/dev/providers/deployment.html
       deployments:


### PR DESCRIPTION
This change introduce the dependency of the idmsvc-backend on the "rbac" service, so it is made available when iqe is launched and when developing the integration with rbac service.