### PR TITLE
HMS-3559 infra: Fix Go version confusion / pr-check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,3 @@ repos:
     rev: v0.5.1
     hooks:
       - id: golangci-lint
-  # TODO This linter is not set up correctly
-  - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.21.0
-    hooks:
-      - id: check-metaschema
-        files: ^api/event/.*\.yaml$

--- a/scripts/mk/go-rules.mk
+++ b/scripts/mk/go-rules.mk
@@ -60,8 +60,8 @@ run: $(BIN)/service .compose-wait-db ## Run the api & kafka consumer locally
 # See: https://go.dev/doc/modules/managing-dependencies#synchronizing
 .PHONY: tidy
 tidy:  ## Synchronize your code's dependencies
-	go mod tidy
-	cd tools && go mod tidy
+	go mod tidy -go=$(GO_VERSION)
+	cd tools && go mod tidy -go=$(GO_VERSION)
 
 .PHONY: get-deps
 get-deps: ## Download golang dependencies
@@ -119,6 +119,12 @@ $(patsubst cmd/%,$(BIN)/%,$(wildcard cmd/*)): $(shell find $(PROJECT_DIR)/cmd -t
 # $(shell find "$(EVENT_MESSAGE_DIR)" -type f -name '*.go'): $(SCHEMA_YAML_FILES)
 # 	$(MAKE) gen-event-messages
 
+.PHONY: pr-check
+pr-check: ## Run common checks before submitting a PR
+	$(MAKE) go-fmt
+	$(MAKE) tidy vet
+	$(MAKE) generate-api generate-mock install-go-tools
+	$(MAKE) build test-unit
 
 ############### TOOLS
 

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -16,6 +16,8 @@ COMPOSE_FILE ?= $(PROJECT_DIR)/deployments/docker-compose.yaml
 
 CONTAINER_IMAGE_BASE ?= quay.io/$(firstword $(subst +, ,$(QUAY_USER)))/$(APP_NAME)-$(APP_COMPONENT)
 
+GO_VERSION ?= 1.20
+
 # Tools and their dependencies
 # Build dependencies
 TOOLS_BIN := tools/bin

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -9,11 +9,11 @@ go 1.20
 
 require (
 	github.com/achiku/planter v0.0.0-20230118102009-4847a8211e35
-	github.com/atombender/go-jsonschema v0.13.1
+	github.com/atombender/go-jsonschema v0.10.0
 	github.com/deepmap/oapi-codegen v1.16.2
 	github.com/golangci/golangci-lint v1.55.2
 	github.com/loov/goda v0.5.7
-	github.com/mikefarah/yq/v4 v4.40.5
+	github.com/mikefarah/yq/v4 v4.35.2
 	github.com/subpop/xrhidgen v0.1.0
 	github.com/vektra/mockery/v2 v2.38.0
 )
@@ -214,7 +214,6 @@ require (
 	github.com/yagipy/maintidx v1.0.0 // indirect
 	github.com/yeya24/promlinter v0.2.0 // indirect
 	github.com/ykadowak/zerologlint v0.1.3 // indirect
-	github.com/yuin/gopher-lua v1.1.1 // indirect
 	gitlab.com/bosi/decorder v0.4.1 // indirect
 	go-simpler.org/sloglint v0.1.2 // indirect
 	go.tmz.dev/musttag v0.7.2 // indirect

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -73,7 +73,7 @@ github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvr
 github.com/alecthomas/kingpin v2.2.6+incompatible/go.mod h1:59OFYbFVLKQKq+mqrL6Rw5bR0c3ACQaawgXx0QYndlE=
 github.com/alecthomas/participle/v2 v2.1.1 h1:hrjKESvSqGHzRb4yW1ciisFJ4p3MGYih6icjJvbsmV8=
 github.com/alecthomas/participle/v2 v2.1.1/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
-github.com/alecthomas/repr v0.3.0 h1:NeYzUPfjjlqHY4KtzgKJiWd6sVq2eNUPTi34PiFGjY8=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
@@ -92,8 +92,8 @@ github.com/ashanbrown/forbidigo v1.6.0 h1:D3aewfM37Yb3pxHujIPSpTf6oQk9sc9WZi8ger
 github.com/ashanbrown/forbidigo v1.6.0/go.mod h1:Y8j9jy9ZYAEHXdu723cUlraTqbzjKF1MUyfOKL+AjcU=
 github.com/ashanbrown/makezero v1.1.1 h1:iCQ87C0V0vSyO+M9E/FZYbu65auqH0lnsOkf5FcB28s=
 github.com/ashanbrown/makezero v1.1.1/go.mod h1:i1bJLCRSCHOcOa9Y6MyF2FTfMZMFdHvxKHxgO5Z1axI=
-github.com/atombender/go-jsonschema v0.13.1 h1:XyxeLVoCCYjsV00XG2GgKKhEQr2yBni9cfP8BDA+inE=
-github.com/atombender/go-jsonschema v0.13.1/go.mod h1:3T0onOJVWcMszwEGoLiW+tBVR4Z9uytqQxw6pOGXtT4=
+github.com/atombender/go-jsonschema v0.10.0 h1:/t6LIwYdVKmVyK5PRqvzyhWA2sAKKPj14tWejmQUBH4=
+github.com/atombender/go-jsonschema v0.10.0/go.mod h1:M0xmyjAR98dvz17jzkc6vcc1xLjm+KMh+Ya7hDgNszk=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -440,8 +440,8 @@ github.com/mbilski/exhaustivestruct v1.2.0 h1:wCBmUnSYufAHO6J4AVWY6ff+oxWxsVFrwg
 github.com/mbilski/exhaustivestruct v1.2.0/go.mod h1:OeTBVxQWoEmB2J2JCHmXWPJ0aksxSUOUy+nvtVEfzXc=
 github.com/mgechev/revive v1.3.4 h1:k/tO3XTaWY4DEHal9tWBkkUMJYO/dLDVyMmAQxmIMDc=
 github.com/mgechev/revive v1.3.4/go.mod h1:W+pZCMu9qj8Uhfs1iJMQsEFLRozUfvwFwqVvRbSNLVw=
-github.com/mikefarah/yq/v4 v4.40.5 h1:7gDj+GlXINEIB4wv30XR/UkH400kJHauiwxKwIXqgRc=
-github.com/mikefarah/yq/v4 v4.40.5/go.mod h1:y2lpkZypzZrJ2kr098cL0PfzdqEwVCJHPW8bH8HNQI8=
+github.com/mikefarah/yq/v4 v4.35.2 h1:WAvRpJNytw13x1arsRprZcdOb3WxDIJ539NG4oshzFc=
+github.com/mikefarah/yq/v4 v4.35.2/go.mod h1:7nyFSLbxP+nXJNoPXUbYTlJDDn/d9K/SMtKbOqQLbwM=
 github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
@@ -658,8 +658,6 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
-github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
-github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 gitlab.com/bosi/decorder v0.4.1 h1:VdsdfxhstabyhZovHafFw+9eJ6eU0d2CkFNJcZz/NU4=
 gitlab.com/bosi/decorder v0.4.1/go.mod h1:jecSqWUew6Yle1pCr2eLWTensJMmsxHsBwt+PVbkAqA=
 go-simpler.org/assert v0.6.0 h1:QxSrXa4oRuo/1eHMXSBFHKvJIpWABayzKldqZyugG7E=


### PR DESCRIPTION
`tools/go.mod` was using Go version 1.21, but our build container is limited to 1.20. Address build confusion by downgrading to a working go-jsonschema version and pinning `go mod tidy` to 1.20.

Introduce `pr-check` to run most important and fast linting, formatting, and testing steps.