### PR TITLE
HMS-2694 feat: Store Hostconf JWKs in DB

### DIFF
--- a/cmd/db-tool/cmd/jwk-list.go
+++ b/cmd/db-tool/cmd/jwk-list.go
@@ -12,19 +12,19 @@ import (
 )
 
 // refreshCmd represents the refresh command
-var jwkRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Short: "Refresh or create JWKs",
-	Long:  `The refresh command ensures that the database contains valid JWKs.`,
+var jwkListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List JWKs",
+	Long:  `The list command shows all JWKs in the database.`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.LogBuildInfo("db-tool")
 		cfg := config.Get()
 		logger.InitLogger(cfg)
 		r := datastore.NewHostconfJwkDb(cfg)
-		err := r.Refresh()
+		err := r.ListKeys()
 		if err != nil {
-			slog.Error("Refresh failed", slog.String("error", err.Error()))
+			slog.Error("List failed", slog.String("error", err.Error()))
 			os.Exit(2)
 		} else {
 			slog.Info("Done")
@@ -33,5 +33,5 @@ var jwkRefreshCmd = &cobra.Command{
 }
 
 func init() {
-	jwkCmd.AddCommand(jwkRefreshCmd)
+	jwkCmd.AddCommand(jwkListCmd)
 }

--- a/cmd/db-tool/cmd/jwk-purge.go
+++ b/cmd/db-tool/cmd/jwk-purge.go
@@ -12,19 +12,19 @@ import (
 )
 
 // refreshCmd represents the refresh command
-var jwkRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Short: "Refresh or create JWKs",
-	Long:  `The refresh command ensures that the database contains valid JWKs.`,
+var jwkPurgeCmd = &cobra.Command{
+	Use:   "purge",
+	Short: "Purge expired JWK",
+	Long:  `The purge command removes all expired JWK from the database.`,
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.LogBuildInfo("db-tool")
 		cfg := config.Get()
 		logger.InitLogger(cfg)
 		r := datastore.NewHostconfJwkDb(cfg)
-		err := r.Refresh()
+		err := r.Purge()
 		if err != nil {
-			slog.Error("Refresh failed", slog.String("error", err.Error()))
+			slog.Error("Purge failed", slog.String("error", err.Error()))
 			os.Exit(2)
 		} else {
 			slog.Info("Done")
@@ -33,5 +33,5 @@ var jwkRefreshCmd = &cobra.Command{
 }
 
 func init() {
-	jwkCmd.AddCommand(jwkRefreshCmd)
+	jwkCmd.AddCommand(jwkPurgeCmd)
 }

--- a/cmd/db-tool/cmd/jwk-revoke.go
+++ b/cmd/db-tool/cmd/jwk-revoke.go
@@ -12,19 +12,19 @@ import (
 )
 
 // refreshCmd represents the refresh command
-var jwkRefreshCmd = &cobra.Command{
-	Use:   "refresh",
-	Short: "Refresh or create JWKs",
-	Long:  `The refresh command ensures that the database contains valid JWKs.`,
-	Args:  cobra.NoArgs,
+var jwkRevokeCmd = &cobra.Command{
+	Use:   "revoke [kid]",
+	Short: "Revoke a JWK",
+	Long:  `The revoke command marks a JWK as revoked.`,
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		logger.LogBuildInfo("db-tool")
 		cfg := config.Get()
 		logger.InitLogger(cfg)
 		r := datastore.NewHostconfJwkDb(cfg)
-		err := r.Refresh()
+		err := r.Revoke(args[0])
 		if err != nil {
-			slog.Error("Refresh failed", slog.String("error", err.Error()))
+			slog.Error("Revoke failed", slog.String("error", err.Error()))
 			os.Exit(2)
 		} else {
 			slog.Info("Done")
@@ -33,5 +33,5 @@ var jwkRefreshCmd = &cobra.Command{
 }
 
 func init() {
-	jwkCmd.AddCommand(jwkRefreshCmd)
+	jwkCmd.AddCommand(jwkRevokeCmd)
 }

--- a/cmd/db-tool/cmd/jwk.go
+++ b/cmd/db-tool/cmd/jwk.go
@@ -7,7 +7,7 @@ import (
 // jwkCmd represents the jwk command
 var jwkCmd = &cobra.Command{
 	Use:   "jwk",
-	Short: "JSON Web Key management",
+	Short: "Hostconf JWK management",
 }
 
 func init() {

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -2,7 +2,7 @@
 logging:
   # level: warn should be the level in production
   # level: trace - Will display the sql statements, usefult for development
-  level: warn
+  level: info
   # Set to false to get a json output for the log
   console: true
   # Set to true to get source code locations printed

--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -10,10 +10,11 @@ import (
 
 func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningKeysParams) error {
 	var (
-		err    error
-		tx     *gorm.DB
-		keys   []string
-		output *public.SigningKeysResponse
+		err         error
+		tx          *gorm.DB
+		keys        []string
+		revokedKids []string
+		output      *public.SigningKeysResponse
 	)
 
 	if tx = a.db.Begin(); tx.Error != nil {
@@ -21,7 +22,7 @@ func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningK
 	}
 	defer tx.Rollback()
 
-	if keys, err = a.hostconfjwk.repository.GetPublicKeyArray(tx); err != nil {
+	if keys, revokedKids, err = a.hostconfjwk.repository.GetPublicKeyArray(tx); err != nil {
 		return err
 	}
 
@@ -29,7 +30,7 @@ func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningK
 		return tx.Error
 	}
 
-	if output, err = a.hostconfjwk.presenter.PublicSigningKeys(keys); err != nil {
+	if output, err = a.hostconfjwk.presenter.PublicSigningKeys(keys, revokedKids); err != nil {
 		return err
 	}
 

--- a/internal/infrastructure/datastore/hostconf_jwk_db.go
+++ b/internal/infrastructure/datastore/hostconf_jwk_db.go
@@ -1,0 +1,237 @@
+package datastore
+
+import (
+	"time"
+
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
+	interface_repository "github.com/podengo-project/idmsvc-backend/internal/interface/repository"
+	"github.com/podengo-project/idmsvc-backend/internal/usecase/repository"
+	"golang.org/x/exp/slog"
+	"gorm.io/gorm"
+)
+
+type HostconfJwkDb struct {
+	cfg        *config.Config
+	repository interface_repository.HostconfJwkRepository
+}
+
+// Create new HostconfJwkDb
+func NewHostconfJwkDb(cfg *config.Config) *HostconfJwkDb {
+	return &HostconfJwkDb{
+		cfg:        cfg,
+		repository: repository.NewHostconfJwkRepository(cfg),
+	}
+}
+
+// Calculate and log renew after and expires at times
+func (r *HostconfJwkDb) timestamps() (renewAfter, expiresAfter time.Time) {
+	utcnow := time.Now().UTC().Truncate(time.Second)
+	renewAfter = utcnow.Add(r.cfg.Application.HostconfJwkRenewalThreshold)
+	expiresAfter = utcnow.Add(r.cfg.Application.HostconfJwkValidity)
+	slog.Info(
+		"Hostconf JWK configuration",
+		slog.Time("now", utcnow),
+		slog.Time("renewAfter", renewAfter),
+		slog.Duration("renewThreshold", r.cfg.Application.HostconfJwkRenewalThreshold),
+		slog.Time("expiresAfter", expiresAfter),
+		slog.Duration("validity", r.cfg.Application.HostconfJwkValidity),
+	)
+	return renewAfter, expiresAfter
+
+}
+
+// Refresh and create JWKs in database
+// A new JWK is created whenever the database has no valid JWK or all JWKs
+// expire within the renewal threshold period.
+func (r *HostconfJwkDb) Refresh() (err error) {
+	var (
+		db     *gorm.DB
+		tx     *gorm.DB
+		hcjwks []model.HostconfJwk
+	)
+	db = NewDB(r.cfg)
+	defer Close(db)
+
+	if tx = db.Begin(); tx.Error != nil {
+		return tx.Error
+	}
+	defer tx.Rollback()
+
+	if hcjwks, err = r.repository.ListJWKs(db); err != nil {
+		return err
+	}
+
+	// Create new JWK unless there is one or more JWK that is not expired,
+	// not revoked, encrypted with current app secret, and which does expires
+	// after renewal threshold.
+	create := true
+	valid := 0
+	revoked := 0
+	expired := 0
+	renewAfter, expiresAfter := r.timestamps()
+
+	for _, hcjwk := range hcjwks {
+		privstate, _ := hcjwk.GetPrivateKeyState(r.cfg.Secrets)
+		log := slog.With(
+			slog.String("kid", hcjwk.KeyId),
+			slog.String("privatekey", hostconf_jwk.KeyStateString(privstate)),
+			slog.Time("expires", hcjwk.ExpiresAt),
+			slog.Time("expiresAfter", expiresAfter),
+			slog.Time("renewalAfter", renewAfter),
+		)
+		switch privstate {
+		case hostconf_jwk.ValidKey:
+			valid += 1
+			if hcjwk.ExpiresAt.Unix() >= renewAfter.Unix() {
+				log.Info("Valid Hostconf JWK")
+				create = false
+			} else {
+				log.Warn("Valid Hostconf JWK is after renewal threshold")
+			}
+		case hostconf_jwk.RevokedKey:
+			log.Info("Hostconf JWK is revoked")
+			revoked += 1
+		case hostconf_jwk.ExpiredKey:
+			log.Info("Hostconf JWK is expired")
+			expired += 1
+		default:
+			log.Info("Hostconf JWK is invalid")
+		}
+	}
+
+	slog.Info(
+		"Current JWKs in database",
+		slog.Int("total", len(hcjwks)),
+		slog.Int("valid", valid),
+		slog.Int("expired", expired),
+		slog.Int("revoked", revoked),
+	)
+
+	if create {
+		var newjwk *model.HostconfJwk
+
+		if valid == 0 {
+			slog.Warn("No valid JWK found in database")
+		} else {
+			slog.Warn("All valid JWKs expire in the renewal threshold period")
+		}
+
+		if newjwk, err = model.NewHostconfJwk(r.cfg.Secrets, expiresAfter); err != nil {
+			return err
+		}
+		r.repository.InsertJWK(db, newjwk)
+		slog.Info(
+			"Created new hostconf JWK",
+			slog.String("kid", newjwk.KeyId),
+			slog.Time("expires", newjwk.ExpiresAt),
+		)
+	}
+
+	if tx.Commit(); tx.Error != nil {
+		return tx.Error
+	}
+	return nil
+}
+
+// Mark a JWK as revoked
+func (r *HostconfJwkDb) Revoke(kid string) (err error) {
+	var (
+		db    *gorm.DB
+		tx    *gorm.DB
+		hcjwk *model.HostconfJwk
+	)
+	db = NewDB(r.cfg)
+	defer Close(db)
+
+	if tx = db.Begin(); tx.Error != nil {
+		return tx.Error
+	}
+	defer tx.Rollback()
+
+	if hcjwk, err = r.repository.RevokeJWK(tx, kid); err != nil {
+		return err
+	}
+	slog.Info("Revoked JWK", slog.String("kid", hcjwk.KeyId))
+
+	if tx.Commit(); tx.Error != nil {
+		return tx.Error
+	}
+	return nil
+}
+
+// Purge and remove expired JWKs from database
+func (r *HostconfJwkDb) Purge() (err error) {
+	var (
+		db     *gorm.DB
+		tx     *gorm.DB
+		hcjwks []model.HostconfJwk
+	)
+	db = NewDB(r.cfg)
+	defer Close(db)
+
+	if tx = db.Begin(); tx.Error != nil {
+		return tx.Error
+	}
+	defer tx.Rollback()
+
+	if hcjwks, err = r.repository.PurgeExpiredJWKs(tx); err != nil {
+		return err
+	}
+	if len(hcjwks) > 0 {
+		slog.Info("Purged keys from DB", slog.Int("purged", len(hcjwks)))
+		for _, hcjwk := range hcjwks {
+			slog.Info(
+				"Purged key",
+				slog.String("kid", hcjwk.KeyId),
+				slog.Time("expires", hcjwk.ExpiresAt),
+			)
+		}
+	} else {
+		slog.Info("Nothing to purge")
+	}
+
+	if tx.Commit(); tx.Error != nil {
+		return tx.Error
+	}
+	return nil
+}
+
+// List all JWKs in database
+func (r *HostconfJwkDb) ListKeys() (err error) {
+	var (
+		db     *gorm.DB
+		tx     *gorm.DB
+		hcjwks []model.HostconfJwk
+		hcjwk  model.HostconfJwk
+	)
+	db = NewDB(r.cfg)
+	defer Close(db)
+
+	if tx = db.Begin(); tx.Error != nil {
+		return tx.Error
+	}
+	defer tx.Rollback()
+
+	renewAfter, expiresAfter := r.timestamps()
+
+	if hcjwks, err = r.repository.ListJWKs(db); err != nil {
+		return err
+	}
+	slog.Info("JWKs in database", slog.Int("length", len(hcjwks)))
+	for _, hcjwk = range hcjwks {
+		pubstate, _ := hcjwk.GetPublicKeyState()
+		privstate, _ := hcjwk.GetPrivateKeyState(r.cfg.Secrets)
+		slog.Info(
+			"Hostconf JWK",
+			slog.String("kid", hcjwk.KeyId),
+			slog.String("publickey", hostconf_jwk.KeyStateString(pubstate)),
+			slog.String("privatekey", hostconf_jwk.KeyStateString(privstate)),
+			slog.Time("expires", hcjwk.ExpiresAt),
+			slog.Time("expiresAfter", expiresAfter),
+			slog.Time("renewAfter", renewAfter),
+		)
+	}
+	return nil
+}

--- a/internal/infrastructure/token/hostconf_jwk/jwk.go
+++ b/internal/infrastructure/token/hostconf_jwk/jwk.go
@@ -7,7 +7,6 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwa"
@@ -15,9 +14,6 @@ import (
 )
 
 const KeyCurve = jwa.P256
-
-// TODO: hard-coded ECDSA seed for testing
-const seed = "dummtestkey1234"
 
 // Generate a private key with additional properties
 // alg: based on key type (ES256 for P256)
@@ -39,20 +35,9 @@ func GeneratePrivateJWK(expiration time.Time) (key jwk.Key, err error) {
 		return nil, fmt.Errorf("Unsupported JWK curve %s", KeyCurve)
 	}
 
-	if len(seed) != 0 {
-		raw = &ecdsa.PrivateKey{}
-		raw.D = &big.Int{}
-		_, ok := raw.D.SetString(seed, 36)
-		if !ok {
-			panic("seed")
-		}
-		raw.PublicKey.Curve = crv
-		raw.PublicKey.X, raw.PublicKey.Y = crv.ScalarBaseMult(raw.D.Bytes())
-	} else {
-		raw, err = ecdsa.GenerateKey(crv, rand.Reader)
-		if err != nil {
-			return nil, err
-		}
+	raw, err = ecdsa.GenerateKey(crv, rand.Reader)
+	if err != nil {
+		return nil, err
 	}
 
 	key, err = jwk.FromRaw(raw)

--- a/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
+++ b/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
@@ -14,11 +14,11 @@ import (
 // HostconfJwks hold public and private JWKs
 type HostconfJwk struct {
 	gorm.Model
-	KeyId        string
-	ExpiresAt    time.Time
-	PublicJwk    string
-	EncryptionId string
-	EncryptedJwk []byte
+	KeyId        string    // JWK KID
+	ExpiresAt    time.Time // Expiration time stamp
+	PublicJwk    string    // Public JWK as serialized JSON
+	EncryptionId string    // id of the encryption key
+	EncryptedJwk []byte    // Encrypted private key, nil if key is revoked
 }
 
 var (
@@ -110,4 +110,14 @@ func (hc *HostconfJwk) GetPrivateJWK(secrets secrets.AppSecrets) (privkey jwk.Ke
 		return nil, hostconf_jwk.KeyDecryptionFailed, err
 	}
 	return privkey, state, err
+}
+
+// Revoke sets the encrypted private key to nil and marks the hostconf JWK
+// as revoked.
+func (hc *HostconfJwk) Revoke() (err error) {
+	if hc.EncryptedJwk == nil {
+		return ErrRevokedKey
+	}
+	hc.EncryptedJwk = nil
+	return nil
 }

--- a/internal/interface/presenter/hostconf_jwk_presenter.go
+++ b/internal/interface/presenter/hostconf_jwk_presenter.go
@@ -3,5 +3,5 @@ package presenter
 import "github.com/podengo-project/idmsvc-backend/internal/api/public"
 
 type HostconfJwkPresenter interface {
-	PublicSigningKeys(keys []string) (*public.SigningKeysResponse, error)
+	PublicSigningKeys(keys []string, revokedKids []string) (*public.SigningKeysResponse, error)
 }

--- a/internal/interface/repository/hostconf_jwk_repository.go
+++ b/internal/interface/repository/hostconf_jwk_repository.go
@@ -7,10 +7,11 @@ import (
 )
 
 type HostconfJwkRepository interface {
-	CreateJWK(db *gorm.DB) (model *model.HostconfJwk, err error)
-	RevokeJWK(db *gorm.DB, kid string) (model *model.HostconfJwk, err error)
-	ListJWKs(db *gorm.DB) (models []model.HostconfJwk, err error)
-	GetPublicKeyArray(db *gorm.DB) (pubkeys []string, err error)
+	InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk) (err error)
+	RevokeJWK(db *gorm.DB, kid string) (hcjwk *model.HostconfJwk, err error)
+	ListJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error)
+	PurgeExpiredJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error)
+	GetPublicKeyArray(db *gorm.DB) (pubkeys []string, revokedKids []string, err error)
 	// TODO: refactor code to use jwk.Set instead of []jwk.Key
 	GetPrivateSigningKeys(db *gorm.DB) (privkeys []jwk.Key, err error)
 }

--- a/internal/test/mock/interface/presenter/hostconf_jwk_presenter.go
+++ b/internal/test/mock/interface/presenter/hostconf_jwk_presenter.go
@@ -13,9 +13,9 @@ type HostconfJwkPresenter struct {
 	mock.Mock
 }
 
-// PublicSigningKeys provides a mock function with given fields: keys
-func (_m *HostconfJwkPresenter) PublicSigningKeys(keys []string) (*public.SigningKeysResponse, error) {
-	ret := _m.Called(keys)
+// PublicSigningKeys provides a mock function with given fields: keys, revokedKids
+func (_m *HostconfJwkPresenter) PublicSigningKeys(keys []string, revokedKids []string) (*public.SigningKeysResponse, error) {
+	ret := _m.Called(keys, revokedKids)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PublicSigningKeys")
@@ -23,19 +23,19 @@ func (_m *HostconfJwkPresenter) PublicSigningKeys(keys []string) (*public.Signin
 
 	var r0 *public.SigningKeysResponse
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]string) (*public.SigningKeysResponse, error)); ok {
-		return rf(keys)
+	if rf, ok := ret.Get(0).(func([]string, []string) (*public.SigningKeysResponse, error)); ok {
+		return rf(keys, revokedKids)
 	}
-	if rf, ok := ret.Get(0).(func([]string) *public.SigningKeysResponse); ok {
-		r0 = rf(keys)
+	if rf, ok := ret.Get(0).(func([]string, []string) *public.SigningKeysResponse); ok {
+		r0 = rf(keys, revokedKids)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*public.SigningKeysResponse)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]string) error); ok {
-		r1 = rf(keys)
+	if rf, ok := ret.Get(1).(func([]string, []string) error); ok {
+		r1 = rf(keys, revokedKids)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/test/mock/interface/repository/hostconf_jwk_repository.go
+++ b/internal/test/mock/interface/repository/hostconf_jwk_repository.go
@@ -15,36 +15,6 @@ type HostconfJwkRepository struct {
 	mock.Mock
 }
 
-// CreateJWK provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) CreateJWK(db *gorm.DB) (*model.HostconfJwk, error) {
-	ret := _m.Called(db)
-
-	if len(ret) == 0 {
-		panic("no return value specified for CreateJWK")
-	}
-
-	var r0 *model.HostconfJwk
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) (*model.HostconfJwk, error)); ok {
-		return rf(db)
-	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB) *model.HostconfJwk); ok {
-		r0 = rf(db)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*model.HostconfJwk)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(*gorm.DB) error); ok {
-		r1 = rf(db)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetPrivateSigningKeys provides a mock function with given fields: db
 func (_m *HostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) ([]jwk.Key, error) {
 	ret := _m.Called(db)
@@ -76,7 +46,7 @@ func (_m *HostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) ([]jwk.Key, 
 }
 
 // GetPublicKeyArray provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, error) {
+func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, []string, error) {
 	ret := _m.Called(db)
 
 	if len(ret) == 0 {
@@ -84,8 +54,9 @@ func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, error
 	}
 
 	var r0 []string
-	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]string, error)); ok {
+	var r1 []string
+	var r2 error
+	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]string, []string, error)); ok {
 		return rf(db)
 	}
 	if rf, ok := ret.Get(0).(func(*gorm.DB) []string); ok {
@@ -93,6 +64,62 @@ func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, error
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*gorm.DB) []string); ok {
+		r1 = rf(db)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).([]string)
+		}
+	}
+
+	if rf, ok := ret.Get(2).(func(*gorm.DB) error); ok {
+		r2 = rf(db)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
+// InsertJWK provides a mock function with given fields: db, hcjwk
+func (_m *HostconfJwkRepository) InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk) error {
+	ret := _m.Called(db, hcjwk)
+
+	if len(ret) == 0 {
+		panic("no return value specified for InsertJWK")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*gorm.DB, *model.HostconfJwk) error); ok {
+		r0 = rf(db, hcjwk)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// ListJWKs provides a mock function with given fields: db
+func (_m *HostconfJwkRepository) ListJWKs(db *gorm.DB) ([]model.HostconfJwk, error) {
+	ret := _m.Called(db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListJWKs")
+	}
+
+	var r0 []model.HostconfJwk
+	var r1 error
+	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]model.HostconfJwk, error)); ok {
+		return rf(db)
+	}
+	if rf, ok := ret.Get(0).(func(*gorm.DB) []model.HostconfJwk); ok {
+		r0 = rf(db)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.HostconfJwk)
 		}
 	}
 
@@ -105,12 +132,12 @@ func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, error
 	return r0, r1
 }
 
-// ListJWKs provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) ListJWKs(db *gorm.DB) ([]model.HostconfJwk, error) {
+// PurgeExpiredJWKs provides a mock function with given fields: db
+func (_m *HostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) ([]model.HostconfJwk, error) {
 	ret := _m.Called(db)
 
 	if len(ret) == 0 {
-		panic("no return value specified for ListJWKs")
+		panic("no return value specified for PurgeExpiredJWKs")
 	}
 
 	var r0 []model.HostconfJwk

--- a/internal/usecase/presenter/hostconf_jwk_presenter.go
+++ b/internal/usecase/presenter/hostconf_jwk_presenter.go
@@ -18,13 +18,17 @@ func NewHostconfJwkPresenter(cfg *config.Config) presenter.HostconfJwkPresenter 
 	return &hostconfJwkPresenter{cfg}
 }
 
-func (p *hostconfJwkPresenter) PublicSigningKeys(keys []string) (*public.SigningKeysResponse, error) {
+func (p *hostconfJwkPresenter) PublicSigningKeys(keys []string, revokedKids []string) (*public.SigningKeysResponse, error) {
 	if keys == nil {
 		return nil, internal_errors.NilArgError("keys")
 	}
 
 	response := &public.SigningKeysResponse{
-		Keys: keys,
+		Keys:        keys,
+		RevokedKids: nil,
+	}
+	if len(revokedKids) > 0 {
+		response.RevokedKids = &revokedKids
 	}
 
 	return response, nil

--- a/internal/usecase/repository/hostconf_jwk_repository.go
+++ b/internal/usecase/repository/hostconf_jwk_repository.go
@@ -1,12 +1,12 @@
 package repository
 
 import (
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/podengo-project/idmsvc-backend/internal/config"
+	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/repository"
@@ -17,9 +17,6 @@ var notImplementedError = fmt.Errorf("TODO: not implemented")
 
 type hostconfJwkRepository struct {
 	config *config.Config
-	// TODO: store JWKs in database
-	signingKeys []jwk.Key
-	publicKeys  []string
 }
 
 func NewHostconfJwkRepository(cfg *config.Config) repository.HostconfJwkRepository {
@@ -27,34 +24,108 @@ func NewHostconfJwkRepository(cfg *config.Config) repository.HostconfJwkReposito
 		panic("'cfg' is nil")
 	}
 	r := &hostconfJwkRepository{config: cfg}
-	err := r.generateEphemeralJWK()
-	if err != nil {
-		panic(err)
-	}
 	return r
 }
 
 // CreateJWK generates and inserts a new JWK into the database. The private
 // key is encrypted with the current app secret.
-func (r *hostconfJwkRepository) CreateJWK(db *gorm.DB) (model *model.HostconfJwk, err error) {
-	return nil, notImplementedError
+func (r *hostconfJwkRepository) InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk) (err error) {
+	if db == nil {
+		return internal_errors.NilArgError("db")
+	}
+
+	if err = db.Create(&hcjwk).Error; err != nil {
+		return err
+	}
+	return nil
 }
 
 // RevokeJWK revokes a JWK with key identifier `kid`
-func (r *hostconfJwkRepository) RevokeJWK(db *gorm.DB, kid string) (model *model.HostconfJwk, err error) {
-	return nil, notImplementedError
+func (r *hostconfJwkRepository) RevokeJWK(db *gorm.DB, kid string) (hcjwk *model.HostconfJwk, err error) {
+	if db == nil {
+		return nil, internal_errors.NilArgError("db")
+	}
+	// find JKW by unique kid
+	if err = db.
+		Where("key_id = ?", kid).
+		First(&hcjwk).
+		Error; err != nil {
+		return nil, err
+	}
+
+	hcjwk.Revoke()
+	if err = db.Save(hcjwk).Error; err != nil {
+		return nil, err
+	}
+
+	return hcjwk, nil
 }
 
 // ListJWKs all JWKs, including expired and revoked JWKs
-func (r *hostconfJwkRepository) ListJWKs(db *gorm.DB) (models []model.HostconfJwk, err error) {
-	return nil, notImplementedError
+func (r *hostconfJwkRepository) ListJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error) {
+	if db == nil {
+		return nil, internal_errors.NilArgError("db")
+	}
+	// list JWKs, order by id to have determinstic sorting
+	if err = db.
+		Order("id").
+		Find(&hcjwks).
+		Error; err != nil {
+		return nil, err
+	}
+	return hcjwks, nil
+}
+
+// PurgeExpiredJWKs find and removes all JWKs that are expired
+func (r *hostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error) {
+	if db == nil {
+		return nil, internal_errors.NilArgError("db")
+	}
+
+	// list JWKs, order by id to have determinstic sorting
+	now := time.Now()
+	if err = db.
+		Order("id").
+		Where("expires_at <= ?", now). // use SQL NOW()?
+		Find(&hcjwks).
+		Error; err != nil {
+		return nil, err
+	}
+	if err = db.
+		Unscoped(). // do not use GORM's soft delete for purging
+		Delete(&hcjwks).
+		Error; err != nil {
+		return nil, err
+	}
+	return hcjwks, nil
 }
 
 // GetPublicKeyArray returns an array of string with all valid, non-expired
 // public JWKs as serialized JSON. Expired or invalid keys are ignored
-func (r *hostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) (pubkeys []string, err error) {
-	// TODO use database
-	return r.publicKeys, nil
+func (r *hostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) (pubkeys []string, revokedKids []string, err error) {
+	if db == nil {
+		return nil, nil, internal_errors.NilArgError("db")
+	}
+	var hcjwks []model.HostconfJwk
+
+	now := time.Now()
+	if err = db.
+		Where("expires_at > ?", now). // use SQL NOW()?
+		Order("id").
+		Find(&hcjwks).Error; err != nil {
+		return nil, nil, err
+	}
+
+	for _, hcjwk := range hcjwks {
+		state, _ := hcjwk.GetPublicKeyState()
+		switch state {
+		case hostconf_jwk.ValidKey:
+			pubkeys = append(pubkeys, hcjwk.PublicJwk)
+		case hostconf_jwk.RevokedKey:
+			revokedKids = append(revokedKids, hcjwk.KeyId)
+		}
+	}
+	return pubkeys, revokedKids, nil
 }
 
 // GetPrivateSigningKeys returns a array of jwk.Keys with all valid, non-expired
@@ -62,32 +133,24 @@ func (r *hostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) (pubkeys []string
 // secret. Expired, invalid keys, and keys encrypted for a different main app
 // secret are ignored.
 func (r *hostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) (privkeys []jwk.Key, err error) {
-	// TODO use database
-	return r.signingKeys, nil
-}
-
-// TODO: temporary hack until DB layer is implemented
-// Generate ephemeral JWKs
-func (r *hostconfJwkRepository) generateEphemeralJWK() (err error) {
-	// TODO: temporary hack
-	var (
-		priv jwk.Key
-		pub  jwk.Key
-		pubs []byte
-	)
-	expiration := time.Now().Add(90 * 24 * time.Hour)
-	if priv, err = hostconf_jwk.GeneratePrivateJWK(expiration); err != nil {
-		return err
+	if db == nil {
+		return nil, internal_errors.NilArgError("db")
 	}
-	r.signingKeys = []jwk.Key{priv}
-
-	if pub, err = priv.PublicKey(); err != nil {
-		return err
+	var hcjwks []model.HostconfJwk
+	now := time.Now()
+	if err = db.
+		Where("encrypted_jwk is not NULL").
+		Where("encrypted_id = ?", r.config.Secrets.HostconfEncryptionId).
+		Where("expires_at > ?", now). // use SQL NOW()?
+		Order("id").
+		Find(&hcjwks).Error; err != nil {
+		return nil, err
 	}
-	if pubs, err = json.Marshal(pub); err != nil {
-		return err
+	for _, hcjwk := range hcjwks {
+		privkey, _, err := hcjwk.GetPrivateJWK(r.config.Secrets)
+		if err == nil {
+			privkeys = append(privkeys, privkey)
+		}
 	}
-	r.publicKeys = []string{string(pubs)}
-
-	return nil
+	return privkeys, nil
 }

--- a/internal/usecase/repository/hostconf_jwk_repository_test.go
+++ b/internal/usecase/repository/hostconf_jwk_repository_test.go
@@ -2,11 +2,15 @@ package repository
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/repository"
 	"github.com/podengo-project/idmsvc-backend/internal/test"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"gorm.io/gorm"
 )
@@ -15,6 +19,7 @@ type HostConfJwkRepositorySuite struct {
 	suite.Suite
 	db         *gorm.DB
 	mock       sqlmock.Sqlmock
+	cfg        *config.Config
 	repository repository.HostconfJwkRepository
 }
 
@@ -28,8 +33,21 @@ func (s *HostConfJwkRepositorySuite) SetupTest() {
 		s.Suite.FailNow("Error calling gorm.Open: %s", err.Error())
 		return
 	}
-	cfg := test.GetTestConfig()
-	s.repository = NewHostconfJwkRepository(cfg)
+	s.mock.MatchExpectationsInOrder(true)
+	s.cfg = test.GetTestConfig()
+	s.repository = NewHostconfJwkRepository(s.cfg)
+}
+
+func (s *HostConfJwkRepositorySuite) newHostconfJWK() (hcjwk *model.HostconfJwk) {
+	t := s.Suite.T()
+
+	expiresAt := time.
+		Now().
+		Add(s.cfg.Application.HostconfJwkValidity).
+		Truncate(time.Second)
+	hcjwk, err := model.NewHostconfJwk(s.cfg.Secrets, expiresAt)
+	require.Nil(t, err)
+	return hcjwk
 }
 
 func (s *HostConfJwkRepositorySuite) TestNewHostconfJwkRepository() {
@@ -41,40 +59,44 @@ func (s *HostConfJwkRepositorySuite) TestNewHostconfJwkRepository() {
 	})
 }
 
-func (s *HostConfJwkRepositorySuite) TestCreateJWK() {
+func (s *HostConfJwkRepositorySuite) TestInsertJWK() {
 	t := s.Suite.T()
-	model, err := s.repository.CreateJWK(s.db)
-	assert.Nil(t, model)
-	assert.EqualError(t, err, notImplementedError.Error())
+
+	hcjwk := s.newHostconfJWK()
+	err := s.repository.InsertJWK(s.db, hcjwk)
+	// TODO mock
+	assert.Error(t, err)
 }
 
 func (s *HostConfJwkRepositorySuite) TestRevokeJWK() {
 	t := s.Suite.T()
-	kid := "keyid"
-	model, err := s.repository.RevokeJWK(s.db, kid)
+
+	hcjwk := s.newHostconfJWK()
+	model, err := s.repository.RevokeJWK(s.db, hcjwk.KeyId)
 	assert.Nil(t, model)
-	assert.EqualError(t, err, notImplementedError.Error())
+	assert.Error(t, err)
 }
 
 func (s *HostConfJwkRepositorySuite) TestListJWKs() {
 	t := s.Suite.T()
 	models, err := s.repository.ListJWKs(s.db)
 	assert.Nil(t, models)
-	assert.EqualError(t, err, notImplementedError.Error())
+	assert.Error(t, err)
 }
 
 func (s *HostConfJwkRepositorySuite) TestGetPublicKeyArray() {
 	t := s.Suite.T()
-	keys, err := s.repository.GetPublicKeyArray(s.db)
-	assert.Equal(t, keys, s.repository.(*hostconfJwkRepository).publicKeys)
-	assert.Nil(t, err)
+	keys, revokedKids, err := s.repository.GetPublicKeyArray(s.db)
+	assert.Nil(t, keys)
+	assert.Nil(t, revokedKids)
+	assert.Error(t, err)
 }
 
 func (s *HostConfJwkRepositorySuite) TestGetPrivateSigningKeys() {
 	t := s.Suite.T()
 	keys, err := s.repository.GetPrivateSigningKeys(s.db)
-	assert.Equal(t, keys, s.repository.(*hostconfJwkRepository).signingKeys)
-	assert.Nil(t, err)
+	assert.Nil(t, keys)
+	assert.Error(t, err)
 }
 
 func TestHostConfJwkRepositorySuite(t *testing.T) {


### PR DESCRIPTION
The Hostconf JWKs are now stored and retrieved from database. Keys are
created and refreshed on startup, either by an init container or by
`make db-migrate-up` call.

The `db-tool` has commands to list, purge, refresh, and revoke keys.

```
$ bin/db-tool jwk
Hostconf JWK management

Available Commands:
  list        List JWKs
  purge       Purge expired JWK
  refresh     Refresh or create JWKs
  revoke      Revoke a JWK
```
