### PR TITLE
HMS-2694 refactor: Move ephemeral JWK into repository

### DIFF
--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -5,12 +5,33 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"gorm.io/gorm"
 )
 
 func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningKeysParams) error {
-	// TODO: hacky implementation
-	output := public.SigningKeysResponse{
-		Keys: a.jwks.publicKeys,
+	var (
+		err    error
+		tx     *gorm.DB
+		keys   []string
+		output *public.SigningKeysResponse
+	)
+
+	if tx = a.db.Begin(); tx.Error != nil {
+		return tx.Error
 	}
+	defer tx.Rollback()
+
+	if keys, err = a.hostconfjwk.repository.GetPublicKeyArray(tx); err != nil {
+		return err
+	}
+
+	if tx.Commit(); tx.Error != nil {
+		return tx.Error
+	}
+
+	if output, err = a.hostconfjwk.presenter.PublicSigningKeys(keys); err != nil {
+		return err
+	}
+
 	return ctx.JSON(http.StatusOK, output)
 }

--- a/internal/usecase/repository/hostconf_jwk_repository_test.go
+++ b/internal/usecase/repository/hostconf_jwk_repository_test.go
@@ -66,15 +66,15 @@ func (s *HostConfJwkRepositorySuite) TestListJWKs() {
 func (s *HostConfJwkRepositorySuite) TestGetPublicKeyArray() {
 	t := s.Suite.T()
 	keys, err := s.repository.GetPublicKeyArray(s.db)
-	assert.Nil(t, keys)
-	assert.EqualError(t, err, notImplementedError.Error())
+	assert.Equal(t, keys, s.repository.(*hostconfJwkRepository).publicKeys)
+	assert.Nil(t, err)
 }
 
 func (s *HostConfJwkRepositorySuite) TestGetPrivateSigningKeys() {
 	t := s.Suite.T()
 	keys, err := s.repository.GetPrivateSigningKeys(s.db)
-	assert.Nil(t, keys)
-	assert.EqualError(t, err, notImplementedError.Error())
+	assert.Equal(t, keys, s.repository.(*hostconfJwkRepository).signingKeys)
+	assert.Nil(t, err)
 }
 
 func TestHostConfJwkRepositorySuite(t *testing.T) {


### PR DESCRIPTION
Wire up more of the hostconf JWK code by generating and serving the ephemeral JWKs from the hostconf JWK repository. This moves the hack from app implementation into DB layer.