### PR TITLE
feat(HMS-3521): Add configuration to enable/disable RBAC middleware

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -140,7 +140,6 @@ linters:
     - testifylint
     - unused
     - whitespace
-    - wrapcheck
     # WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive.
     # - golint
     # # - asasalint

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,10 @@
     },
     "go.autocompleteUnimportedPackages": true,
     "go.formatTool": "gofumpt",
-    "go.lintTool": "golangci-lint"
+    // https://golangci-lint.run/usage/integrations/#go-for-visual-studio-code
+    "go.lintTool": "golangci-lint",
+    "go.lintOnSave": "workspace",
+    "go.lintFlags": [
+        "--fast"
+    ]
 }

--- a/configs/config.ci.yaml
+++ b/configs/config.ci.yaml
@@ -80,3 +80,6 @@ app:
   # main secret for various MAC and encryptions like domain registration
   # token and encrypted private JWKs. "random" generates an ephemeral secret.
   secret: random
+  # Enable/Disable RBAC verification
+  # TODO remove override when HMS-3521 is implemented
+  enable_rbac: false

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -82,3 +82,6 @@ app:
   # main secret for various MAC and encryptions like domain registration
   # token and encrypted private JWKs. "random" generates an ephemeral secret.
   secret: random
+  # Enable/Disable RBAC verification
+  # TODO remove override when HMS-3521 is implemented
+  enable_rbac: false

--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -215,3 +215,8 @@ parameters:
     value: "false"
     description: |
       A flag to suspend execution of 'db-tool jwk refresh' cron job.
+  # TODO HMS-3528 Set "true" or remove the feature flag
+  - name: APP_ENABLE_RBAC
+    value: "false"
+    description: |
+      It allows to enable / disable RBAC middleware.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,8 @@ const (
 	DefaultTokenExpirationTimeSeconds = 7200
 	// DefaultWebPort is the default port where the public API is listening
 	DefaultWebPort = 8000
+	// DefaultEnableRBAC is true
+	DefaultEnableRBAC = true
 
 	// https://github.com/project-koku/koku/blob/main/koku/api/common/pagination.py
 
@@ -176,6 +178,8 @@ type Application struct {
 	// token and encrypted private JWKs. "random" generates an ephemeral secret.
 	// Secrets are derived with HKDF-SHA256.
 	MainSecret string `mapstructure:"secret" validate:"required,base64rawurl"`
+	// Flag to enable/disable rbac
+	EnableRBAC bool `mapstructure:"enable_rbac"`
 }
 
 var config *Config = nil
@@ -217,6 +221,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("app.pagination_max_limit", PaginationMaxLimit)
 	v.SetDefault("app.accept_x_rh_fake_identity", DefaultAcceptXRHFakeIdentity)
 	v.SetDefault("app.validate_api", DefaultValidateAPI)
+	v.SetDefault("app.enable_rbac", DefaultEnableRBAC)
 	v.SetDefault("app.url_path_prefix", DefaultPathPrefix)
 	v.SetDefault("app.secret", "")
 	v.SetDefault("app.debug", false)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -20,12 +20,15 @@ func TestSetDefaults(t *testing.T) {
 		setDefaults(v)
 	})
 
+	// TODO HMS-3609 There are many more properties to check; complete the test
 	assert.Equal(t, DefaultWebPort, v.Get("web.port"))
 	assert.Equal(t, "info", v.Get("logging.level"))
 	assert.Equal(t, "http://localhost:8010/api/inventory/v1", v.Get("clients.host_inventory_base_url"))
 	assert.Equal(t, DefaultTokenExpirationTimeSeconds, v.Get("app.token_expiration_seconds"))
 	assert.Equal(t, PaginationDefaultLimit, v.Get("app.pagination_default_limit"))
 	assert.Equal(t, PaginationMaxLimit, v.Get("app.pagination_max_limit"))
+
+	assert.Equal(t, DefaultEnableRBAC, v.Get("app.enable_rbac"))
 }
 
 func TestSetClowderConfiguration(t *testing.T) {
@@ -159,6 +162,7 @@ func TestValidateConfig(t *testing.T) {
 	assert.Error(t, err)
 	ve, ok := err.(validator.ValidationErrors)
 	assert.True(t, ok)
+	// TODO Change the order; it should be (t, expected_value, current_calue)
 	assert.Equal(t, len(ve), 1)
 	assert.Equal(t, ve[0].Namespace(), "Config.Application.TokenExpirationTimeSeconds")
 	assert.Equal(t, ve[0].Tag(), "gte")

--- a/internal/infrastructure/middleware/rbac.go
+++ b/internal/infrastructure/middleware/rbac.go
@@ -1,0 +1,39 @@
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	echo_middleware "github.com/labstack/echo/v4/middleware"
+)
+
+// TODO HMS-3522 Add RBACMap and implement its methods:
+//
+// Add(route string, method string, permission string) RBACMap
+// Get(route string, method string) string
+
+type route string
+type method string
+type permission string
+
+// RBACMap is a mapping for the permissions [path][method] => permission
+type RBACMap map[route]map[method]permission
+
+type RBACConfig struct {
+	// Skipper function to skip for some request if necessary
+	Skipper echo_middleware.Skipper
+	// TODO HMS-3522 Add the mapping structure
+	PermissionMap RBACMap
+}
+
+func RBACWithConfig(config *RBACConfig) echo.MiddlewareFunc {
+	if config == nil {
+		panic("'config' is nil")
+	}
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// TODO Implement HMS-3522
+			return echo.NewHTTPError(http.StatusUnauthorized, "unauthorized")
+		}
+	}
+}

--- a/internal/infrastructure/middleware/rbac_test.go
+++ b/internal/infrastructure/middleware/rbac_test.go
@@ -1,0 +1,47 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	"github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	"github.com/stretchr/testify/assert"
+)
+
+func helperSetupRBACMiddleware(config *RBACConfig, method, path string) *echo.Echo {
+	e := echo.New()
+	e.Use(CreateContext())
+	e.Use(EnforceIdentityWithConfig(&IdentityConfig{}))
+	e.Use(RBACWithConfig(config))
+	e.Add(method, path, func(c echo.Context) error {
+		return c.NoContent(http.StatusOK)
+	})
+	return e
+}
+
+func TestRBACWithConfig(t *testing.T) {
+	xrhid := api.NewUserXRHID().Build()
+	xrhidString := header.EncodeXRHID(&xrhid)
+	rbacMap := RBACMap{}
+	rbacConfig := RBACConfig{Skipper: nil, PermissionMap: rbacMap}
+
+	// Fails with nil configuration
+	assert.Panics(t, func() {
+		RBACWithConfig(nil)
+	})
+
+	// Execute middleware
+	method := http.MethodGet
+	path := "/api/idmsvc/v1/domains"
+	e := helperSetupRBACMiddleware(&rbacConfig, method, path)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, http.NoBody)
+	req.Header.Add("X-Rh-Identity", xrhidString)
+	e.ServeHTTP(rec, req)
+	assert.Equal(t, http.StatusUnauthorized, rec.Code)
+
+	// TODO HMS-3522
+}

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -117,3 +117,8 @@ export APP_TOKEN_EXPIRATION_SECONDS
 # domain registration token and encrypted private JWKs
 APP_SECRET ?= sFamo2ER65JN7wxZ48UZb5GbtDc053ahIPJ0Qx47bzA
 export APP_SECRET
+
+# Enable / disable the rbac middleware
+APP_ENABLE_RBAC ?= false
+export APP_ENABLE_RBAC
+


### PR DESCRIPTION
This change add the configuration and skeleton for the RBAC middleware and unit tests.

The default value at config will be enabled in the code, but will be disabled until the implementation is full finished at HMS-3528

Checked by:

- `APP_ENABLE_RBAC=false make test-smoke` # run successfully
- `APP_ENABLE_RBAC=true make test-smoke`  # Fail with 403
- `make test` # Run successfully