### PR TITLE
HMS-3190 fix: Include VCS info in container binaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,5 @@ configs
 # File generated when running unit tests
 coverage.out
 
-# Delete git files from the container context
-.git
-
+# NOTE: .git directory is not listed here. `go build` needs the full `.git`
+# directory to include VCS information in go binaries.

--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -8,6 +8,7 @@ ENV OPENSSL_FORCE_FIPS_MODE=1
 WORKDIR /go/src/app
 COPY . .
 USER 0
+RUN git log -1
 RUN make get-deps build
 
 


### PR DESCRIPTION
Do not exclude `.git` directory from Docker COPY, so `go build` is able to figure out and include VCS information in binaries that are built inside a container.