### PR TITLE
Fix: logging location needs simple template for boolean

### DIFF
--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -81,7 +81,7 @@ objects:
               - name: LOGGING_LEVEL
                 value: ${{LOGGING_LEVEL}}
               - name: LOGGING_LOCATION
-                value: ${{LOGGING_LOCATION}}
+                value: ${LOGGING_LOCATION}
               - name: APP_TOKEN_EXPIRATION_SECONDS
                 value: "${APP_TOKEN_EXPIRATION_SECONDS}"
               - name: APP_PAGINATION_DEFAULT_LIMIT
@@ -137,7 +137,7 @@ objects:
               - name: LOGGING_LEVEL
                 value: ${{LOGGING_LEVEL}}
               - name: LOGGING_LOCATION
-                value: ${{LOGGING_LOCATION}}
+                value: ${LOGGING_LOCATION}
               - name: APP_TOKEN_EXPIRATION_SECONDS
                 value: "${APP_TOKEN_EXPIRATION_SECONDS}"
               - name: APP_SECRET


### PR DESCRIPTION
Fixes:
```
* spec.deployments[0].podSpec.env[2].value: Invalid value: "boolean": spec.deployments[0].podSpec.env[2].value in body must be of type string: "boolean"
```