### PR TITLE
fix(HMS-3731): workaround for cloudwatch type field

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -290,6 +290,11 @@ func setClowderConfiguration(v *viper.Viper, clowderConfig *clowder.AppConfig) {
 		v.Set("logging.cloudwatch.group", clowderConfig.Logging.Cloudwatch.LogGroup)
 		v.Set("logging.cloudwatch.region", clowderConfig.Logging.Cloudwatch.Region)
 		v.Set("logging.cloudwatch.secret", clowderConfig.Logging.Cloudwatch.SecretAccessKey)
+		// TODO Delete the block below when the below PR is merged
+		// See: https://github.com/RedHatInsights/clowder/pull/627
+		if clowderConfig.Logging.Type == "" && len(clowderConfig.Logging.Cloudwatch.SecretAccessKey) > 0 {
+			v.Set("logging.type", "cloudwatch")
+		}
 	}
 
 	// Metrics configuration

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -103,6 +103,7 @@ func TestSetClowderConfiguration(t *testing.T) {
 	assert.Equal(t, "testgroup", v.Get("logging.cloudwatch.group"))
 	assert.Equal(t, "testsecret", v.Get("logging.cloudwatch.secret"))
 	assert.Equal(t, "testaccesskeyid", v.Get("logging.cloudwatch.key"))
+	assert.Equal(t, "cloudwatch", v.Get("logging.type"))
 }
 
 func TestHasKafkaBrokerConfig(t *testing.T) {


### PR DESCRIPTION
This workaround would fix the cloudwatch situation, so
the type field is filled with `"coudwatch"` string when
the cloudwatch values are merged on the service configuration.

When https://github.com/RedHatInsights/clowder/pull/627 PR
is merged, we can revert the first commit of this PR.