### PR TITLE
HMS-2694 refactor: Split token package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 .DS_Store
 .cicd_bootstrap.sh
-secrets
+/secrets
 /idm-ci-secrets
 .venv
 /bin
@@ -10,11 +10,11 @@ tmp.*/**
 
 *.log
 
-configs/**
-!configs/config.example.yaml
-!configs/config.ci.yaml
-!configs/bonfire.example.yaml
-!configs/cdappconfig.json
+/configs/**
+!/configs/config.example.yaml
+!/configs/config.ci.yaml
+!/configs/bonfire.example.yaml
+!/configs/cdappconfig.json
 
 # File generated when running unit tests
 coverage.out

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	validator "github.com/go-playground/validator/v10"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/secrets"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
 	"golang.org/x/exp/slog"
@@ -53,6 +54,8 @@ type Config struct {
 	Metrics     Metrics
 	Clients     Clients
 	Application Application `mapstructure:"app"`
+	// Secrets is an untagged field and filled out on load
+	Secrets secrets.AppSecrets `mapstructure:"-"`
 }
 
 type Web struct {
@@ -333,6 +336,13 @@ func Get() *Config {
 		reportError(err)
 		panic("Invalid configuration")
 	}
+
+	sec, err := secrets.NewAppSecrets(config.Application.MainSecret)
+	if err != nil {
+		panic(err)
+	}
+	config.Secrets = *sec
+
 	return config
 }
 

--- a/internal/handler/impl/application_test.go
+++ b/internal/handler/impl/application_test.go
@@ -24,10 +24,6 @@ func TestNewHandler(t *testing.T) {
 	assert.Panics(t, func() {
 		NewHandler(&config.Config{}, nil, nil, nil)
 	})
-	// no app secrets
-	assert.Panics(t, func() {
-		NewHandler(&config.Config{}, gormDB, &metrics.Metrics{}, inventoryMock)
-	})
 	cfg := test.GetTestConfig()
 	assert.NotPanics(t, func() {
 		NewHandler(cfg, gormDB, &metrics.Metrics{}, inventoryMock)
@@ -43,6 +39,6 @@ func TestAppSecrets(t *testing.T) {
 	handler := NewHandler(cfg, gormDB, &metrics.Metrics{}, inventoryMock)
 	app := handler.(*application)
 
-	assert.NotEmpty(t, app.secrets.domainRegKey)
-	assert.Equal(t, len(app.secrets.domainRegKey), 32)
+	assert.NotEmpty(t, app.config.Secrets.DomainRegKey)
+	assert.Equal(t, len(app.config.Secrets.DomainRegKey), 32)
 }

--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -211,7 +211,7 @@ func (a *application) RegisterDomain(
 	}
 
 	if orgId, clientVersion, data, err = a.domain.interactor.Register(
-		a.secrets.domainRegKey,
+		a.config.Secrets.DomainRegKey,
 		xrhid,
 		&params,
 		&input,
@@ -439,7 +439,7 @@ func (a *application) CreateDomainToken(ctx echo.Context, params public.CreateDo
 
 	validity := time.Duration(a.config.Application.TokenExpirationTimeSeconds) * time.Second
 	if token, err = a.domain.repository.CreateDomainToken(
-		a.secrets.domainRegKey,
+		a.config.Secrets.DomainRegKey,
 		validity,
 		orgID,
 		domainType,

--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -50,7 +50,7 @@ func (a *application) HostConf(
 		return err
 	}
 	if hctoken, err = a.host.repository.SignHostConfToken(
-		a.secrets.signingKeys,
+		a.jwks.signingKeys,
 		options,
 		domain,
 	); err != nil {

--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -10,7 +10,7 @@ import (
 func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningKeysParams) error {
 	// TODO: hacky implementation
 	output := public.SigningKeysResponse{
-		Keys: a.secrets.publicKeys,
+		Keys: a.jwks.publicKeys,
 	}
 	return ctx.JSON(http.StatusOK, output)
 }

--- a/internal/infrastructure/secrets/app_secrets.go
+++ b/internal/infrastructure/secrets/app_secrets.go
@@ -1,0 +1,43 @@
+package secrets
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+type AppSecrets struct {
+	DomainRegKey []byte
+}
+
+const (
+	MainSecretMinLength = 16
+)
+
+// Parse main secret and get sub secrets
+func NewAppSecrets(mainSecret string) (sec *AppSecrets, err error) {
+	var secret []byte
+	if mainSecret == "random" {
+		secret = make([]byte, MainSecretMinLength)
+		if _, err = rand.Read(secret); err != nil {
+			return nil, err
+		}
+	} else {
+		if secret, err = base64.RawURLEncoding.DecodeString(mainSecret); err != nil {
+			return nil, fmt.Errorf("Failed to main secret: %v", err)
+		}
+		if len(secret) < MainSecretMinLength {
+			return nil, fmt.Errorf("Main secret is too short, expected at least %d bytes.", MainSecretMinLength)
+		}
+	}
+
+	// extract PRK from main secret
+	prk := HkdfExtract(secret)
+
+	sec = &AppSecrets{}
+	sec.DomainRegKey, err = HkdfExpand(prk, DomainRegKeyInfo)
+	if err != nil {
+		return nil, err
+	}
+	return sec, nil
+}

--- a/internal/infrastructure/secrets/app_secrets_test.go
+++ b/internal/infrastructure/secrets/app_secrets_test.go
@@ -1,0 +1,21 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewAppSecret(t *testing.T) {
+	var (
+		err error
+		sec *AppSecrets
+	)
+	sec, err = NewAppSecrets("random")
+	assert.NoError(t, err)
+	assert.NotNil(t, sec.DomainRegKey)
+
+	sec, err = NewAppSecrets("short")
+	assert.Nil(t, sec)
+	assert.Error(t, err)
+}

--- a/internal/infrastructure/secrets/hkdf.go
+++ b/internal/infrastructure/secrets/hkdf.go
@@ -1,0 +1,40 @@
+package secrets
+
+import (
+	"crypto/sha256"
+	"io"
+
+	"golang.org/x/crypto/hkdf"
+)
+
+type PRK []byte
+
+type HkdfInfo struct {
+	Info   []byte
+	Length int
+}
+
+const (
+	Salt = "idmsvc-backend"
+)
+
+var (
+	DomainRegKeyInfo = HkdfInfo{[]byte("domain registration key"), 32}
+)
+
+// Extract pseudo random key from a secret
+func HkdfExtract(mainSecret []byte) PRK {
+	var hash = sha256.New
+	return PRK(hkdf.Extract(hash, mainSecret, []byte(Salt)))
+}
+
+// Expand pseudo random key into a secret
+func HkdfExpand(prk PRK, hi HkdfInfo) (secret []byte, err error) {
+	var hash = sha256.New
+	reader := hkdf.Expand(hash, prk, hi.Info)
+	secret = make([]byte, hi.Length)
+	if _, err := io.ReadFull(reader, secret); err != nil {
+		return nil, err
+	}
+	return secret, err
+}

--- a/internal/infrastructure/secrets/hkdf_test.go
+++ b/internal/infrastructure/secrets/hkdf_test.go
@@ -1,0 +1,26 @@
+package secrets
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHkdfExpand(t *testing.T) {
+	mainSecret := []byte("mainSecret")
+	prk := HkdfExtract(mainSecret)
+	assert.Equal(t, prk, PRK{0xfc, 0x66, 0x8, 0xeb, 0x2f, 0x83, 0x77, 0x93, 0x2, 0x1a, 0x57, 0xf2, 0x1d, 0x39, 0x8a, 0x5, 0xa, 0x48, 0x9a, 0x63, 0x8e, 0xf9, 0x57, 0xfb, 0xac, 0x7a, 0x21, 0x63, 0x50, 0x3f, 0xac, 0x69})
+}
+
+// from cryptography.hazmat.primitives import hashes
+// from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+// HKDF(hashes.SHA256(), 8, b"idmsvc-backend", b"test").derive(b"mainSecret")
+
+func TestHkdfExtract(t *testing.T) {
+	mainSecret := []byte("mainSecret")
+	prk := HkdfExtract(mainSecret)
+	info := HkdfInfo{[]byte("test"), 8}
+	secret, err := HkdfExpand(prk, info)
+	assert.NoError(t, err)
+	assert.Equal(t, secret, []byte{0xe7, 0x84, 0x18, 0xae, 0xc6, 0x4d, 0xe5, 0x42})
+}

--- a/internal/infrastructure/token/domain_token/domain_token.go
+++ b/internal/infrastructure/token/domain_token/domain_token.go
@@ -2,7 +2,7 @@
  *
  * see docs/domain-token.md for more information
  */
-package token
+package domain_token
 
 import (
 	"crypto/hmac"

--- a/internal/infrastructure/token/domain_token/domain_token_test.go
+++ b/internal/infrastructure/token/domain_token/domain_token_test.go
@@ -1,4 +1,4 @@
-package token
+package domain_token
 
 import (
 	"testing"

--- a/internal/infrastructure/token/hostconf_jwk/encrypt.go
+++ b/internal/infrastructure/token/hostconf_jwk/encrypt.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_jwk
 
 import (
 	"crypto/aes"

--- a/internal/infrastructure/token/hostconf_jwk/encrypt_test.go
+++ b/internal/infrastructure/token/hostconf_jwk/encrypt_test.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_jwk
 
 import (
 	"crypto/ecdsa"

--- a/internal/infrastructure/token/hostconf_jwk/jwk.go
+++ b/internal/infrastructure/token/hostconf_jwk/jwk.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_jwk
 
 import (
 	"crypto"

--- a/internal/infrastructure/token/hostconf_jwk/jwk_test.go
+++ b/internal/infrastructure/token/hostconf_jwk/jwk_test.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_jwk
 
 import (
 	"encoding/json"

--- a/internal/infrastructure/token/hostconf_jwk/variables.go
+++ b/internal/infrastructure/token/hostconf_jwk/variables.go
@@ -1,0 +1,11 @@
+package hostconf_jwk
+
+// JWK key state
+type KeyState int
+
+const (
+	ValidKey KeyState = iota
+	ExpiredKey
+	InvalidKey
+	RevokedKey
+)

--- a/internal/infrastructure/token/hostconf_token/hostconf_token.go
+++ b/internal/infrastructure/token/hostconf_token/hostconf_token.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_token
 
 import (
 	"crypto/rand"

--- a/internal/infrastructure/token/hostconf_token/hostconf_token_test.go
+++ b/internal/infrastructure/token/hostconf_token/hostconf_token_test.go
@@ -1,4 +1,4 @@
-package token
+package hostconf_token
 
 import (
 	"testing"
@@ -7,6 +7,7 @@ import (
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk"
 	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/stretchr/testify/assert"
 )
@@ -56,12 +57,12 @@ func TestSignToken(t *testing.T) {
 	assert.NoError(t, err)
 
 	exp := time.Now().Add(time.Hour)
-	priv1, err := GeneratePrivateJWK(exp)
+	priv1, err := hostconf_jwk.GeneratePrivateJWK(exp)
 	assert.NoError(t, err)
 	pub1, err := priv1.PublicKey()
 	assert.NoError(t, err)
 
-	priv2, err := GeneratePrivateJWK(exp)
+	priv2, err := hostconf_jwk.GeneratePrivateJWK(exp)
 	assert.NoError(t, err)
 	pub2, err := priv2.PublicKey()
 	assert.NoError(t, err)

--- a/internal/infrastructure/token/hostconf_token/variables.go
+++ b/internal/infrastructure/token/hostconf_token/variables.go
@@ -1,14 +1,4 @@
-package token
-
-// JWK key state
-type KeyState int
-
-const (
-	ValidKey KeyState = iota
-	ExpiredKey
-	InvalidKey
-	RevokedKey
-)
+package hostconf_token
 
 // Token
 const (

--- a/internal/test/config_helper.go
+++ b/internal/test/config_helper.go
@@ -1,6 +1,9 @@
 package test
 
-import "github.com/podengo-project/idmsvc-backend/internal/config"
+import (
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/secrets"
+)
 
 // Config for testing
 func GetTestConfig() (cfg *config.Config) {
@@ -10,5 +13,12 @@ func GetTestConfig() (cfg *config.Config) {
 	cfg.Application.MainSecret = "random"
 	cfg.Application.PaginationDefaultLimit = 10
 	cfg.Application.PaginationMaxLimit = 100
+	// initialize secrets
+	sec, err := secrets.NewAppSecrets(cfg.Application.MainSecret)
+	if err != nil {
+		panic(err)
+	}
+	cfg.Secrets = *sec
+
 	return cfg
 }

--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -13,7 +13,7 @@ import (
 	api_public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
-	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/domain_token"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
 )
@@ -159,11 +159,11 @@ func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, p
 	}
 
 	// verify token
-	if domainID, err = token.VerifyDomainRegistrationToken(
+	if domainID, err = domain_token.VerifyDomainRegistrationToken(
 		domainRegKey,
 		string(body.DomainType),
 		orgID,
-		token.DomainRegistrationToken(params.XRhIdmRegistrationToken),
+		domain_token.DomainRegistrationToken(params.XRhIdmRegistrationToken),
 	); err != nil {
 		msg := fmt.Sprintf("Domain registration token is invalid: %s", err)
 		return "", nil, nil, echo.NewHTTPError(http.StatusUnauthorized, msg)

--- a/internal/usecase/interactor/domain_interactor_test.go
+++ b/internal/usecase/interactor/domain_interactor_test.go
@@ -15,7 +15,7 @@ import (
 	api_public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
-	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/domain_token"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/redhatinsights/platform-go-middlewares/identity"
@@ -49,7 +49,7 @@ func TestRegisterIpa(t *testing.T) {
 		orgID = "12345"
 	)
 	secret := []byte("token secret")
-	tok, _, err := token.NewDomainRegistrationToken(
+	tok, _, err := domain_token.NewDomainRegistrationToken(
 		secret,
 		string(api_public.RhelIdm),
 		orgID,
@@ -58,7 +58,7 @@ func TestRegisterIpa(t *testing.T) {
 	assert.NoError(t, err)
 	var (
 		rhsmID      = uuid.MustParse("cf26cd96-c75d-11ed-ae20-482ae3863d30")
-		domainID    = token.TokenDomainId(tok)
+		domainID    = domain_token.TokenDomainId(tok)
 		requestID   = pointy.String("TW9uIE1hciAyMCAyMDo1Mzoz")
 		xrhidSystem = identity.XRHID{
 			Identity: identity.Identity{

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -11,7 +11,7 @@ import (
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
-	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/domain_token"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/repository"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
@@ -294,11 +294,11 @@ func (r *domainRepository) CreateDomainToken(
 	orgID string,
 	domainType public.DomainType,
 ) (drt *repository.DomainRegToken, err error) {
-	tok, expireNS, err := token.NewDomainRegistrationToken(key, string(domainType), orgID, validity)
+	tok, expireNS, err := domain_token.NewDomainRegistrationToken(key, string(domainType), orgID, validity)
 	if err != nil {
 		return nil, err
 	}
-	domainId := token.TokenDomainId(tok)
+	domainId := domain_token.TokenDomainId(tok)
 	drt = &repository.DomainRegToken{
 		DomainId:     domainId,
 		DomainToken:  string(tok),

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
-	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/domain_token"
 	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1251,7 +1251,7 @@ func (s *Suite) TestCreateDomainToken() {
 	assert.Equal(
 		t,
 		drt.DomainId,
-		token.TokenDomainId(token.DomainRegistrationToken(drt.DomainToken)),
+		domain_token.TokenDomainId(domain_token.DomainRegistrationToken(drt.DomainToken)),
 	)
 	assert.Greater(t, drt.ExpirationNS, uint64(time.Now().UnixNano()))
 }

--- a/internal/usecase/repository/host_repository.go
+++ b/internal/usecase/repository/host_repository.go
@@ -9,7 +9,7 @@ import (
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
-	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_token"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/repository"
 	"gorm.io/gorm"
@@ -94,7 +94,7 @@ func (r *hostRepository) SignHostConfToken(
 	}
 
 	validity := time.Hour
-	tok, err := token.BuildHostconfToken(
+	tok, err := hostconf_token.BuildHostconfToken(
 		options.CommonName,
 		options.OrgId,
 		options.InventoryId,
@@ -105,7 +105,7 @@ func (r *hostRepository) SignHostConfToken(
 	if err != nil {
 		return "", err
 	}
-	b, err := token.SignToken(tok, privs)
+	b, err := hostconf_token.SignToken(tok, privs)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Split the token package into three separate packages and move the HKDF code into a new `secrets` package.

- `hostconf_token` deals with host configuration token
- `hostconf_jwk` handles private and public JWKs for host configuration token
- `domain_token` deals with domain registration tokens
- new `secrets` expands and extracts secrets from the main app secret
- secrets are now part of `config` structure in an untagged struct member (therefore not handled by viper)