### PR TITLE
HMS-2694 feat: Add boilerplate for JWK key refresh

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -31,6 +31,18 @@
             }
         },
         {
+            "name": "db-tool-jwk-refresh",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}/cmd/db-tool",
+            "cwd": "${workspaceFolder}",
+            "args": ["jwk", "refresh"],
+            "env": {
+                "CONFIG_PATH": "${workspaceFolder}/configs",
+            }
+        },
+        {
             "name": "db-tool-migrate-down",
             "type": "go",
             "request": "launch",

--- a/cmd/db-tool/cmd/jwk-refresh.go
+++ b/cmd/db-tool/cmd/jwk-refresh.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+// refreshCmd represents the refresh command
+var refreshCmd = &cobra.Command{
+	Use:   "refresh",
+	Short: "Refresh or create JWKs",
+	Long:  `The refresh command ensures that the database contains valid JWKs.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// Print not implemented warning, but don't fail.
+		fmt.Println("JWK refresh is not implemented yet.")
+		os.Exit(0)
+	},
+}
+
+func init() {
+	jwkCmd.AddCommand(refreshCmd)
+}

--- a/cmd/db-tool/cmd/jwk.go
+++ b/cmd/db-tool/cmd/jwk.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// jwkCmd represents the jwk command
+var jwkCmd = &cobra.Command{
+	Use:   "jwk",
+	Short: "JSON Web Key management",
+}
+
+func init() {
+	rootCmd.AddCommand(jwkCmd)
+}

--- a/cmd/db-tool/cmd/root.go
+++ b/cmd/db-tool/cmd/root.go
@@ -15,6 +15,7 @@ var rootCmd = &cobra.Command{
 	db-tool new [migration-name]
 	db-tool migrate up [steps]
 	db-tool migrate down [steps]
+	db-tool jwk refresh
 `,
 }
 

--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -40,13 +40,19 @@ objects:
               apiPath: ${APP_NAME}
           podSpec:
             initContainers:
-              - name: db-migrate
+              - name: db-migrate-up
                 inheritEnv: true
                 args:
                   - /opt/bin/db-tool
                   - migrate
                   - up
                   - "0"
+              - name: db-jwk-refresh
+                inheritEnv: true
+                args:
+                  - /opt/bin/db-tool
+                  - jwk
+                  - refresh
             image: ${IMAGE}:${IMAGE_TAG}
             command:
               - /opt/bin/service
@@ -113,19 +119,36 @@ objects:
 
       # https://consoledot.pages.redhat.com/clowder/dev/providers/cronjob.html
       jobs:
-        # TODO Uncomment and update for your jobs
-        # - name: todo-job-name
-        #   # https://crontab.guru/
-        #   schedule: "0 0/8 * * *"
-        #   concurrencyPolicy: "Forbid"
-        #   podSpec:
-        #     image: ${IMAGE}:${IMAGE_TAG}
-        #     inheritEnv: true
-        #     command:
-        #       - /opt/bin/my-job-binary
-        #     env:
-        #       - name: LOGGING_LEVEL
-        #         value: ${{LOGGING_LEVEL}}
+        - name: jwk-refresh
+          schedule: "@hourly"
+          concurrencyPolicy: Replace
+          restartPolicy: Never
+          suspend: ${{DB_JWK_REFRESH_SUSPEND}}
+          podSpec:
+            image: ${IMAGE}:${IMAGE_TAG}
+            command:
+              - /opt/bin/db-tool
+              - jwk
+              - refresh
+            env:
+              - name: CLOWDER_ENABLED
+                value: "true"
+              - name: LOGGING_LEVEL
+                value: ${{LOGGING_LEVEL}}
+              - name: APP_TOKEN_EXPIRATION_SECONDS
+                value: "${APP_TOKEN_EXPIRATION_SECONDS}"
+              - name: APP_SECRET
+                valueFrom:
+                  secretKeyRef:
+                    key: app_secret
+                    name: app-secret
+            resources:
+              limits:
+                cpu: ${CPU_LIMIT}
+                memory: ${MEMORY_LIMIT}
+              requests:
+                cpu: ${CPU_REQUESTS}
+                memory: ${MEMORY_REQUESTS}
 
       # https://consoledot.pages.redhat.com/clowder/dev/providers/database.html
       database:
@@ -188,3 +211,7 @@ parameters:
     description: |
       It allows to validate API requests by using the
       service OpenAPI specification.
+  - name: DB_JWK_REFRESH_SUSPEND
+    value: "false"
+    description: |
+      A flag to suspend execution of 'db-tool jwk refresh' cron job.

--- a/scripts/mk/db.mk
+++ b/scripts/mk/db.mk
@@ -6,8 +6,9 @@
 install-db-tool: $(BIN)/db-tool
 
 .PHONY: db-migrate-up
-db-migrate-up: $(BIN)/db-tool  ## Migrate the database upto the current state
+db-migrate-up: $(BIN)/db-tool  ## Migrate the database upto the current state and refresh/create JWKs
 	$(BIN)/db-tool migrate up 0
+	$(BIN)/db-tool jwk refresh
 
 .PHONY: db-cli
 db-cli:  ## Open a cli shell inside the databse container


### PR DESCRIPTION
The `db-tool` command now has a subcommand to refresh JWKs. The subcommand doesn't do anything besides printing a string. The actual refresh code will be implemented later.

- add dummy implementation of `db-tool jwk refresh`
- update cloweder template to run refresh in init container and as periodic job. The cron job runs every hour, which makes testing and debug a bit easier. Later one we could reduce the schedule to daily.
- run `db-tool jwk refresh` during `make db-migrate-up`