### PR TITLE
fix(HMS-4061): fix auto enrollment

### DIFF
--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -127,7 +127,7 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 					assert.Equal(t, "", *body.Description)
 
 					require.NotNil(t, body.AutoEnrollmentEnabled)
-					assert.True(t, *body.AutoEnrollmentEnabled)
+					assert.False(t, *body.AutoEnrollmentEnabled)
 
 					// Check rhel-idm
 					if bodyRequest != nil {

--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -178,8 +178,8 @@ func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, p
 	// default title is domain name
 	domain.Title = pointy.String(body.DomainName)
 	domain.Description = pointy.String("")
-	// new domains are enabled by default
-	domain.AutoEnrollmentEnabled = pointy.Bool(true)
+	// new domains are disabled by default
+	domain.AutoEnrollmentEnabled = pointy.Bool(false)
 
 	return orgID, clientVersion, domain, nil
 }

--- a/internal/usecase/interactor/domain_interactor_test.go
+++ b/internal/usecase/interactor/domain_interactor_test.go
@@ -212,7 +212,7 @@ func TestRegisterIpa(t *testing.T) {
 					DomainName:            pointy.String("mydomain.example"),
 					Title:                 pointy.String("mydomain.example"),
 					Description:           pointy.String(""),
-					AutoEnrollmentEnabled: pointy.Bool(true),
+					AutoEnrollmentEnabled: pointy.Bool(false),
 					Type:                  pointy.Uint(model.DomainTypeIpa),
 					IpaDomain: &model.Ipa{
 						RealmName:    pointy.String(""),
@@ -249,7 +249,7 @@ func TestRegisterIpa(t *testing.T) {
 					DomainName:            pointy.String("mydomain.example"),
 					Title:                 pointy.String("mydomain.example"),
 					Description:           pointy.String(""),
-					AutoEnrollmentEnabled: pointy.Bool(true),
+					AutoEnrollmentEnabled: pointy.Bool(false),
 					Type:                  pointy.Uint(model.DomainTypeIpa),
 					IpaDomain: &model.Ipa{
 						RealmName:    pointy.String("MYDOMAIN.EXAMPLE"),
@@ -287,7 +287,7 @@ func TestRegisterIpa(t *testing.T) {
 					DomainName:            pointy.String("mydomain.example"),
 					Title:                 pointy.String("mydomain.example"),
 					Description:           pointy.String(""),
-					AutoEnrollmentEnabled: pointy.Bool(true),
+					AutoEnrollmentEnabled: pointy.Bool(false),
 					Type:                  pointy.Uint(model.DomainTypeIpa),
 					IpaDomain: &model.Ipa{
 						RealmName:    pointy.String("MYDOMAIN.EXAMPLE"),
@@ -335,7 +335,7 @@ func TestRegisterIpa(t *testing.T) {
 					DomainName:            pointy.String("mydomain.example"),
 					Title:                 pointy.String("mydomain.example"),
 					Description:           pointy.String(""),
-					AutoEnrollmentEnabled: pointy.Bool(true),
+					AutoEnrollmentEnabled: pointy.Bool(false),
 					Type:                  pointy.Uint(model.DomainTypeIpa),
 					IpaDomain: &model.Ipa{
 						RealmName: pointy.String("MYDOMAIN.EXAMPLE"),
@@ -393,7 +393,7 @@ func TestRegisterIpa(t *testing.T) {
 					DomainName:            pointy.String("mydomain.example"),
 					Title:                 pointy.String("mydomain.example"),
 					Description:           pointy.String(""),
-					AutoEnrollmentEnabled: pointy.Bool(true),
+					AutoEnrollmentEnabled: pointy.Bool(false),
 					Type:                  pointy.Uint(model.DomainTypeIpa),
 					IpaDomain: &model.Ipa{
 						RealmName: pointy.String("MYDOMAIN.EXAMPLE"),


### PR DESCRIPTION
When the register operation happens, it is set
auto-enrollment to false by default. This is for
the `POST /domains` operation.

Later the user decide if it is enable or disabled
with a `PATCH /domains/:domain_id` operation, which
match with clicking on the **Finish** button on the
registration domain wizard.

It can be checked by:

```shell
# Start the backend
make compose-clean clean build commpose-up run
# From another terminal run the below
# Generate a token
./test/scripts/local-domain-token.sh
TOKEN="..."  # the value returned for it
# Register the example domain
./test/scripts/local-domain-register "$TOKEN"
# Check the database
make db-cli
select * from domains;
# You will see the field for auto_enrollment_enabled is f
# which means it is disabled
```

