### PR TITLE
test(HMS-3524): read only permission

### DIFF
--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -228,9 +228,51 @@ func (s *SuiteRbacPermission) TestAdminRole() {
 }
 
 func (s *SuiteRbacPermission) TestReadPermission() {
-	t := s.T()
-	t.Log("TestReadPermission is not implemented")
-	// TODO Add the test set for the read only permission
+	testCases := []TestCasePermission{
+		{
+			Name:     "Test idmsvc:token:create",
+			Given:    s.prepareNoop,
+			Then:     s.doTestTokenCreate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:create",
+			Given:    s.prepareDomainIpaCreate,
+			Then:     s.doTestDomainIpaCreate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test Update Agent idmsvc:domain:update",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaUpdate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test Update User idmsvc:domain:update",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaPatch,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:read",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaRead,
+			Expected: http.StatusOK,
+		},
+		{
+			Name:     "Test idmsvc:domain:delete",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaDelete,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:list",
+			Given:    s.prepareNoop,
+			Then:     s.doTestDomainList,
+			Expected: http.StatusOK,
+		},
+	}
+	s.commonRun(mock_rbac.ProfileDomainReadOnly, testCases)
 }
 
 func (s *SuiteRbacPermission) TestNoPermission() {


### PR DESCRIPTION
Add smoke tests to check permissions for read-only operations.
This use all the previous infrastructure, so we only have to
describe the status code for the operations unauthorized.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/169