### PR TITLE
fix(HMS-3805): add mixed enforcement

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity.go
+++ b/internal/infrastructure/middleware/enforce_identity.go
@@ -57,7 +57,7 @@ func EnforceUserPredicate(data *identity.XRHID) error {
 		return fmt.Errorf("'data' cannot be nil")
 	}
 	if data.Identity.Type != "User" {
-		return fmt.Errorf("'Identity.Type' is not 'User'")
+		return fmt.Errorf("'Identity.Type=%s' is not 'User'", data.Identity.Type)
 	}
 	if !data.Identity.User.Active {
 		return fmt.Errorf("'Identity.User.Active' is not true")
@@ -88,6 +88,24 @@ func EnforceSystemPredicate(data *identity.XRHID) error {
 		return fmt.Errorf("'Identity.System.CommonName' is empty")
 	}
 	return nil
+}
+
+// NewEnforceOr allow to create new predicates by composing a
+// logical OR with existing predicates.
+func NewEnforceOr(predicates ...IdentityPredicate) IdentityPredicate {
+	return func(data *identity.XRHID) error {
+		var firsterr error
+		for i := range predicates {
+			if err := predicates[i](data); err == nil {
+				return nil
+			} else {
+				if firsterr == nil {
+					firsterr = err
+				}
+			}
+		}
+		return firsterr
+	}
 }
 
 // EnforceIdentityWithConfig instantiate a EnforceIdentity middleware

--- a/internal/infrastructure/router/public_test.go
+++ b/internal/infrastructure/router/public_test.go
@@ -229,6 +229,13 @@ func TestSkipperUser(t *testing.T) {
 			Expected: true,
 		})
 	}
+	for i := range mixedEnforceRoutes {
+		testCases = append(testCases, TestCase{
+			Name:     fmt.Sprintf("Skip mixedEnforceRoutes[%d]: %v", i, mixedEnforceRoutes[i]),
+			Given:    mixedEnforceRoutes[i],
+			Expected: true,
+		})
+	}
 	for _, testCase := range testCases {
 		t.Log(testCase.Name)
 		ctx := helperNewContextForSkipper(
@@ -259,6 +266,13 @@ func TestSkipperSystem(t *testing.T) {
 		testCases = append(testCases, TestCase{
 			Name:     fmt.Sprintf("Skip userEnforceRoutes[%d]: %v", i, userEnforceRoutes[i]),
 			Given:    userEnforceRoutes[i],
+			Expected: true,
+		})
+	}
+	for i := range mixedEnforceRoutes {
+		testCases = append(testCases, TestCase{
+			Name:     fmt.Sprintf("Skip mixedEnforceRoutes[%d]: %v", i, mixedEnforceRoutes[i]),
+			Given:    mixedEnforceRoutes[i],
 			Expected: true,
 		})
 	}
@@ -359,4 +373,44 @@ func TestInitRbacMiddleware(t *testing.T) {
 		})
 	}, "Initialize the rbac middleware")
 	assert.NotNil(t, result)
+}
+
+func TestSkipperMixedPredicate(t *testing.T) {
+	type TestCase struct {
+		Name     string
+		Given    enforceRoute
+		Expected bool
+	}
+	testCases := []TestCase{}
+	for i := range userEnforceRoutes {
+		testCases = append(testCases, TestCase{
+			Name:     fmt.Sprintf("Skip userEnforceRoutes[%d]: %v", i, userEnforceRoutes[i]),
+			Given:    userEnforceRoutes[i],
+			Expected: true,
+		})
+	}
+	for i := range systemEnforceRoutes {
+		testCases = append(testCases, TestCase{
+			Name:     fmt.Sprintf("Skip systemEnforceRoutes[%d]: %v", i, systemEnforceRoutes[i]),
+			Given:    systemEnforceRoutes[i],
+			Expected: true,
+		})
+	}
+	for i := range mixedEnforceRoutes {
+		testCases = append(testCases, TestCase{
+			Name:     fmt.Sprintf("No skip mixedEnforceRoutes[%d]: %v", i, mixedEnforceRoutes[i]),
+			Given:    mixedEnforceRoutes[i],
+			Expected: false,
+		})
+	}
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+		ctx := helperNewContextForSkipper(
+			testCase.Given.Path,
+			testCase.Given.Method,
+			testCase.Given.Path,
+			nil)
+		result := skipperMixedPredicate(ctx)
+		assert.Equal(t, testCase.Expected, result)
+	}
 }


### PR DESCRIPTION
This change allow to define routes for mixed enforcement for the routes that could be reached out by users or systems.