### PR TITLE
fix(HMS-4274): rbac calls for system endpoints

### DIFF
--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -179,7 +179,7 @@ func (a *application) DeleteDomain(
 	return ctx.NoContent(http.StatusNoContent)
 }
 
-// RegisterIpa (PUT /domains) initialize the
+// RegisterDomain (PUT /domains) initialize the
 // IPA domain information into the database. This requires
 // a valid X-Rh-IDM-Token. The token is removed when the
 // operation is success. Only update information that

--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -53,7 +54,12 @@ func (a *application) HostConf(
 	}
 
 	if keys, err = a.hostconfjwk.repository.GetPrivateSigningKeys(tx); err != nil {
-		// TODO: log and convert to HTTP error
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
+		return err
+	}
+	if len(keys) == 0 {
+		err = echo.NewHTTPError(http.StatusInternalServerError, "no keys available")
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 

--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -31,17 +31,21 @@ func (a *application) HostConf(
 		keys    []jwk.Key
 	)
 	if xrhid, err = getXRHID(ctx); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 
 	if err = ctx.Bind(&input); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 	if options, err = a.host.interactor.HostConf(xrhid, inventoryId, fqdn, &params, &input); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 
 	if tx = a.db.Begin(); tx.Error != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return tx.Error
 	}
 	defer tx.Rollback()
@@ -50,6 +54,7 @@ func (a *application) HostConf(
 		tx,
 		options,
 	); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 
@@ -68,16 +73,19 @@ func (a *application) HostConf(
 		options,
 		domain,
 	); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 
 	if tx.Commit(); tx.Error != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return tx.Error
 	}
 
 	if output, err = a.host.presenter.HostConf(
 		domain, hctoken,
 	); err != nil {
+		slog.ErrorContext(ctx.Request().Context(), err.Error())
 		return err
 	}
 	return ctx.JSON(http.StatusOK, *output)

--- a/internal/infrastructure/middleware/rbac.go
+++ b/internal/infrastructure/middleware/rbac.go
@@ -52,6 +52,7 @@ func RBACWithConfig(rbacConfig *RBACConfig) echo.MiddlewareFunc {
 
 			// Process skippers
 			if rbacConfig.Skipper != nil && rbacConfig.Skipper(c) {
+				slog.DebugContext(c.Request().Context(), "Skipping rbac for "+c.Request().RequestURI)
 				return next(c)
 			}
 

--- a/internal/infrastructure/middleware/rbac_test.go
+++ b/internal/infrastructure/middleware/rbac_test.go
@@ -31,17 +31,13 @@ func helperRbacCreateMapping() rbac_data.RBACMap {
 	service := rbac_data.RBACService("idmsvc")
 	resourceToken := rbac_data.RBACResource("token")
 	resourceDomains := rbac_data.RBACResource("domains")
-	resourceSigningKeys := rbac_data.RBACResource("signing_keys")
-	resourceHostConf := rbac_data.RBACResource("host_conf")
+	// This map fit the one at internal/infrastructure/router/rbac.yaml
 	data := rbac_data.NewRBACMapBuilder().
 		Add("/domains/token", http.MethodPost, rbac_data.NewRbacPermission(service, resourceToken, rbac_data.RbacVerbCreate)).
 		Add("/domains", http.MethodGet, rbac_data.NewRbacPermission(service, resourceDomains, rbac_data.RbacVerbRead)).
 		Add("/domains/:uuid", http.MethodGet, rbac_data.NewRbacPermission(service, resourceDomains, rbac_data.RbacVerbRead)).
-		Add("/domains/:uuid", http.MethodPost, rbac_data.NewRbacPermission(service, resourceDomains, rbac_data.RbacVerbCreate)).
 		Add("/domains/:uuid", http.MethodPatch, rbac_data.NewRbacPermission(service, resourceDomains, rbac_data.RbacVerbUpdate)).
 		Add("/domains/:uuid", http.MethodDelete, rbac_data.NewRbacPermission(service, resourceDomains, rbac_data.RbacVerbDelete)).
-		Add("/signing_keys", http.MethodDelete, rbac_data.NewRbacPermission(service, resourceSigningKeys, rbac_data.RbacVerbExecute)).
-		Add("/host-conf/:inventory_id/:fqdn", http.MethodDelete, rbac_data.NewRbacPermission(service, resourceHostConf, rbac_data.RbacVerbExecute)).
 		Build()
 	return data
 }

--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -75,11 +75,12 @@ func newRbacSkipper(service string) echo_middleware.Skipper {
 			cc middleware.DomainContextInterface
 			ok bool
 		)
+		openapiPath := "/api/" + service + "/v1/openapi.json"
 		ctx := c.Request().Context()
 		routePath := c.Path()
 		// The access to the openapi specification is public
-		if routePath == "/api/"+service+"/v1/openapi.json" {
-			slog.DebugContext(ctx, "Skipping "+routePath)
+		if routePath == openapiPath {
+			slog.DebugContext(ctx, "route is '"+openapiPath+"'")
 			return true
 		}
 		if cc, ok = c.(middleware.DomainContextInterface); !ok {
@@ -87,12 +88,7 @@ func newRbacSkipper(service string) echo_middleware.Skipper {
 			return false
 		}
 		if cc.XRHID().Identity.Type == "System" {
-			for i := range systemEnforceRoutes {
-				if routePath == systemEnforceRoutes[i].Path {
-					slog.DebugContext(ctx, "Skipping "+routePath+" for the System with CN="+cc.XRHID().Identity.System.CommonName)
-					return true
-				}
-			}
+			return true
 		}
 		return false
 	}

--- a/internal/infrastructure/router/rbac.yaml
+++ b/internal/infrastructure/router/rbac.yaml
@@ -8,14 +8,8 @@ data:
   "/domains/token":
     POST: "idmsvc:token:create"
   "/domains":
-    POST: "idmsvc:domains:create"
     GET: "idmsvc:domains:list"
   "/domains/:uuid":
     GET: "idmsvc:domains:read"
-    PUT: "idmsvc:domains:update"
     PATCH: "idmsvc:domains:update"
     DELETE: "idmsvc:domains:delete"
-  "/host-conf/:inventory_id/:fqdn":
-    POST: "idmsvc:host_conf:execute"
-  "/signing_keys":
-    GET: "idmsvc:signing_keys:execute"

--- a/internal/infrastructure/service/impl/mock/rbac/impl/rbac.go
+++ b/internal/infrastructure/service/impl/mock/rbac/impl/rbac.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"sync"
@@ -176,7 +177,11 @@ func (m *mockRbac) Start() error {
 		defer m.waitGroup.Done()
 		slog.Info("mock rbac service starting")
 		if err := m.echo.Start(m.address); err != nil {
-			slog.Error(err.Error())
+			if err != http.ErrServerClosed {
+				slog.Error(err.Error())
+			} else {
+				slog.Info("Service rbac mock closed")
+			}
 			return
 		}
 	}()

--- a/internal/test/builder/api/builder_domain_rhel_idm_server.go
+++ b/internal/test/builder/api/builder_domain_rhel_idm_server.go
@@ -11,6 +11,7 @@ type DomainIpaServer interface {
 	// TODO Add methods and implement them as they are needed
 	// With...() DomainIpaServer
 	WithHccUpdateServer(value bool) DomainIpaServer
+	WithHccEnrollmentServer(value bool) DomainIpaServer
 	WithSubscriptionManagerId(value string) DomainIpaServer
 }
 
@@ -39,6 +40,11 @@ func (b *domainIpaServer) WithSubscriptionManagerId(value string) DomainIpaServe
 	subscriptionManagerID := &uuid.UUID{}
 	*subscriptionManagerID = uuid.MustParse(value)
 	b.SubscriptionManagerId = subscriptionManagerID
+	return b
+}
+
+func (b *domainIpaServer) WithHccEnrollmentServer(value bool) DomainIpaServer {
+	b.HccEnrollmentServer = value
 	return b
 }
 

--- a/internal/test/builder/api/builder_host_conf.go
+++ b/internal/test/builder/api/builder_host_conf.go
@@ -1,11 +1,9 @@
 package api
 
 import (
-	"github.com/google/uuid"
 	"github.com/openlyinc/pointy"
 	"github.com/pioz/faker"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
-	"github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
 )
 
 // HostConf builder interface
@@ -19,11 +17,9 @@ type HostConf interface {
 type hostConf public.HostConf
 
 func NewHostConf() HostConf {
-	id := &uuid.UUID{}
-	*id = uuid.New()
 	return &hostConf{
-		DomainId:   id,
-		DomainName: pointy.String(helper.GenRandDomainName(2)),
+		DomainId:   nil,
+		DomainName: nil,
 		DomainType: (*public.DomainType)(pointy.String(faker.Pick(string(public.RhelIdm)))),
 	}
 }

--- a/internal/test/builder/model/builder_hostconf_jwk.go
+++ b/internal/test/builder/model/builder_hostconf_jwk.go
@@ -1,0 +1,72 @@
+package model
+
+import (
+	"time"
+
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
+	"gorm.io/gorm"
+)
+
+type HostconfJwk interface {
+	Build() *model.HostconfJwk
+	WithModel(value *gorm.Model) HostconfJwk
+	WithKeyId(value string) HostconfJwk
+	WithExpiresAt(value time.Time) HostconfJwk
+	WithPublicJwk(value string) HostconfJwk
+	WithEncryptionId(value string) HostconfJwk
+	WithEncryptedJwk(value []byte) HostconfJwk
+}
+
+// gormModel is the specific builder implementation
+type hostconfJwk struct {
+	model.HostconfJwk
+}
+
+// NewModel generate a gorm.Model with random information
+// overrided by the customized options.
+func NewHostconfJwk() HostconfJwk {
+	return &hostconfJwk{
+		HostconfJwk: model.HostconfJwk{
+			Model:        NewModel().Build(),
+			KeyId:        "",
+			ExpiresAt:    time.Now().UTC().Add(24 * time.Hour),
+			PublicJwk:    "",
+			EncryptionId: "",
+			EncryptedJwk: []byte{},
+		},
+	}
+}
+
+func (b *hostconfJwk) Build() *model.HostconfJwk {
+	return (*model.HostconfJwk)(&b.HostconfJwk)
+}
+
+func (b *hostconfJwk) WithModel(value *gorm.Model) HostconfJwk {
+	b.HostconfJwk.Model = *value
+	return b
+}
+
+func (b *hostconfJwk) WithKeyId(value string) HostconfJwk {
+	b.HostconfJwk.KeyId = value
+	return b
+}
+
+func (b *hostconfJwk) WithExpiresAt(value time.Time) HostconfJwk {
+	b.HostconfJwk.ExpiresAt = value
+	return b
+}
+
+func (b *hostconfJwk) WithPublicJwk(value string) HostconfJwk {
+	b.HostconfJwk.PublicJwk = value
+	return b
+}
+
+func (b *hostconfJwk) WithEncryptionId(value string) HostconfJwk {
+	b.HostconfJwk.EncryptionId = value
+	return b
+}
+
+func (b *hostconfJwk) WithEncryptedJwk(value []byte) HostconfJwk {
+	b.HostconfJwk.EncryptedJwk = value
+	return b
+}

--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -218,31 +218,6 @@ func (s *SuiteRbacPermission) helperCommonAdmin() []TestCasePermission {
 			Then:     s.doTestDomainList,
 			Expected: http.StatusOK,
 		},
-		// System requests are identified by its certificate
-		{
-			Name:     "Test Agent register domain",
-			Given:    s.prepareDomainIpaCreate,
-			Then:     s.doTestDomainIpaCreate,
-			Expected: http.StatusCreated,
-		},
-		{
-			Name:     "Test Update Agent",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestDomainIpaUpdate,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Agent Read domain",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestSystemReadDomain,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Read SigningKeys",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestReadSigningKeys,
-			Expected: http.StatusOK,
-		},
 	}
 	return testCases
 }
@@ -287,31 +262,6 @@ func (s *SuiteRbacPermission) TestReadPermission() {
 			Then:     s.doTestDomainList,
 			Expected: http.StatusOK,
 		},
-		// System requests are identified by its certificate
-		{
-			Name:     "Test Agent register domain",
-			Given:    s.prepareDomainIpaCreate,
-			Then:     s.doTestDomainIpaCreate,
-			Expected: http.StatusCreated,
-		},
-		{
-			Name:     "Test Update Agent",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestDomainIpaUpdate,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Agent Read domain",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestSystemReadDomain,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Read SigningKeys",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestReadSigningKeys,
-			Expected: http.StatusOK,
-		},
 	}
 	s.commonRun(mock_rbac.ProfileDomainReadOnly, testCases)
 }
@@ -348,50 +298,6 @@ func (s *SuiteRbacPermission) TestNoPermission() {
 			Then:     s.doTestDomainList,
 			Expected: http.StatusUnauthorized,
 		},
-		// System requests are identified by its certificate
-		{
-			Name:     "Test Agent register domain",
-			Given:    s.prepareDomainIpaCreate,
-			Then:     s.doTestDomainIpaCreate,
-			Expected: http.StatusCreated,
-		},
-		{
-			Name:     "Test Update Agent",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestDomainIpaUpdate,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Agent Read domain",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestSystemReadDomain,
-			Expected: http.StatusOK,
-		},
-		{
-			Name:     "Test Read SigningKeys",
-			Given:    s.prepareDomainIpa,
-			Then:     s.doTestReadSigningKeys,
-			Expected: http.StatusOK,
-		},
 	}
 	s.commonRun(mock_rbac.ProfileDomainNoPerms, testCases)
-}
-
-func (s *SuiteRbacPermission) TestHostConfExecute() {
-	// This is executed on their own test because
-	// one verification is that only one domain match
-	// for the current organization, for the specified
-	// criteria.
-	t := s.T()
-	s.prepareDomainIpa(t)
-	domainType := public.RhelIdm
-	res, err := s.SystemHostConfWithResponse(
-		s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String(),
-		"client."+s.domain.DomainName,
-		builder_api.NewHostConf().
-			WithDomainName(pointy.String(s.domain.DomainName)).
-			WithDomainType(&domainType).
-			Build())
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, res.StatusCode)
 }

--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -40,14 +40,6 @@ func (s *SuiteRbacPermission) doTestTokenCreate(t *testing.T) int {
 	return res.StatusCode
 }
 
-func (s *SuiteRbacPermission) prepareDomainIpaCreate(t *testing.T) {
-	token, err := s.CreateToken()
-	require.NoError(t, err)
-	require.NotNil(t, token)
-	require.NotEqual(t, "", token.DomainToken)
-	s.token = token
-}
-
 func (s *SuiteRbacPermission) prepareDomainIpa(t *testing.T) {
 	var err error
 	s.token, err = s.CreateToken()
@@ -83,46 +75,6 @@ func (s *SuiteRbacPermission) prepareDomainIpa(t *testing.T) {
 	require.NotNil(t, s.domain)
 }
 
-func (s *SuiteRbacPermission) doTestDomainIpaCreate(t *testing.T) int {
-	res, err := s.RegisterIpaDomainWithResponse(s.token.DomainToken,
-		builder_api.NewDomain("test.example").
-			WithDomainID(&s.token.DomainId).
-			WithRhelIdm(builder_api.NewRhelIdmDomain("test.example").
-				AddServer(builder_api.NewDomainIpaServer("1.test.example").
-					WithHccUpdateServer(true).
-					WithSubscriptionManagerId(s.SystemXRHID.Identity.System.CommonName).
-					Build()).
-				Build(),
-			).Build(),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	return res.StatusCode
-}
-
-func (s *SuiteRbacPermission) doTestDomainIpaUpdate(t *testing.T) int {
-	subscriptionManagerID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
-	domainID := s.domain.DomainId.String()
-	res, err := s.UpdateDomainWithResponse(
-		domainID,
-		builder_api.NewUpdateDomainAgent("test.example").
-			WithHCCUpdate(true).
-			WithDomainRhelIdm(*builder_api.NewRhelIdmDomain("test.example").
-				WithServers([]public.DomainIpaServer{}).
-				AddServer(
-					builder_api.NewDomainIpaServer("1.test.example").
-						WithHccUpdateServer(true).
-						WithSubscriptionManagerId(subscriptionManagerID).
-						Build(),
-				).Build(),
-			).WithSubscriptionManagerID(subscriptionManagerID).
-			Build(),
-	)
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	return res.StatusCode
-}
-
 func (s *SuiteRbacPermission) doTestDomainIpaPatch(t *testing.T) int {
 	res, err := s.PatchDomainWithResponse(
 		s.domain.DomainId.String(),
@@ -154,18 +106,6 @@ func (s *SuiteRbacPermission) doTestDomainList(t *testing.T) int {
 	res, err := s.ListDomainWithResponse(0, 10)
 	require.NoError(t, err)
 	require.NotNil(t, res)
-	return res.StatusCode
-}
-
-func (s *SuiteRbacPermission) doTestReadSigningKeys(t *testing.T) int {
-	res, err := s.SystemSigningKeysWithResponse()
-	require.NoError(t, err)
-	return res.StatusCode
-}
-
-func (s *SuiteRbacPermission) doTestSystemReadDomain(t *testing.T) int {
-	res, err := s.SystemReadDomainWithResponse(*s.domain.DomainId)
-	require.NoError(t, err)
 	return res.StatusCode
 }
 
@@ -223,10 +163,12 @@ func (s *SuiteRbacPermission) helperCommonAdmin() []TestCasePermission {
 }
 
 func (s *SuiteRbacPermission) TestSuperAdminRole() {
+	// This check the wildcards
 	s.commonRun(mock_rbac.ProfileSuperAdmin, s.helperCommonAdmin())
 }
 
 func (s *SuiteRbacPermission) TestAdminRole() {
+	// This check the Domains administrator role
 	s.commonRun(mock_rbac.ProfileDomainAdmin, s.helperCommonAdmin())
 }
 

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -491,7 +491,6 @@ func (s *SuiteBase) SystemHostConfWithResponse(inventoryID string, fqdn string, 
 	method := http.MethodPost
 	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
 	s.addRequestID(&hdr, "test_system_host_conf")
-	// TODO Fill this content
 	body := hostconf
 	resp, err := s.DoRequest(
 		method,
@@ -529,12 +528,11 @@ func (s *SuiteBase) SystemSigningKeysWithResponse() (*http.Response, error) {
 	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
 	s.addRequestID(&hdr, "test_system_signing_keys")
 	// TODO Fill this content
-	body := http.NoBody
 	resp, err := s.DoRequest(
 		method,
 		url,
 		hdr,
-		body,
+		http.NoBody,
 	)
 	return resp, err
 }
@@ -786,4 +784,5 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, new(SuiteListDomains))
 	suite.Run(t, new(SuiteDeleteDomain))
 	suite.Run(t, new(SuiteRbacPermission))
+	suite.Run(t, new(SuiteSystemEndpoints))
 }

--- a/internal/test/smoke/system_endpoints_test.go
+++ b/internal/test/smoke/system_endpoints_test.go
@@ -1,0 +1,180 @@
+package smoke
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/datastore"
+	mock_rbac "github.com/podengo-project/idmsvc-backend/internal/infrastructure/service/impl/mock/rbac/impl"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// SuiteTokenCreate is the suite token for smoke tests at /api/idmsvc/v1/domains/token
+type SuiteSystemEndpoints struct {
+	SuiteBase
+	token  *public.DomainRegTokenResponse
+	domain *public.Domain
+}
+
+func (s *SuiteSystemEndpoints) prepareDomainIpaCreate(t *testing.T) {
+	token, err := s.CreateToken()
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.NotEqual(t, "", token.DomainToken)
+	s.token = token
+}
+
+func (s *SuiteSystemEndpoints) prepareDomainIpa(t *testing.T) {
+	var err error
+
+	// Add key to the database
+	t.Log("Adding key")
+	hcdb := datastore.NewHostconfJwkDb(s.cfg)
+	hcdb.ListKeys()
+	hcdb.Purge()
+	hcdb.Refresh()
+	hcdb.ListKeys()
+
+	// Create a token to register a domain
+	t.Log("Creating token")
+	s.token, err = s.CreateToken()
+	require.NoError(t, err)
+	require.NotNil(t, s.token)
+	require.NotEqual(t, "", s.token.DomainToken)
+
+	// This operation set AutoEnrollmentEnabled = False whatever
+	// is the value we indicate here; we have to PATCH in a second
+	// operation
+	t.Log("Registering a domain")
+	domain := "test.example"
+	s.domain, err = s.RegisterIpaDomain(s.token.DomainToken,
+		builder_api.NewDomain(domain).
+			WithDomainID(&s.token.DomainId).
+			WithRhelIdm(builder_api.NewRhelIdmDomain(domain).
+				WithServers([]public.DomainIpaServer{}).
+				AddServer(builder_api.NewDomainIpaServer("1."+domain).
+					WithHccUpdateServer(true).
+					WithHccEnrollmentServer(true).
+					WithSubscriptionManagerId(s.SystemXRHID.Identity.System.CommonName).
+					Build(),
+				).Build(),
+			).Build(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s.domain)
+
+	// Enable auto-join for the domain
+	t.Log("Enabling auto-enrollment")
+	s.domain, err = s.PatchDomain(
+		s.domain.DomainId.String(),
+		builder_api.NewUpdateDomainUserRequest().
+			WithTitle(pointy.String(s.domain.DomainName)).
+			WithDescription(nil).
+			WithAutoEnrollmentEnabled(pointy.Bool(true)).
+			Build())
+	require.NoError(t, err)
+	require.NotNil(t, s.domain)
+}
+
+func (s *SuiteSystemEndpoints) TestHostConfExecute() {
+	t := s.T()
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.prepareDomainIpa(t)
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
+
+	t.Log("Calling SystemHostConfWithResponse")
+	domainType := public.RhelIdm
+	res, err := s.SystemHostConfWithResponse(
+		s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String(),
+		"client."+s.domain.DomainName,
+		builder_api.NewHostConf().
+			WithDomainName(pointy.String(s.domain.DomainName)).
+			WithDomainType(&domainType).
+			Build())
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	require.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func (s *SuiteSystemEndpoints) TestReadSigningKeys() {
+	t := s.T()
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.prepareDomainIpa(t)
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
+	res, err := s.SystemSigningKeysWithResponse()
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func (s *SuiteSystemEndpoints) TestSystemReadDomain() {
+	t := s.T()
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.prepareDomainIpa(t)
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
+	res, err := s.SystemReadDomainWithResponse(*s.domain.DomainId)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func (s *SuiteSystemEndpoints) TestSystemUpdateDomain() {
+	t := s.T()
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.prepareDomainIpa(t)
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
+	subscriptionManagerID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
+	domainID := s.domain.DomainId.String()
+	res, err := s.UpdateDomainWithResponse(
+		domainID,
+		builder_api.NewUpdateDomainAgent("test.example").
+			WithHCCUpdate(true).
+			WithDomainRhelIdm(*builder_api.NewRhelIdmDomain("test.example").
+				WithServers([]public.DomainIpaServer{}).
+				AddServer(
+					builder_api.NewDomainIpaServer("1.test.example").
+						WithHccUpdateServer(true).
+						WithSubscriptionManagerId(subscriptionManagerID).
+						Build(),
+				).Build(),
+			).WithSubscriptionManagerID(subscriptionManagerID).
+			Build(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.Equal(t, http.StatusOK, res.StatusCode)
+}
+
+func (s *SuiteSystemEndpoints) TestSystemCreateDomain() {
+	t := s.T()
+	var err error
+
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainAdmin])
+
+	// Create a token to register a domain
+	s.token, err = s.CreateToken()
+	require.NoError(t, err)
+	require.NotNil(t, s.token)
+	require.NotEqual(t, "", s.token.DomainToken)
+
+	// Create the domains entry
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
+	s.domain, err = s.RegisterIpaDomain(s.token.DomainToken,
+		builder_api.NewDomain("test.example").
+			WithDomainID(&s.token.DomainId).
+			WithRhelIdm(builder_api.NewRhelIdmDomain("test.example").
+				WithServers([]public.DomainIpaServer{}).
+				AddServer(builder_api.NewDomainIpaServer("1.test.example").
+					WithHccUpdateServer(true).
+					WithSubscriptionManagerId(s.SystemXRHID.Identity.System.CommonName).
+					Build(),
+				).Build(),
+			).Build(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s.domain)
+}

--- a/internal/usecase/repository/host_repository.go
+++ b/internal/usecase/repository/host_repository.go
@@ -43,7 +43,8 @@ func (r *hostRepository) MatchDomain(db *gorm.DB, options *interactor.HostConfOp
 		Joins("left join ipas on domains.id = ipas.id").
 		Where("domains.org_id = ?", options.OrgId)
 	if options.DomainId != nil {
-		tx = tx.Where("domains.domain_uuid = ?", options.DomainId.String())
+		domainUUID := options.DomainId.String()
+		tx = tx.Where("domains.domain_uuid = ?", domainUUID)
 	}
 	if options.DomainName != nil {
 		tx = tx.Where("domains.domain_name = ?", *options.DomainName)

--- a/internal/usecase/repository/hostconf_jwk_repository.go
+++ b/internal/usecase/repository/hostconf_jwk_repository.go
@@ -105,12 +105,14 @@ func (r *hostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) (hcjwks []model.Ho
 		slog.Error(err.Error())
 		return nil, err
 	}
-	if err = db.
-		Unscoped(). // do not use GORM's soft delete for purging
-		Delete(&hcjwks).
-		Error; err != nil {
-		slog.Error(err.Error())
-		return nil, err
+	if len(hcjwks) > 0 {
+		if err = db.
+			Unscoped(). // do not use GORM's soft delete for purging
+			Delete(&hcjwks).
+			Error; err != nil {
+			slog.Error(err.Error())
+			return nil, err
+		}
 	}
 	return hcjwks, nil
 }


### PR DESCRIPTION
System calls are failing; this change fix the situation calling to rbac endpoints when it is required.

The tests for the System endpoints has been extracted in its own test suite and additional endpoints for the smoke tests has been added there. A new builder is added for HostConfJwk instances, it prints more logs for the HostConf endpoint handler when an error happens.

Additionally
- a confusing error message when rbac mock close connection is removed.
- it fix rbac mapping created for the unit tests of the rbac middleware.
- add missed `/api/idmsvc/v1/signing_keys` at the system enforcement routes.
- include suggestions from @pvoborni .
- fix a situation to delete keys only when the slice has items.

https://issues.redhat.com/browse/HMS-4274
https://issues.redhat.com/browse/HMS-3525
