### PR TITLE
feat(HMS-3528): enable rbac by default

### DIFF
--- a/configs/bonfire.example.yaml
+++ b/configs/bonfire.example.yaml
@@ -33,7 +33,7 @@ apps:
           APP_ACCEPT_X_RH_FAKE_IDENTITY: "true"
           APP_VALIDATE_API: "true"
           APP_TOKEN_EXPIRATION_SECONDS: "7200"
-          APP_ENABLE_RBAC: "true"
+          # APP_ENABLE_RBAC: "true"
           CLIENTS_RBAC_BASE_URL: "http://rbac-service:8000/api/rbac/v1"
 
       - name: frontend

--- a/configs/config.example.yaml
+++ b/configs/config.example.yaml
@@ -47,4 +47,4 @@ app:
   #     python -c "import secrets; print(secrets.token_urlsafe())"
   secret: sFamo2ER65JN7wxZ48UZb5GbtDc053ahIPJ0Qx47bzA
   # Enable/Disable RBAC verification
-  enable_rbac: false
+  enable_rbac: true

--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -231,9 +231,8 @@ parameters:
     value: "false"
     description: |
       A flag to suspend execution of 'db-tool jwk refresh' cron job.
-  # TODO HMS-3528 Set "true" or remove the feature flag
   - name: APP_ENABLE_RBAC
-    value: "false"
+    value: "true"
     description: |
       It allows to enable / disable RBAC middleware.
   - name: CLIENTS_RBAC_BASE_URL

--- a/scripts/mk/private.example.mk
+++ b/scripts/mk/private.example.mk
@@ -51,7 +51,7 @@ POOL ?= default
 
 # Set token expiration time, expressed in seconds (default 2 hours)
 APP_TOKEN_EXPIRATION_SECONDS ?= 7200
-APP_ENABLE_RBAC ?= true
+# APP_ENABLE_RBAC ?= true
 
 ########### NO SECRETS BUT GENERAL OVERRIDES
 


### PR DESCRIPTION
This change enable RBAC by default, this means the below:

- rbac is enabled by default when we run locally the service by `make run`. See: secrets/private.mk to avoid it is override the value.
- rbac is enabled by default when we deploy in dev cluster by `make ephemeral-deploy` or `make ephemeral-build-deploy`.
- rbac is enabled by default when we deploy in stage, unless the parameter APP_ENABLE_RBAC is override on deployment time.