### PR TITLE
HMS-2182 refactor: enforce identity order

### DIFF
--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -74,16 +74,22 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 	systemIdentityMiddleware := middleware.EnforceIdentityWithConfig(
 		&middleware.IdentityConfig{
 			Skipper: skipperSystemPredicate,
-			Predicates: map[string]middleware.IdentityPredicate{
-				"system-identity": middleware.EnforceSystemPredicate,
+			Predicates: []middleware.IdentityPredicateEntry{
+				{
+					Name:      "system-identity",
+					Predicate: middleware.EnforceSystemPredicate,
+				},
 			},
 		},
 	)
 	userIdentityMiddleware := middleware.EnforceIdentityWithConfig(
 		&middleware.IdentityConfig{
 			Skipper: skipperUserPredicate,
-			Predicates: map[string]middleware.IdentityPredicate{
-				"user-identity": middleware.EnforceUserPredicate,
+			Predicates: []middleware.IdentityPredicateEntry{
+				{
+					Name:      "user-identity",
+					Predicate: middleware.EnforceUserPredicate,
+				},
 			},
 		},
 	)


### PR DESCRIPTION
This change provide a deterministic order when the enforce identity middleware is applied, when more than one predicate is provided.