### PR TITLE
refactor(HMS-3968): add `As` semantics

### DIFF
--- a/internal/test/builder/api/builder_service_account_xrhid.go
+++ b/internal/test/builder/api/builder_service_account_xrhid.go
@@ -1,0 +1,94 @@
+package api
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	builder_helper "github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
+	identity "github.com/redhatinsights/platform-go-middlewares/v2/identity"
+)
+
+type ServiceAccountXRHID interface {
+	Build() identity.XRHID
+	WithAccountNumber(value string) ServiceAccountXRHID
+	WithEmployeeAccountNumber(value string) ServiceAccountXRHID
+	WithOrgID(value string) ServiceAccountXRHID
+	WithAuthType(value string) ServiceAccountXRHID
+
+	WithClientID(value string) ServiceAccountXRHID
+	WithUsername(value string) ServiceAccountXRHID
+}
+
+type serviceAccountXRHID identity.XRHID
+
+// NewServiceAccountXRHID create a new builder to get a XRHID for a user
+func NewServiceAccountXRHID() ServiceAccountXRHID {
+	var orgID = strconv.Itoa(int(builder_helper.GenRandNum(1, 100000)))
+	// See: https://github.com/RedHatInsights/identity-schemas/blob/main/3scale/identities/service-account.json
+	return &serviceAccountXRHID{
+		Identity: identity.Identity{
+			AccountNumber:         strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			EmployeeAccountNumber: strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
+			OrgID:                 orgID,
+			Type:                  "ServiceAccount",
+			AuthType:              "jwt-auth",
+			Internal: identity.Internal{
+				OrgID:    orgID,
+				AuthTime: float32(time.Now().Sub(time.Time{})),
+			},
+			ServiceAccount: &identity.ServiceAccount{
+				ClientId: uuid.NewString(),
+				Username: helper.GenRandUsername(),
+			},
+		},
+	}
+}
+
+func (b *serviceAccountXRHID) Build() identity.XRHID {
+	return identity.XRHID(*b)
+}
+
+func (b *serviceAccountXRHID) WithOrgID(value string) ServiceAccountXRHID {
+	b.Identity.OrgID = value
+	b.Identity.Internal.OrgID = value
+	return b
+}
+
+func (b *serviceAccountXRHID) WithAuthType(value string) ServiceAccountXRHID {
+	switch value {
+	case authType[0]:
+		b.Identity.AuthType = value
+		return b
+	case authType[1]:
+		b.Identity.AuthType = value
+		return b
+	default:
+		panic(fmt.Sprintf("value='%s' is not valid", value))
+	}
+}
+
+func (b *serviceAccountXRHID) WithAccountNumber(value string) ServiceAccountXRHID {
+	b.Identity.AccountNumber = value
+	return b
+}
+
+func (b *serviceAccountXRHID) WithEmployeeAccountNumber(value string) ServiceAccountXRHID {
+	b.Identity.EmployeeAccountNumber = value
+	return b
+}
+
+// --- Start specific ServiceAccount data
+
+func (b *serviceAccountXRHID) WithClientID(value string) ServiceAccountXRHID {
+	b.Identity.ServiceAccount.ClientId = value
+	return b
+}
+
+func (b *serviceAccountXRHID) WithUsername(value string) ServiceAccountXRHID {
+	b.Identity.ServiceAccount.Username = value
+	return b
+
+}

--- a/internal/test/smoke/domain_delete_test.go
+++ b/internal/test/smoke/domain_delete_test.go
@@ -15,7 +15,7 @@ type SuiteDeleteDomain struct {
 }
 
 func (s *SuiteDeleteDomain) TestDeleteDomain() {
-	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
+	xrhidEncoded := header.EncodeXRHID(&s.userXRHID)
 	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId)
 	domainName := builder_helper.GenRandDomainName(2)
 
@@ -24,8 +24,9 @@ func (s *SuiteDeleteDomain) TestDeleteDomain() {
 		{
 			Name: "TestDeleteDomain",
 			Given: TestCaseGiven{
-				Method: http.MethodDelete,
-				URL:    url,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodDelete,
+				URL:          url,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 					header.HeaderXRHID:      {xrhidEncoded},

--- a/internal/test/smoke/domain_list_test.go
+++ b/internal/test/smoke/domain_list_test.go
@@ -67,9 +67,11 @@ func (s *SuiteListDomains) SetupTest() {
 	s.Domains = []*public.Domain{}
 	for i := 1; i < 50; i++ {
 		domainName := fmt.Sprintf("domain%d.test", i)
+		s.As(XRHIDUser)
 		if token, err = s.CreateToken(); err != nil {
 			s.FailNow("error creating token")
 		}
+		s.As(XRHIDSystem)
 		domain, err = s.RegisterIpaDomain(token.DomainToken, builder_api.NewDomain(domainName).Build())
 		if err != nil {
 			s.FailNow("error registering domain")
@@ -116,7 +118,6 @@ func (s *SuiteListDomains) assertInDomains(t *testing.T, data []public.ListDomai
 
 func (s *SuiteListDomains) TestListDomains() {
 	t := s.T()
-	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
 	req, err := http.NewRequest(http.MethodGet, s.DefaultPublicBaseURL()+"/domains", nil)
 	require.NoError(t, err)
 	q := req.URL.Query()
@@ -139,11 +140,11 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=0&limit=10 case",
 			Given: TestCaseGiven{
-				Method: http.MethodGet,
-				URL:    url1,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodGet,
+				URL:          url1,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -179,11 +180,11 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=40&limit=10 case",
 			Given: TestCaseGiven{
-				Method: http.MethodGet,
-				URL:    url2,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodGet,
+				URL:          url2,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -220,11 +221,11 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=20&limit=10 case",
 			Given: TestCaseGiven{
-				Method: http.MethodGet,
-				URL:    url3,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodGet,
+				URL:          url3,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -261,11 +262,11 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: no params",
 			Given: TestCaseGiven{
-				Method: http.MethodGet,
-				URL:    url4,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodGet,
+				URL:          url4,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},

--- a/internal/test/smoke/domain_patch_user_test.go
+++ b/internal/test/smoke/domain_patch_user_test.go
@@ -26,7 +26,6 @@ func (s *SuiteDomainUpdateUser) TearDownTest() {
 }
 
 func (s *SuiteDomainUpdateUser) TestPatchDomain() {
-	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
 	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId.String())
 	patchedDomain := builder_api.NewUpdateDomainUserRequest().Build()
 
@@ -35,11 +34,11 @@ func (s *SuiteDomainUpdateUser) TestPatchDomain() {
 		{
 			Name: "TestPatchDomain",
 			Given: TestCaseGiven{
-				Method: http.MethodPatch,
-				URL:    url,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodPatch,
+				URL:          url,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_domain_patch"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: patchedDomain,
 			},

--- a/internal/test/smoke/domain_read_test.go
+++ b/internal/test/smoke/domain_read_test.go
@@ -27,7 +27,6 @@ func (s *SuiteReadDomain) TearDownTest() {
 }
 
 func (s *SuiteReadDomain) TestReadDomain() {
-	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
 	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId)
 	domainName := builder_helper.GenRandDomainName(2)
 
@@ -36,11 +35,11 @@ func (s *SuiteReadDomain) TestReadDomain() {
 		{
 			Name: "TestReadDomain",
 			Given: TestCaseGiven{
-				Method: http.MethodGet,
-				URL:    url,
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodGet,
+				URL:          url,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},

--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -62,6 +62,7 @@ func (s *SuiteRegisterDomain) SetupTest() {
 	s.SuiteBase.SetupTest()
 
 	// Get a token for the registration
+	s.As(XRHIDUser)
 	if s.token, err = s.CreateToken(); err != nil {
 		s.FailNow("Error creating a token for registering a rhel-idm domain", "%s", err.Error())
 	}
@@ -72,7 +73,7 @@ func (s *SuiteRegisterDomain) TearDownTest() {
 }
 
 func (s *SuiteRegisterDomain) TestRegisterDomain() {
-	xrhidEncoded := header.EncodeXRHID(&s.SystemXRHID)
+	xrhidEncoded := header.EncodeXRHID(&s.systemXRHID)
 	url := s.DefaultPublicBaseURL() + "/domains"
 	domainName := builder_helper.GenRandDomainName(2)
 	bodyRequest := builder_api.
@@ -84,8 +85,9 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 		{
 			Name: "TestRegisterDomain rhel-idm",
 			Given: TestCaseGiven{
-				Method: http.MethodPost,
-				URL:    url,
+				XRHIDProfile: XRHIDSystem,
+				Method:       http.MethodPost,
+				URL:          url,
 				Header: http.Header{
 					header.HeaderXRequestID:              {"test_token"},
 					header.HeaderXRHID:                   {xrhidEncoded},

--- a/internal/test/smoke/suite_base_one_domain_test.go
+++ b/internal/test/smoke/suite_base_one_domain_test.go
@@ -27,7 +27,8 @@ func (s *SuiteBaseWithDomain) SetupTest() {
 	// Domain 1 in OrgID1
 	i = 0
 	s.Domains = []*public.Domain{}
-	s.As(XRHIDUser)
+	// As an admin user
+	s.As(RBACAdmin, XRHIDUser)
 	if token, err = s.CreateToken(); err != nil {
 		s.FailNow("error creating token")
 	}

--- a/internal/test/smoke/suite_base_one_domain_test.go
+++ b/internal/test/smoke/suite_base_one_domain_test.go
@@ -27,10 +27,12 @@ func (s *SuiteBaseWithDomain) SetupTest() {
 	// Domain 1 in OrgID1
 	i = 0
 	s.Domains = []*public.Domain{}
+	s.As(XRHIDUser)
 	if token, err = s.CreateToken(); err != nil {
 		s.FailNow("error creating token")
 	}
 	domainName = fmt.Sprintf("domain%d.test", i)
+	s.As(XRHIDSystem)
 	domain, err = s.RegisterIpaDomain(token.DomainToken, builder_api.NewDomain(domainName).Build())
 	if err != nil {
 		s.FailNow("error creating rhel-idm domain")

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -98,18 +98,27 @@ type SuiteBase struct {
 // SetupTest start the services and await until they are ready
 // for being used.
 func (s *SuiteBase) SetupTest() {
+	t := s.T()
+	t.Log("SetupTest")
 	s.cfg = config.Get()
+	require.NotNil(t, s.cfg)
 	s.cfg.Application.EnableRBAC = true
 	s.wg = &sync.WaitGroup{}
 	logger.InitLogger(s.cfg)
 	s.db = datastore.NewDB(s.cfg)
+	require.NotNil(t, s.db)
 
 	ctx, cancel := StartSignalHandler(context.Background())
+	require.NotNil(t, ctx)
+	require.NotNil(t, cancel)
 	s.cancel = cancel
 	inventory := client_inventory.NewHostInventory(s.cfg)
+	require.NotNil(t, inventory)
 	s.svcRbac, s.RbacMock = mock_rbac.NewRbacMock(ctx, s.cfg)
-	s.svcRbac.Start()
-	s.RbacMock.WaitAddress(3 * time.Second)
+	require.NotNil(t, s.svcRbac)
+	require.NotNil(t, s.RbacMock)
+	require.NoError(t, s.svcRbac.Start())
+	require.NoError(t, s.RbacMock.WaitAddress(3*time.Second))
 	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainAdmin])
 	rbacClient, err := client_rbac.NewClient("idmsvc", client_rbac.WithBaseURL(s.cfg.Clients.RbacBaseURL))
 	if err != nil {
@@ -134,6 +143,8 @@ func (s *SuiteBase) SetupTest() {
 // TearDownTest Stop the services in an ordered way before every
 // smoke test executed.
 func (s *SuiteBase) TearDownTest() {
+	t := s.T()
+	t.Log("TearDownTest")
 	TearDownSignalHandler()
 	defer datastore.Close(s.db)
 	defer s.cancel()

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -37,6 +37,40 @@ import (
 	client_rbac "github.com/podengo-project/idmsvc-backend/internal/usecase/client/rbac"
 )
 
+type XRHIDProfile string
+
+// The constants below indicate which XRHID will be added
+// to the headers of the header request that use the API client methods.
+// When I specify `s.As(XRHIDUser)`, I am indicating that
+// the API call will inject a `x-rh-identity` header of a User
+// type. Below the meaning for each value:
+//   - XRHIDNothing that match with a field not initialized, and
+//     indicate to the client to don't touch anything in regarding
+//     to the `x-rh-identity` header. This could be useful when
+//     test cases are specified in a table, and all are using the
+//     same type of XRHID set in advance.
+//   - XRHIDNone that indicate to be sure the `x-rh-identity` header
+//     does not exist in the request. So we can test scenarios
+//     where we are sure the `x-rh-identity` header is not present.
+//   - XRHIDUser that indicates to inject a 'x-rh-identity` which
+//     type is User.
+//   - XRHIDServiceAccount that indicates to inject a `x-rh-identity`
+//     which type is a service account.
+//   - XRHIDSystem that indicates to inject a `x-rh-identity` which
+//     type is a System.
+const (
+	// XRHIDNothing
+	XRHIDNothing XRHIDProfile = ""
+	// XRHIDNone
+	XRHIDNone XRHIDProfile = "None"
+	// XRHIDUser
+	XRHIDUser XRHIDProfile = "User"
+	// XRHIDServiceAccount
+	XRHIDServiceAccount XRHIDProfile = "ServiceAccount"
+	// XRHIDSystem
+	XRHIDSystem XRHIDProfile = "System"
+)
+
 // SuiteBase represents the base Suite to be used for smoke tests, this
 // start the services before run the smoke tests.
 // TODO the smoke tests cannot be executed in parallel yet, an alternative
@@ -45,10 +79,12 @@ import (
 // would provide data partition between the tests.
 type SuiteBase struct {
 	suite.Suite
-	cfg         *config.Config
-	OrgID       string
-	UserXRHID   identity.XRHID
-	SystemXRHID identity.XRHID
+	cfg                 *config.Config
+	OrgID               string
+	userXRHID           identity.XRHID
+	systemXRHID         identity.XRHID
+	serviceAccountXRHID identity.XRHID
+	currentXRHID        *identity.XRHID
 
 	cancel        context.CancelFunc
 	svc           service.ApplicationService
@@ -87,8 +123,10 @@ func (s *SuiteBase) SetupTest() {
 		}
 	}()
 	s.OrgID = strconv.Itoa(int(builder_helper.GenRandNum(1, 99999999)))
-	s.UserXRHID = builder_api.NewUserXRHID().WithOrgID(s.OrgID).WithActive(true).Build()
-	s.SystemXRHID = builder_api.NewSystemXRHID().WithOrgID(s.OrgID).Build()
+	s.userXRHID = builder_api.NewUserXRHID().WithOrgID(s.OrgID).WithActive(true).Build()
+	s.systemXRHID = builder_api.NewSystemXRHID().WithOrgID(s.OrgID).Build()
+	s.serviceAccountXRHID = builder_api.NewServiceAccountXRHID().WithOrgID(s.OrgID).Build()
+	s.currentXRHID = nil
 	s.IpaHccVersion = header.NewXRHIDMVersion("1.0.0", "4.19.0", "9.3", "redhat-9.3")
 	s.WaitReady(s.cfg)
 }
@@ -104,11 +142,36 @@ func (s *SuiteBase) TearDownTest() {
 	s.wg.Wait()
 }
 
+func (s *SuiteBase) As(profile XRHIDProfile) {
+	switch profile {
+	case XRHIDNone:
+		{
+			s.currentXRHID = nil
+		}
+	case XRHIDUser:
+		{
+			s.currentXRHID = &s.userXRHID
+		}
+	case XRHIDServiceAccount:
+		{
+			s.currentXRHID = &s.serviceAccountXRHID
+		}
+	case XRHIDSystem:
+		{
+			s.currentXRHID = &s.systemXRHID
+		}
+	default:
+		{
+			panic(fmt.Sprintf("XRHID profile = '%s' not supported", profile))
+		}
+	}
+}
+
 // WaitReady poll the ready healthcheck until the response is http.StatusOK
 // cfg is the current configuration to use for the application.
 func (s *SuiteBase) WaitReady(cfg *config.Config) {
 	if cfg == nil {
-		panic("cfg is nil")
+		panic("'cfg' is nil")
 	}
 	header := http.Header{}
 	for i := 0; i < 300; i++ {
@@ -161,7 +224,6 @@ func (s *SuiteBase) addToken(hdr *http.Header, token string) {
 func (s *SuiteBase) CreateTokenWithResponse() (*http.Response, error) {
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/domains/token"
-	s.addXRHIDHeader(&hdr, &s.UserXRHID)
 	s.addRequestID(&hdr, "test_create_token")
 	resp, err := s.DoRequest(
 		http.MethodPost,
@@ -200,7 +262,6 @@ func (s *SuiteBase) CreateToken() (*public.DomainRegTokenResponse, error) {
 
 func (s *SuiteBase) RegisterIpaDomainWithResponse(token string, domain *public.Domain) (*http.Response, error) {
 	hdr := http.Header{}
-	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
 	s.addXRHIpaClientVersionHeader(&hdr, s.IpaHccVersion)
 	s.addToken(&hdr, token)
 	s.addRequestID(&hdr, "test_register_domain")
@@ -239,14 +300,14 @@ func (s *SuiteBase) RegisterIpaDomain(token string, domain *public.Domain) (*pub
 	return createdDomain, nil
 }
 
-func (s *SuiteBase) readDomainWithResponse(xrhid *identity.XRHID, domainID uuid.UUID) (*http.Response, error) {
-	if xrhid == nil {
-		panic("'xrhid' is nil")
-	}
+// ReadDomainWithResponse is a helper function to read a domain with the API
+// for a rhel-idm domain using the OrgID assigned to the unit test.
+// Return the http response and nil, or nil and the error during
+// the request.
+func (s *SuiteBase) ReadDomainWithResponse(domainID uuid.UUID) (*http.Response, error) {
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/domains/" + domainID.String()
 	method := http.MethodGet
-	s.addXRHIDHeader(&hdr, xrhid)
 	s.addRequestID(&hdr, "test_read_domain")
 	resp, err := s.DoRequest(
 		method,
@@ -257,49 +318,13 @@ func (s *SuiteBase) readDomainWithResponse(xrhid *identity.XRHID, domainID uuid.
 	return resp, err
 }
 
-func (s *SuiteBase) UserReadDomainWithResponse(domainID uuid.UUID) (*http.Response, error) {
-	return s.readDomainWithResponse(&s.UserXRHID, domainID)
-}
-
-// UserReadDomain is a helper function to read a domain with the API
+// ReadDomain is a helper function to read a domain with the API
 // for a rhel-idm domain using the OrgID assigned to the unit test.
-// Return the token response or error.
-func (s *SuiteBase) UserReadDomain(domainID uuid.UUID) (*public.Domain, error) {
+// Return the Domain object unserialized and nil error on success,
+// or nil and the error filed with the cause.
+func (s *SuiteBase) ReadDomain(domainID uuid.UUID) (*public.Domain, error) {
 	url := s.DefaultPublicBaseURL() + "/domains/" + domainID.String()
-	resp, err := s.UserReadDomainWithResponse(domainID)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
-	}
-
-	var data []byte
-	data, err = io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("failure when reading body for POST %s because an empty response", url)
-	}
-
-	var domain *public.Domain = &public.Domain{}
-	err = json.Unmarshal(data, domain)
-	if err != nil {
-		return nil, fmt.Errorf("failure when unmarshalling the information for reading a domain: %w", err)
-	}
-
-	return domain, nil
-}
-
-func (s *SuiteBase) SystemReadDomainWithResponse(domainID uuid.UUID) (*http.Response, error) {
-	return s.readDomainWithResponse(&s.SystemXRHID, domainID)
-}
-
-// SystemReadDomain is a helper function to read a domain with the API
-// for a rhel-idm domain using the OrgID assigned to the unit test.
-// Return the token response or error.
-func (s *SuiteBase) SystemReadDomain(domainID uuid.UUID) (*public.Domain, error) {
-	url := s.DefaultPublicBaseURL() + "/domains/" + domainID.String()
-	resp, err := s.SystemReadDomainWithResponse(domainID)
+	resp, err := s.ReadDomainWithResponse(domainID)
 	if err != nil {
 		return nil, err
 	}
@@ -331,7 +356,6 @@ func (s *SuiteBase) ListDomainWithResponse(offset int, limit int) (*http.Respons
 	q.Add("offset", "0")
 	q.Add("limit", "10")
 	url := req.URL.String() + "?" + q.Encode()
-	s.addXRHIDHeader(&hdr, &s.UserXRHID)
 	s.addRequestID(&hdr, "test_list_domain")
 	resp, err := s.DoRequest(
 		method,
@@ -380,7 +404,6 @@ func (s *SuiteBase) DeleteDomainWithResponse(domainID uuid.UUID) (*http.Response
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/domains/" + domainID.String()
 	method := http.MethodDelete
-	s.addXRHIDHeader(&hdr, &s.UserXRHID)
 	s.addRequestID(&hdr, "test_delete_domain")
 	resp, err := s.DoRequest(
 		method,
@@ -412,7 +435,6 @@ func (s *SuiteBase) UpdateDomainWithResponse(domainID string, domain *public.Upd
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/domains/" + domainID
 	method := http.MethodPut
-	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
 	s.addRequestID(&hdr, "test_update_domain")
 	s.addXRHIpaClientVersionHeader(&hdr, s.IpaHccVersion)
 	resp, err := s.DoRequest(
@@ -451,7 +473,6 @@ func (s *SuiteBase) PatchDomainWithResponse(domainID string, domain *public.Upda
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/domains/" + domainID
 	method := http.MethodPatch
-	s.addXRHIDHeader(&hdr, &s.UserXRHID)
 	s.addRequestID(&hdr, "test_patch_domain")
 	resp, err := s.DoRequest(
 		method,
@@ -485,11 +506,10 @@ func (s *SuiteBase) PatchDomain(domainID string, domain *public.UpdateDomainUser
 	return result, nil
 }
 
-func (s *SuiteBase) SystemHostConfWithResponse(inventoryID string, fqdn string, hostconf *public.HostConf) (*http.Response, error) {
+func (s *SuiteBase) HostConfWithResponse(inventoryID string, fqdn string, hostconf *public.HostConf) (*http.Response, error) {
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/host-conf/" + inventoryID + "/" + fqdn
 	method := http.MethodPost
-	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
 	s.addRequestID(&hdr, "test_system_host_conf")
 	body := hostconf
 	resp, err := s.DoRequest(
@@ -501,9 +521,9 @@ func (s *SuiteBase) SystemHostConfWithResponse(inventoryID string, fqdn string, 
 	return resp, err
 }
 
-func (s *SuiteBase) SystemHostConf(inventoryID string, fqdn string, hostconf *public.HostConf) (*public.HostConfResponse, error) {
+func (s *SuiteBase) HostConf(inventoryID string, fqdn string, hostconf *public.HostConf) (*public.HostConfResponse, error) {
 	url := s.DefaultPublicBaseURL() + "/host-conf/" + inventoryID + "/" + fqdn
-	resp, err := s.SystemHostConfWithResponse(inventoryID, fqdn, hostconf)
+	resp, err := s.HostConfWithResponse(inventoryID, fqdn, hostconf)
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
@@ -521,12 +541,11 @@ func (s *SuiteBase) SystemHostConf(inventoryID string, fqdn string, hostconf *pu
 	return result, nil
 }
 
-func (s *SuiteBase) SystemSigningKeysWithResponse() (*http.Response, error) {
+func (s *SuiteBase) ReadSigningKeysWithResponse() (*http.Response, error) {
 	hdr := http.Header{}
 	url := s.DefaultPublicBaseURL() + "/signing_keys"
 	method := http.MethodGet
-	s.addXRHIDHeader(&hdr, &s.SystemXRHID)
-	s.addRequestID(&hdr, "test_system_signing_keys")
+	s.addRequestID(&hdr, "test_read_signing_keys")
 	// TODO Fill this content
 	resp, err := s.DoRequest(
 		method,
@@ -537,10 +556,10 @@ func (s *SuiteBase) SystemSigningKeysWithResponse() (*http.Response, error) {
 	return resp, err
 }
 
-func (s *SuiteBase) SystemSigningKeys() (*public.SigningKeysResponse, error) {
+func (s *SuiteBase) ReadSigningKeys() (*public.SigningKeysResponse, error) {
 	url := s.DefaultPublicBaseURL() + "/signing_keys"
 
-	resp, err := s.SystemSigningKeysWithResponse()
+	resp, err := s.ReadSigningKeysWithResponse()
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("failure when POST %s: expected '%d' but got '%d'", url, http.StatusOK, resp.StatusCode)
 	}
@@ -592,6 +611,7 @@ func (s *SuiteBase) RunTestCase(testCase *TestCase) {
 	}
 
 	// WHEN
+	s.As(testCase.Given.XRHIDProfile)
 	resp, err = s.DoRequest(testCase.Given.Method, testCase.Given.URL, testCase.Given.Header, testCase.Given.Body)
 
 	// THEN
@@ -660,7 +680,7 @@ func (s *SuiteBase) DefaultPrivateBaseURL() string {
 // Return the http.Response object and nil when the endpoint is reached out,
 // or nil and a non error when some non API situation happens trying to reach
 // out the endpoint.
-func (s *SuiteBase) DoRequest(method string, url string, header http.Header, body any) (*http.Response, error) {
+func (s *SuiteBase) DoRequest(method string, url string, hdr http.Header, body any) (*http.Response, error) {
 	var reader io.Reader = nil
 	client := &http.Client{}
 
@@ -685,8 +705,14 @@ func (s *SuiteBase) DoRequest(method string, url string, header http.Header, bod
 	}
 
 	req.Header.Set("Content-Type", "application/json")
-	for key, value := range header {
+	for key, value := range hdr {
 		req.Header.Set(key, strings.Join(value, "; "))
+	}
+	// Override
+	if s.currentXRHID != nil {
+		s.addXRHIDHeader(&req.Header, s.currentXRHID)
+	} else {
+		req.Header.Del(header.HeaderXRHID)
 	}
 
 	resp, err := client.Do(req)
@@ -701,6 +727,8 @@ type BodyFunc func(t *testing.T, body []byte) bool
 
 // TestCaseGiven represents the requirements for the smoke test to implement.
 type TestCaseGiven struct {
+	// XRHIDProfile is a string that represent the XRHID to use if any.
+	XRHIDProfile XRHIDProfile
 	// Method represents the http method for the request.
 	Method string
 	// URL represents the url for the route to test.

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -71,6 +71,15 @@ const (
 	XRHIDSystem XRHIDProfile = "System"
 )
 
+type RBACProfile string
+
+const (
+	RBACSuperAdmin RBACProfile = mock_rbac.ProfileSuperAdmin
+	RBACAdmin      RBACProfile = mock_rbac.ProfileDomainAdmin
+	RBACReadOnly   RBACProfile = mock_rbac.ProfileDomainReadOnly
+	RBACNoPermis   RBACProfile = mock_rbac.ProfileDomainNoPerms
+)
+
 // SuiteBase represents the base Suite to be used for smoke tests, this
 // start the services before run the smoke tests.
 // TODO the smoke tests cannot be executed in parallel yet, an alternative
@@ -119,7 +128,7 @@ func (s *SuiteBase) SetupTest() {
 	require.NotNil(t, s.RbacMock)
 	require.NoError(t, s.svcRbac.Start())
 	require.NoError(t, s.RbacMock.WaitAddress(3*time.Second))
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainAdmin])
+	s.As(RBACSuperAdmin)
 	rbacClient, err := client_rbac.NewClient("idmsvc", client_rbac.WithBaseURL(s.cfg.Clients.RbacBaseURL))
 	if err != nil {
 		panic(err)
@@ -153,7 +162,28 @@ func (s *SuiteBase) TearDownTest() {
 	s.wg.Wait()
 }
 
-func (s *SuiteBase) As(profile XRHIDProfile) {
+func (s *SuiteBase) As(profiles ...any) {
+	for i := range profiles {
+		switch t := profiles[i].(type) {
+		case RBACProfile:
+			{
+				s.asRBACProfile(t)
+			}
+		case XRHIDProfile:
+			{
+				s.asXRHIDProfile(t)
+			}
+		default:
+			panic("profile has an unsupported type")
+		}
+	}
+}
+
+func (s *SuiteBase) asRBACProfile(profile RBACProfile) {
+	s.RbacMock.SetPermissions(mock_rbac.Profiles[string(profile)])
+}
+
+func (s *SuiteBase) asXRHIDProfile(profile XRHIDProfile) {
 	switch profile {
 	case XRHIDNone:
 		{

--- a/internal/test/smoke/system_endpoints_test.go
+++ b/internal/test/smoke/system_endpoints_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/datastore"
-	mock_rbac "github.com/podengo-project/idmsvc-backend/internal/infrastructure/service/impl/mock/rbac/impl"
 	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -86,13 +85,12 @@ func (s *SuiteSystemEndpoints) prepareDomainIpa(t *testing.T) {
 
 func (s *SuiteSystemEndpoints) TestHostConfExecute() {
 	t := s.T()
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.As(RBACSuperAdmin)
 	s.prepareDomainIpa(t)
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
 
 	t.Log("Calling SystemHostConfWithResponse")
 	domainType := public.RhelIdm
-	s.As(XRHIDSystem)
+	s.As(XRHIDSystem, RBACNoPermis)
 	res, err := s.HostConfWithResponse(
 		s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String(),
 		"client."+s.domain.DomainName,
@@ -107,10 +105,9 @@ func (s *SuiteSystemEndpoints) TestHostConfExecute() {
 
 func (s *SuiteSystemEndpoints) TestReadSigningKeys() {
 	t := s.T()
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.As(RBACSuperAdmin)
 	s.prepareDomainIpa(t)
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
-	s.As(XRHIDSystem)
+	s.As(RBACNoPermis, XRHIDSystem)
 	res, err := s.ReadSigningKeysWithResponse()
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -119,10 +116,9 @@ func (s *SuiteSystemEndpoints) TestReadSigningKeys() {
 
 func (s *SuiteSystemEndpoints) TestSystemReadDomain() {
 	t := s.T()
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.As(RBACSuperAdmin)
 	s.prepareDomainIpa(t)
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
-	s.As(XRHIDSystem)
+	s.As(RBACNoPermis, XRHIDSystem)
 	res, err := s.ReadDomainWithResponse(*s.domain.DomainId)
 	require.NoError(t, err)
 	require.NotNil(t, res)
@@ -131,13 +127,12 @@ func (s *SuiteSystemEndpoints) TestSystemReadDomain() {
 
 func (s *SuiteSystemEndpoints) TestSystemUpdateDomain() {
 	t := s.T()
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileSuperAdmin])
+	s.As(RBACSuperAdmin)
 	s.prepareDomainIpa(t)
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
 	subscriptionManagerID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
 	domainID := s.domain.DomainId.String()
 
-	s.As(XRHIDSystem)
+	s.As(RBACNoPermis, XRHIDSystem)
 	res, err := s.UpdateDomainWithResponse(
 		domainID,
 		builder_api.NewUpdateDomainAgent("test.example").
@@ -162,18 +157,15 @@ func (s *SuiteSystemEndpoints) TestSystemCreateDomain() {
 	t := s.T()
 	var err error
 
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainAdmin])
-
 	// Create a token to register a domain
-	s.As(XRHIDUser)
+	s.As(RBACAdmin, XRHIDUser)
 	s.token, err = s.CreateToken()
 	require.NoError(t, err)
 	require.NotNil(t, s.token)
 	require.NotEqual(t, "", s.token.DomainToken)
 
 	// Create the domains entry
-	s.RbacMock.SetPermissions(mock_rbac.Profiles[mock_rbac.ProfileDomainNoPerms])
-	s.As(XRHIDSystem)
+	s.As(RBACNoPermis, XRHIDSystem)
 	s.domain, err = s.RegisterIpaDomain(s.token.DomainToken,
 		builder_api.NewDomain("test.example").
 			WithDomainID(&s.token.DomainId).

--- a/internal/test/smoke/token_create_test.go
+++ b/internal/test/smoke/token_create_test.go
@@ -82,18 +82,16 @@ func (s *SuiteTokenCreate) bodyExpectationTestToken(t *testing.T, body *public.D
 }
 
 func (s *SuiteTokenCreate) TestToken() {
-	xrhidEncoded := header.EncodeXRHID(&s.UserXRHID)
-
 	// Prepare the tests
 	testCases := []TestCase{
 		{
 			Name: "TestToken",
 			Given: TestCaseGiven{
-				Method: http.MethodPost,
-				URL:    s.DefaultPublicBaseURL() + "/domains/token",
+				XRHIDProfile: XRHIDUser,
+				Method:       http.MethodPost,
+				URL:          s.DefaultPublicBaseURL() + "/domains/token",
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      {xrhidEncoded},
 				},
 				Body: public.DomainRegTokenRequest{
 					DomainType: "rhel-idm",


### PR DESCRIPTION
This PR add `As` semantics so it can be used for
set the RBACProfile or XRHIDProfile; we can provide
several in the list of arguments, and they are applied
from left to right; the last value is the one that take
effect. More details below:

About XRHID:

- As(XRHIDServiceAccount): it indicates that following
  API operations will use a service account XRHID.
- As(XRHIDUser): it indicates that following API
  operations will use a user XRHID.
- As(XRHIDSystem): it indicates that following API
  operations will use a System XRHID.
- As(XRHIDNone): it indicates that following API operations
  will not add any XRHID header. It forces to delete the
  header when the request is made.
- As(XRHIDNothing): it indicates that following API
  operations will not add / delete any XRHID header.

About RBAC:

- As(RBACSuperAdmin): tell to the rbac mock to return super admin
  permissions for the following requests.
- As(RBACAdmin): tell to the rbac mock to return admin permissions
  for the following requests.
- As(RBACReadOnly): tell to the rbac mock to return read only
  permissions for the following requests.
- As(RBACNoPerms): tell to the rbac mock to return empty list
  of permissions for the following requests.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/235