### PR TITLE
HMS-2694 feat: Hostconf JWK model and table

### DIFF
--- a/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
+++ b/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
@@ -1,8 +1,13 @@
 package model
 
 import (
+	"encoding/json"
+	"errors"
 	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/secrets"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk"
 	"gorm.io/gorm"
 )
 
@@ -16,6 +21,13 @@ type HostconfJwk struct {
 	EncryptedJwk []byte
 }
 
+var (
+	ErrExpiredKey          = errors.New("expired key")
+	ErrInvalidKey          = errors.New("invalid key")
+	ErrRevokedKey          = errors.New("revoked key")
+	ErrKeyDecryptionFailed = errors.New("decryption failed")
+)
+
 // Before create hook
 func (hc *HostconfJwk) BeforeCreate(tx *gorm.DB) (err error) {
 	var currentTime = time.Now()
@@ -23,4 +35,88 @@ func (hc *HostconfJwk) BeforeCreate(tx *gorm.DB) (err error) {
 	hc.UpdatedAt = currentTime
 
 	return nil
+}
+
+// Create a new Hostconf JWK entry with public and encrypted private JWK
+func NewHostconfJwk(secrets secrets.AppSecrets, expiresAt time.Time) (hc *HostconfJwk, err error) {
+	var (
+		encryptedJwk []byte
+		pubkey       jwk.Key
+		pubkeybytes  []byte
+		privkey      jwk.Key
+	)
+
+	// create an encrypt private key
+	if privkey, err = hostconf_jwk.GeneratePrivateJWK(expiresAt); err != nil {
+		return nil, err
+	}
+	if encryptedJwk, err = hostconf_jwk.EncryptJWK(secrets.HostConfEncryptionKey, privkey); err != nil {
+		return nil, err
+	}
+
+	// serialize public key
+	if pubkey, err = hostconf_jwk.GetPublicJWK(privkey); err != nil {
+		return nil, err
+	}
+	if pubkeybytes, err = json.Marshal(pubkey); err != nil {
+		return nil, err
+	}
+
+	hc = &HostconfJwk{
+		KeyId:        pubkey.KeyID(),
+		ExpiresAt:    expiresAt,
+		PublicJwk:    string(pubkeybytes),
+		EncryptedJwk: encryptedJwk,
+		EncryptionId: secrets.HostconfEncryptionId,
+	}
+
+	return hc, nil
+}
+
+// Get public key state (invalid, expired, revoked, valid)
+// A public key can be valid although its private key cannot be decrypted
+// by current secret.
+func (hc *HostconfJwk) GetPublicKeyState() (hostconf_jwk.KeyState, error) {
+	if hc.PublicJwk == "" || hc.KeyId == "" {
+		return hostconf_jwk.InvalidKey, ErrInvalidKey
+	}
+	if hc.ExpiresAt.Unix() <= time.Now().Unix() {
+		return hostconf_jwk.ExpiredKey, ErrExpiredKey
+	}
+	if hc.EncryptedJwk == nil {
+		return hostconf_jwk.RevokedKey, ErrRevokedKey
+	}
+	return hostconf_jwk.ValidKey, nil
+}
+
+// Get public jwk.Key from entry
+// Fails if key is invalid, expired, or revoked.
+func (hc *HostconfJwk) GetPublicJWK() (pubkey jwk.Key, state hostconf_jwk.KeyState, err error) {
+	if state, err = hc.GetPublicKeyState(); err != nil {
+		return nil, state, err
+	}
+	return hostconf_jwk.ParseJWK([]byte(hc.PublicJwk))
+}
+
+// Get private key state (invalid, expired, revoked, mismatch, valid)
+func (hc *HostconfJwk) GetPrivateKeyState(secrets secrets.AppSecrets) (state hostconf_jwk.KeyState, err error) {
+	state, err = hc.GetPublicKeyState()
+	if state == hostconf_jwk.ValidKey {
+		if hc.EncryptionId != secrets.HostconfEncryptionId {
+			return hostconf_jwk.EncryptionIdMismatch, ErrKeyDecryptionFailed
+		}
+	}
+	return state, err
+}
+
+// Decrypt and return private jwk.Key from entry
+// Fails if key is invalid, expired, revoked, or not encrypted with secret.
+func (hc *HostconfJwk) GetPrivateJWK(secrets secrets.AppSecrets) (privkey jwk.Key, state hostconf_jwk.KeyState, err error) {
+	if state, err = hc.GetPrivateKeyState(secrets); err != nil {
+		return nil, state, err
+	}
+	if privkey, err = hostconf_jwk.DecryptJWK(secrets.HostConfEncryptionKey, hc.EncryptedJwk); err != nil {
+		return nil, hostconf_jwk.KeyDecryptionFailed, err
+	}
+	return privkey, state, err
 }

--- a/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model_test.go
+++ b/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model_test.go
@@ -1,9 +1,16 @@
 package model
 
 import (
+	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/secrets"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk"
+	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBeforeCreateHook(t *testing.T) {
@@ -14,4 +21,258 @@ func TestBeforeCreateHook(t *testing.T) {
 	item.BeforeCreate(nil)
 	assert.NotEmpty(t, item.CreatedAt)
 	assert.NotEmpty(t, item.UpdatedAt)
+}
+
+func TestNewHostconfJwk(t *testing.T) {
+	config := test.GetTestConfig()
+	expiresAt := time.
+		Now().
+		Add(config.Application.HostconfJwkValidity).
+		Truncate(time.Second)
+	hc, err := NewHostconfJwk(config.Secrets, expiresAt)
+	assert.Nil(t, err)
+
+	assert.NotNil(t, hc.CreatedAt)
+	assert.Equal(t, hc.CreatedAt, hc.UpdatedAt)
+	assert.NotNil(t, hc.KeyId)
+	assert.Equal(t, hc.ExpiresAt, expiresAt)
+	assert.NotNil(t, hc.PublicJwk)
+	assert.NotNil(t, hc.EncryptedJwk)
+	assert.Equal(t, hc.EncryptionId, config.Secrets.HostconfEncryptionId)
+
+	k, err := jwk.ParseKey([]byte(hc.PublicJwk))
+	assert.Nil(t, err)
+	assert.Equal(t, k.KeyID(), hc.KeyId)
+
+	state, err := hc.GetPublicKeyState()
+	assert.Nil(t, err)
+	assert.Equal(t, state, hostconf_jwk.ValidKey)
+
+	pubkey, state, err := hc.GetPublicJWK()
+	assert.Nil(t, err)
+	assert.Equal(t, state, hostconf_jwk.ValidKey)
+	assert.Equal(t, k, pubkey)
+
+	state, err = hc.GetPrivateKeyState(config.Secrets)
+	assert.Nil(t, err)
+	assert.Equal(t, state, hostconf_jwk.ValidKey)
+
+	privkey, state, err := hc.GetPrivateJWK(config.Secrets)
+	assert.Nil(t, err)
+	assert.Equal(t, state, hostconf_jwk.ValidKey)
+
+	privpubkey, err := privkey.PublicKey()
+	assert.Nil(t, err)
+	assert.Equal(t, pubkey, privpubkey)
+}
+
+func TestHostconfJwkMethods(t *testing.T) {
+	var (
+		err   error
+		state hostconf_jwk.KeyState
+	)
+	type TestCaseGiven struct {
+		HC     *HostconfJwk
+		Secret *secrets.AppSecrets
+	}
+	type TestCaseExpected struct {
+		PubState  hostconf_jwk.KeyState
+		PubError  error
+		PrivState hostconf_jwk.KeyState
+		PrivError error
+	}
+	type TestCase struct {
+		Name     string
+		Given    TestCaseGiven
+		Expected TestCaseExpected
+	}
+
+	expiresFuture := time.Now().Add(time.Hour)
+	expiresPast := time.Now().Add(-time.Hour)
+
+	sec, err := secrets.NewAppSecrets("3cBBUQSnlKHQO7-5hyxJRQ")
+	assert.Nil(t, err)
+
+	sec2, err := secrets.NewAppSecrets("MLaVBnV5kadqAasiUmtEwg")
+	assert.Nil(t, err)
+
+	privkey, err := hostconf_jwk.GeneratePrivateJWK(expiresFuture)
+	assert.Nil(t, err)
+	encryptedJwk, err := hostconf_jwk.EncryptJWK(sec.HostConfEncryptionKey, privkey)
+	assert.Nil(t, err)
+
+	pubkey, err := hostconf_jwk.GetPublicJWK(privkey)
+	assert.Nil(t, err)
+	pubkeybytes, err := json.Marshal(pubkey)
+	assert.Nil(t, err)
+	kid := privkey.KeyID()
+
+	testCases := []TestCase{
+		{
+			Name: "All valid",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresFuture,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: encryptedJwk,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.ValidKey,
+				PubError:  nil,
+				PrivState: hostconf_jwk.ValidKey,
+				PrivError: nil,
+			},
+		},
+		{
+			Name: "Invalid (missing pubkey)",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresFuture,
+					PublicJwk:    "",
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: encryptedJwk,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.InvalidKey,
+				PubError:  ErrInvalidKey,
+				PrivState: hostconf_jwk.InvalidKey,
+				PrivError: ErrInvalidKey,
+			},
+		},
+		{
+			Name: "Invalid (missing kid)",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        "",
+					ExpiresAt:    expiresFuture,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: encryptedJwk,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.InvalidKey,
+				PubError:  ErrInvalidKey,
+				PrivState: hostconf_jwk.InvalidKey,
+				PrivError: ErrInvalidKey,
+			},
+		},
+		{
+			Name: "Expired",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresPast,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: encryptedJwk,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.ExpiredKey,
+				PubError:  ErrExpiredKey,
+				PrivState: hostconf_jwk.ExpiredKey,
+				PrivError: ErrExpiredKey,
+			},
+		},
+		{
+			Name: "Revoked private key",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresFuture,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: nil,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.RevokedKey,
+				PubError:  ErrRevokedKey,
+				PrivState: hostconf_jwk.RevokedKey,
+				PrivError: ErrRevokedKey,
+			},
+		},
+		{
+			Name: "Revoked and expired key returns ExpiredKey",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresPast,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: nil,
+				},
+				Secret: sec,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.ExpiredKey,
+				PubError:  ErrExpiredKey,
+				PrivState: hostconf_jwk.ExpiredKey,
+				PrivError: ErrExpiredKey,
+			},
+		},
+		{
+			Name: "Private key with different encryption id",
+			Given: TestCaseGiven{
+				HC: &HostconfJwk{
+					KeyId:        kid,
+					ExpiresAt:    expiresFuture,
+					PublicJwk:    string(pubkeybytes),
+					EncryptionId: sec.HostconfEncryptionId,
+					EncryptedJwk: encryptedJwk,
+				},
+				// different secret
+				Secret: sec2,
+			},
+			Expected: TestCaseExpected{
+				PubState:  hostconf_jwk.ValidKey,
+				PubError:  nil,
+				PrivState: hostconf_jwk.EncryptionIdMismatch,
+				PrivError: ErrKeyDecryptionFailed,
+			},
+		},
+	}
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+		hc := testCase.Given.HC
+
+		state, err = hc.GetPublicKeyState()
+		require.Equal(t, testCase.Expected.PubState, state)
+		require.Equal(t, testCase.Expected.PubError, err)
+
+		pubkeyout, state, err := hc.GetPublicJWK()
+		require.Equal(t, testCase.Expected.PubState, state)
+		require.Equal(t, testCase.Expected.PubError, err)
+
+		if testCase.Expected.PubState == hostconf_jwk.ValidKey {
+			assert.Equal(t, pubkeyout, pubkey)
+		} else {
+			assert.Nil(t, pubkeyout)
+		}
+
+		state, err = hc.GetPrivateKeyState(*testCase.Given.Secret)
+		require.Equal(t, testCase.Expected.PrivState, state)
+		require.Equal(t, testCase.Expected.PrivError, err)
+
+		privkeyout, state, err := hc.GetPrivateJWK(*testCase.Given.Secret)
+		require.Equal(t, testCase.Expected.PrivState, state)
+		require.Equal(t, testCase.Expected.PrivError, err)
+
+		if testCase.Expected.PrivState == hostconf_jwk.ValidKey {
+			assert.Equal(t, privkeyout, privkey)
+		} else {
+			assert.Nil(t, privkeyout)
+		}
+	}
 }

--- a/internal/infrastructure/token/hostconf_jwk/variables.go
+++ b/internal/infrastructure/token/hostconf_jwk/variables.go
@@ -8,4 +8,25 @@ const (
 	ExpiredKey
 	InvalidKey
 	RevokedKey
+	EncryptionIdMismatch
+	KeyDecryptionFailed
 )
+
+func KeyStateString(state KeyState) string {
+	switch state {
+	case ValidKey:
+		return "valid"
+	case ExpiredKey:
+		return "expired"
+	case InvalidKey:
+		return "invalid"
+	case RevokedKey:
+		return "revoked"
+	case EncryptionIdMismatch:
+		return "encryptionIdMismatch"
+	case KeyDecryptionFailed:
+		return "keyDecryptionFailed"
+	default:
+		return "<unknown>"
+	}
+}

--- a/scripts/db/migrations/20240130080519_hostconf_jwks.down.sql
+++ b/scripts/db/migrations/20240130080519_hostconf_jwks.down.sql
@@ -1,0 +1,5 @@
+
+-- File created by: bin/db-tool new hostconf_jwks
+BEGIN;
+DROP TABLE IF EXISTS hostconf_jwks;
+COMMIT;

--- a/scripts/db/migrations/20240130080519_hostconf_jwks.up.sql
+++ b/scripts/db/migrations/20240130080519_hostconf_jwks.up.sql
@@ -1,0 +1,18 @@
+
+-- File created by: bin/db-tool new hostconf_jwks
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS hostconf_jwks (
+    id SERIAL UNIQUE NOT NULL PRIMARY KEY,
+    created_at TIMESTAMP,
+    updated_at TIMESTAMP,
+    deleted_at TIMESTAMP DEFAULT NULL,
+
+    key_id VARCHAR(16) NOT NULL UNIQUE,
+    expires_at TIMESTAMP NOT NULL,
+    public_jwk TEXT NOT NULL,
+    encryption_id VARCHAR(16) NOT NULL,
+    encrypted_jwk BYTEA
+);
+
+COMMIT;


### PR DESCRIPTION
Add helper methods to HostconfJwk GORM model that deal with
public/private key state, deserialization of public JWK and decryption
of private JWK. The factory function `NewHostconfJwk` creates a new
HostconfJwk item with public and encrypted private JWK.