### PR TITLE
HMS-2694 feat: Config changes for JWK in DB

### DIFF
--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -80,8 +80,9 @@ app:
   # Validate API requests and response against the openapi specification
   validate_api: true
   # main secret for various MAC and encryptions like domain registration
-  # token and encrypted private JWKs. "random" generates an ephemeral secret.
-  secret: random
+  # token and encrypted private JWKs. You can generate a secret with:
+  #     python -c "import secrets; print(secrets.token_urlsafe())"
+  secret: sFamo2ER65JN7wxZ48UZb5GbtDc053ahIPJ0Qx47bzA
   # Enable/Disable RBAC verification
   # TODO remove override when HMS-3521 is implemented
   enable_rbac: false

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 
 	validator "github.com/go-playground/validator/v10"
 	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/secrets"
 	clowder "github.com/redhatinsights/app-common-go/pkg/api/v1"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
@@ -153,9 +154,11 @@ func TestLoad(t *testing.T) {
 func TestValidateConfig(t *testing.T) {
 	cfg := Config{
 		Application: Application{
-			PathPrefix:                 DefaultPathPrefix,
-			MainSecret:                 "random",
-			TokenExpirationTimeSeconds: 0,
+			PathPrefix:                  DefaultPathPrefix,
+			MainSecret:                  secrets.GenerateRandomMainSecret(),
+			TokenExpirationTimeSeconds:  0,
+			HostconfJwkValidity:         DefaultHostconfJwkValidity,
+			HostconfJwkRenewalThreshold: DefaultHostconfJwkRenewalThreshold,
 		},
 	}
 	err := Validate(&cfg)

--- a/internal/infrastructure/secrets/app_secrets.go
+++ b/internal/infrastructure/secrets/app_secrets.go
@@ -3,32 +3,41 @@ package secrets
 import (
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 )
 
 type AppSecrets struct {
-	DomainRegKey []byte
+	DomainRegKey          []byte
+	HostconfEncryptionId  string
+	HostConfEncryptionKey []byte
 }
 
 const (
 	MainSecretMinLength = 16
 )
 
+// Generate random value for main secret, used in tests
+func GenerateRandomMainSecret() string {
+	random := make([]byte, MainSecretMinLength)
+	if _, err := rand.Read(random); err != nil {
+		panic(err)
+	}
+	return base64.RawURLEncoding.EncodeToString(random)
+}
+
 // Parse main secret and get sub secrets
 func NewAppSecrets(mainSecret string) (sec *AppSecrets, err error) {
 	var secret []byte
+
 	if mainSecret == "random" {
-		secret = make([]byte, MainSecretMinLength)
-		if _, err = rand.Read(secret); err != nil {
-			return nil, err
-		}
-	} else {
-		if secret, err = base64.RawURLEncoding.DecodeString(mainSecret); err != nil {
-			return nil, fmt.Errorf("Failed to main secret: %v", err)
-		}
-		if len(secret) < MainSecretMinLength {
-			return nil, fmt.Errorf("Main secret is too short, expected at least %d bytes.", MainSecretMinLength)
-		}
+		return nil, fmt.Errorf("random main secret is no longer supported")
+	}
+	if secret, err = base64.RawURLEncoding.DecodeString(mainSecret); err != nil {
+		return nil, fmt.Errorf("Failed to decode main secret: %v", err)
+	}
+	if len(secret) < MainSecretMinLength {
+		return nil, fmt.Errorf("Main secret is too short, expected at least %d bytes.", MainSecretMinLength)
 	}
 
 	// extract PRK from main secret
@@ -39,5 +48,15 @@ func NewAppSecrets(mainSecret string) (sec *AppSecrets, err error) {
 	if err != nil {
 		return nil, err
 	}
+	sec.HostConfEncryptionKey, err = HkdfExpand(prk, HostconfEncryptionKeyInfo)
+	if err != nil {
+		return nil, err
+	}
+	encid, err := HkdfExpand(prk, HostconfEncryptionIdInfo)
+	if err != nil {
+		return nil, err
+	}
+	sec.HostconfEncryptionId = hex.EncodeToString(encid)
+
 	return sec, nil
 }

--- a/internal/infrastructure/secrets/app_secrets_test.go
+++ b/internal/infrastructure/secrets/app_secrets_test.go
@@ -11,9 +11,11 @@ func TestNewAppSecret(t *testing.T) {
 		err error
 		sec *AppSecrets
 	)
-	sec, err = NewAppSecrets("random")
+	sec, err = NewAppSecrets(GenerateRandomMainSecret())
 	assert.NoError(t, err)
 	assert.NotNil(t, sec.DomainRegKey)
+	assert.NotNil(t, sec.HostConfEncryptionKey)
+	assert.NotEmpty(t, sec.HostconfEncryptionId)
 
 	sec, err = NewAppSecrets("short")
 	assert.Nil(t, sec)

--- a/internal/infrastructure/secrets/hkdf.go
+++ b/internal/infrastructure/secrets/hkdf.go
@@ -19,7 +19,12 @@ const (
 )
 
 var (
+	// MAC key for domain registration token
 	DomainRegKeyInfo = HkdfInfo{[]byte("domain registration key"), 32}
+	// hex string to identify AES encryption keys for encrypted private JWKs
+	HostconfEncryptionIdInfo = HkdfInfo{[]byte("hostconf JWK encryption id"), 8}
+	// AES-GCM encryption keys for private JWKs
+	HostconfEncryptionKeyInfo = HkdfInfo{[]byte("hostconf JWK encryption key"), 16}
 )
 
 // Extract pseudo random key from a secret

--- a/internal/test/config_helper.go
+++ b/internal/test/config_helper.go
@@ -9,8 +9,12 @@ import (
 func GetTestConfig() (cfg *config.Config) {
 	cfg = &config.Config{}
 	config.Load(cfg)
+
 	// override some default settings
-	cfg.Application.MainSecret = "random"
+	cfg.Application.MainSecret = secrets.GenerateRandomMainSecret()
+	cfg.Application.TokenExpirationTimeSeconds = 3600
+	cfg.Application.HostconfJwkValidity = config.DefaultHostconfJwkValidity
+	cfg.Application.HostconfJwkRenewalThreshold = config.DefaultHostconfJwkRenewalThreshold
 	cfg.Application.PaginationDefaultLimit = 10
 	cfg.Application.PaginationMaxLimit = 100
 	// initialize secrets


### PR DESCRIPTION
Add configuration settings for hostconf JWK expiration and refresh threshold. The minimum values are set to 1 minute for easier testing.

Remove support for `random` app secret. Random keys are incompatible with persistent JWKs. Local example configuration now uses the same secret as Makefile. Ephemeral and stage get their secret from Vault.

Note: ParseDuration does not support days.