### PR TITLE
HMS-3474 fix: Check for clowder AppConfig.Kafka for nil

### DIFF
--- a/internal/config/event.go
+++ b/internal/config/event.go
@@ -66,7 +66,7 @@ func NewTopicTranslationWithDefaults() *TopicTranslation {
 // NewTopicTranslationWithClowder Build a topic map based into the
 // clowder configuration.
 func NewTopicTranslationWithClowder(cfg *clowder.AppConfig) *TopicTranslation {
-	if cfg == nil {
+	if cfg == nil || cfg.Kafka == nil {
 		return NewTopicTranslationWithDefaults()
 	}
 

--- a/internal/infrastructure/event/topics_test.go
+++ b/internal/infrastructure/event/topics_test.go
@@ -22,6 +22,25 @@ func TestNewTopicTranslationWithClowder(t *testing.T) {
 		cfg    *clowder.AppConfig
 		result *config.TopicTranslation
 	)
+
+	// When it is nil, it returns the defaults
+	result = config.NewTopicTranslationWithClowder(nil)
+	for _, topic := range event.AllowedTopics {
+		assert.Equal(t, topic, result.GetInternal(topic))
+		assert.Equal(t, topic, result.GetReal(topic))
+	}
+
+	// When Kafka is nil, it returns the defaults
+	cfg = &clowder.AppConfig{
+		Kafka: nil,
+	}
+	result = config.NewTopicTranslationWithClowder(cfg)
+	for _, topic := range event.AllowedTopics {
+		assert.Equal(t, topic, result.GetInternal(topic))
+		assert.Equal(t, topic, result.GetReal(topic))
+	}
+
+	// Try the custom mapping is right
 	cfg = &clowder.AppConfig{
 		Kafka: &clowder.KafkaConfig{
 			Topics: []clowder.TopicConfig{
@@ -32,15 +51,6 @@ func TestNewTopicTranslationWithClowder(t *testing.T) {
 			},
 		},
 	}
-
-	// When it is nil, it returns the defaults
-	result = config.NewTopicTranslationWithClowder(nil)
-	for _, topic := range event.AllowedTopics {
-		assert.Equal(t, topic, result.GetInternal(topic))
-		assert.Equal(t, topic, result.GetReal(topic))
-	}
-
-	// Try the custom mapping is right
 	result = config.NewTopicTranslationWithClowder(cfg)
 	assert.Equal(t, "real.topic.name", result.GetReal("requested.topic.name"))
 	assert.Equal(t, "requested.topic.name", result.GetInternal("real.topic.name"))


### PR DESCRIPTION
Clowder configuration may have AppConfig.Kafka set to `nil`. The function `NewTopicTranslationWithClowder` was not checking the value for nil and crashed when it attempted to iterate over cfg.Kafka.Topics.