### PR TITLE
refactor: Remove unnecessary BeforeCreate hook

### DIFF
--- a/internal/domain/model/domain.go
+++ b/internal/domain/model/domain.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	"github.com/google/uuid"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
@@ -63,15 +62,6 @@ func DomainTypeUint(data string) uint {
 }
 
 // See: https://gorm.io/docs/hooks.html
-
-func (d *Domain) BeforeCreate(tx *gorm.DB) (err error) {
-	var currentTime = time.Now()
-	d.CreatedAt = currentTime
-	d.UpdatedAt = currentTime
-
-	return nil
-}
-
 func (d *Domain) AfterCreate(tx *gorm.DB) (err error) {
 	if d.Type == nil {
 		return internal_errors.NilArgError("Type")

--- a/internal/domain/model/domain_test.go
+++ b/internal/domain/model/domain_test.go
@@ -21,16 +21,6 @@ func TestDomainTypeUint(t *testing.T) {
 	assert.Equal(t, DomainTypeIpa, DomainTypeUint(DomainTypeIpaString))
 }
 
-func TestDomainBeforeCreate(t *testing.T) {
-	var item *Domain
-	item = &Domain{}
-	item.BeforeCreate(nil)
-
-	assert.Empty(t, item.DomainUuid)
-	assert.NotEmpty(t, item.CreatedAt)
-	assert.NotEmpty(t, item.UpdatedAt)
-}
-
 func TestDomainAfterCreate(t *testing.T) {
 	var item *Domain
 

--- a/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
+++ b/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model.go
@@ -28,15 +28,6 @@ var (
 	ErrKeyDecryptionFailed = errors.New("decryption failed")
 )
 
-// Before create hook
-func (hc *HostconfJwk) BeforeCreate(tx *gorm.DB) (err error) {
-	var currentTime = time.Now()
-	hc.CreatedAt = currentTime
-	hc.UpdatedAt = currentTime
-
-	return nil
-}
-
 // Create a new Hostconf JWK entry with public and encrypted private JWK
 func NewHostconfJwk(secrets secrets.AppSecrets, expiresAt time.Time) (hc *HostconfJwk, err error) {
 	var (

--- a/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model_test.go
+++ b/internal/infrastructure/token/hostconf_jwk/model/hostconf_jwk_model_test.go
@@ -13,16 +13,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBeforeCreateHook(t *testing.T) {
-	item := &HostconfJwk{}
-	assert.Empty(t, item.CreatedAt)
-	assert.Empty(t, item.UpdatedAt)
-
-	item.BeforeCreate(nil)
-	assert.NotEmpty(t, item.CreatedAt)
-	assert.NotEmpty(t, item.UpdatedAt)
-}
-
 func TestNewHostconfJwk(t *testing.T) {
 	config := test.GetTestConfig()
 	expiresAt := time.


### PR DESCRIPTION
There is no need to populate CreatedAt and UpdatedAt fields with a custom hook. Gorm maintains the fields automatically for us.

See: https://gorm.io/docs/models.html#gorm-Model