### PR TITLE
test(HMS-3526): check rbac when no permissions

### DIFF
--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -276,7 +276,49 @@ func (s *SuiteRbacPermission) TestReadPermission() {
 }
 
 func (s *SuiteRbacPermission) TestNoPermission() {
-	t := s.T()
-	t.Log("TestReadPermission is not implemented")
-	// TODO Add the test set for an empty set of permission
+	testCases := []TestCasePermission{
+		{
+			Name:     "Test idmsvc:token:create",
+			Given:    s.prepareNoop,
+			Then:     s.doTestTokenCreate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:create",
+			Given:    s.prepareDomainIpaCreate,
+			Then:     s.doTestDomainIpaCreate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test Update Agent idmsvc:domain:update",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaUpdate,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test Update User idmsvc:domain:update",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaPatch,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:read",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaRead,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:delete",
+			Given:    s.prepareDomainIpa,
+			Then:     s.doTestDomainIpaDelete,
+			Expected: http.StatusUnauthorized,
+		},
+		{
+			Name:     "Test idmsvc:domain:list",
+			Given:    s.prepareNoop,
+			Then:     s.doTestDomainList,
+			Expected: http.StatusUnauthorized,
+		},
+	}
+	s.commonRun(mock_rbac.ProfileDomainNoPerms, testCases)
 }

--- a/internal/usecase/client/rbac/wrapper.go
+++ b/internal/usecase/client/rbac/wrapper.go
@@ -110,7 +110,7 @@ func (c *rbacWrapper) addXRHID(ctx context.Context, req *http.Request) error {
 
 func (c *rbacWrapper) retrieveACL(ctx context.Context) ([]string, error) {
 	// Credits on RHEnvision: https://github.com/RHEnVision/provisioning-backend/blob/main/internal/clients/http/rbac/rbac_client.go#L83
-	// Credits on hmscontent-service:
+	// Credits on hmscontent-service: https://github.com/content-services/content-sources-backend/blob/main/pkg/rbac/client_wrapper.go
 	var (
 		limit  int
 		offset int


### PR DESCRIPTION
This change add integration tests to verify the
response for the operations is unauthorized when
none of the permissions are returned.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/169