### PR TITLE
fix(HMS-3914): harden dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+.podman
+.docker
+.kube
+
 .DS_Store
 .cicd_bootstrap.sh
 secrets


### PR DESCRIPTION
Add a policy to ignore by default from .dockerignore file. As .git is not copied, the printing out the last commit is made from the container-build rule. For internal CI/CD we can track the repository related state by the image tag which is the short hash of the repository.

Credits on: insights-rbac contributors