### PR TITLE
HMS-3900 test: Use new mock-rbac container for testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ tmp.*/**
 !/configs/config.ci.yaml
 !/configs/bonfire.example.yaml
 !/configs/cdappconfig.json
+!/configs/rbac-test.yaml
 
 !/configs/rbac_client_api.json
 !/configs/rbac_client_gen_config.yaml

--- a/configs/rbac-test.yaml
+++ b/configs/rbac-test.yaml
@@ -1,0 +1,18 @@
+---
+users:
+  superadmin:
+    - "*:*:*"
+  adminuser:
+    - idmsvc:token:create
+    - idmsvc:domains:create
+    - idmsvc:domains:list
+    - idmsvc:domains:update
+    - idmsvc:domains:delete
+    - idmsvc:domains:read
+  test:
+    - idmsvc:domains:list
+    - idmsvc:domains:read
+
+systems:
+  "server1.ipa.test":
+    - domain-none

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -125,6 +125,16 @@ services:
   #       timeout: 3s
   #       start_period: 5s
 
+  mock-rbac:
+    image: "${MOCK_RBAC_CONTAINER}"
+    environment:
+      RBAC_BASE_URL: http://0.0.0.0:8020/api/rbac/v1
+      RBAC_CONFIG: /configs/${MOCK_RBAC_CONFIG:-rbac-test.yaml}
+    ports:
+      - 8020:8020
+    volumes:
+      - ../configs:/configs:z
+
 volumes:
   database:
   zookeeper:

--- a/scripts/mk/mock-rbac.mk
+++ b/scripts/mk/mock-rbac.mk
@@ -1,0 +1,11 @@
+##
+# Rules to automate rbac mock tasks
+##
+
+.PHONY: mock-rbac-up
+mock-rbac-up: ## Start rbac mock using local infra
+	$(CONTAINER_COMPOSE) -p idmsvc -f "$(COMPOSE_FILE)" up -d mock-rbac
+
+.PHONY: mock-rbac-down
+mock-rbac-down: ## Stop rbac mock using local infra
+	$(CONTAINER_COMPOSE) -p idmsvc -f "$(COMPOSE_FILE)" down mock-rbac

--- a/scripts/mk/variables.mk
+++ b/scripts/mk/variables.mk
@@ -122,3 +122,10 @@ export APP_SECRET
 APP_ENABLE_RBAC ?= false
 export APP_ENABLE_RBAC
 
+# relative to ./configs/ directory
+MOCK_RBAC_CONFIG ?= rbac-test.yaml
+export MOCK_RBAC_CONFIG
+
+# The image is updated automatically
+MOCK_RBAC_CONTAINER ?= quay.io/podengo/mock-rbac:main
+export MOCK_RBAC_CONTAINER

--- a/test/scripts/local-rbac.sh
+++ b/test/scripts/local-rbac.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -eo pipefail
+
+source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
+
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+unset X_RH_FAKE_IDENTITY
+unset CREDS
+unset X_RH_IDM_VERSION
+BASE_URL="http://localhost:8020/api/rbac/v1"
+
+exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/access?application=idmsvc&offset=0&limit=1000"


### PR DESCRIPTION
Configure compose to use latest mock-rbac container with new configuration. The latest container (PR pending) maps XRHID account information to permissions.

See: https://github.com/podengo-project/mock-rbac/pull/4