### PR TITLE
test(HMS-3968): cover service accounts in smoke

### DIFF
--- a/internal/test/smoke/domain_list_test.go
+++ b/internal/test/smoke/domain_list_test.go
@@ -118,6 +118,9 @@ func (s *SuiteListDomains) assertInDomains(t *testing.T, data []public.ListDomai
 
 func (s *SuiteListDomains) TestListDomains() {
 	t := s.T()
+
+	xrhids := []XRHIDProfile{XRHIDUser, XRHIDServiceAccount}
+
 	req, err := http.NewRequest(http.MethodGet, s.DefaultPublicBaseURL()+"/domains", nil)
 	require.NoError(t, err)
 	q := req.URL.Query()
@@ -140,9 +143,8 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=0&limit=10 case",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodGet,
-				URL:          url1,
+				Method: http.MethodGet,
+				URL:    url1,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 				},
@@ -180,9 +182,8 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=40&limit=10 case",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodGet,
-				URL:          url2,
+				Method: http.MethodGet,
+				URL:    url2,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 				},
@@ -221,9 +222,8 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: offset=20&limit=10 case",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodGet,
-				URL:          url3,
+				Method: http.MethodGet,
+				URL:    url3,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 				},
@@ -262,9 +262,8 @@ func (s *SuiteListDomains) TestListDomains() {
 		{
 			Name: "TestListDomains: no params",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodGet,
-				URL:          url4,
+				Method: http.MethodGet,
+				URL:    url4,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 				},
@@ -303,5 +302,10 @@ func (s *SuiteListDomains) TestListDomains() {
 	}
 
 	// Execute the test cases
-	s.RunTestCases(testCases)
+	for _, xrhid := range xrhids {
+		for i := range testCases {
+			testCases[i].Given.XRHIDProfile = xrhid
+		}
+		s.RunTestCases(testCases)
+	}
 }

--- a/internal/test/smoke/domain_patch_user_test.go
+++ b/internal/test/smoke/domain_patch_user_test.go
@@ -28,15 +28,15 @@ func (s *SuiteDomainUpdateUser) TearDownTest() {
 func (s *SuiteDomainUpdateUser) TestPatchDomain() {
 	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId.String())
 	patchedDomain := builder_api.NewUpdateDomainUserRequest().Build()
+	xrhids := []XRHIDProfile{XRHIDUser, XRHIDServiceAccount}
 
 	// Prepare the tests
 	testCases := []TestCase{
 		{
 			Name: "TestPatchDomain",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodPatch,
-				URL:          url,
+				Method: http.MethodPatch,
+				URL:    url,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_domain_patch"},
 				},
@@ -66,5 +66,10 @@ func (s *SuiteDomainUpdateUser) TestPatchDomain() {
 	}
 
 	// Execute the test cases
-	s.RunTestCases(testCases)
+	for _, xrhid := range xrhids {
+		for i := range testCases {
+			testCases[i].Given.XRHIDProfile = xrhid
+		}
+		s.RunTestCases(testCases)
+	}
 }

--- a/internal/test/smoke/domain_read_test.go
+++ b/internal/test/smoke/domain_read_test.go
@@ -27,17 +27,17 @@ func (s *SuiteReadDomain) TearDownTest() {
 }
 
 func (s *SuiteReadDomain) TestReadDomain() {
-	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId)
+	url := fmt.Sprintf("%s/%s/%s", s.DefaultPublicBaseURL(), "domains", s.Domains[0].DomainId.String())
 	domainName := builder_helper.GenRandDomainName(2)
+	xrhids := []XRHIDProfile{XRHIDUser, XRHIDServiceAccount, XRHIDSystem}
 
 	// Prepare the tests
 	testCases := []TestCase{
 		{
 			Name: "TestReadDomain",
 			Given: TestCaseGiven{
-				XRHIDProfile: XRHIDUser,
-				Method:       http.MethodGet,
-				URL:          url,
+				Method: http.MethodGet,
+				URL:    url,
 				Header: http.Header{
 					header.HeaderXRequestID: {"test_token"},
 				},
@@ -59,6 +59,11 @@ func (s *SuiteReadDomain) TestReadDomain() {
 		},
 	}
 
-	// Execute the test cases
-	s.RunTestCases(testCases)
+	for _, xrhid := range xrhids {
+		for i := range testCases {
+			testCases[i].Given.XRHIDProfile = xrhid
+		}
+		// Execute the test cases
+		s.RunTestCases(testCases)
+	}
 }

--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -117,7 +117,7 @@ func (s *SuiteRbacPermission) doTestDomainList(t *testing.T) int {
 func (s *SuiteRbacPermission) commonRun(rbacProfile RBACProfile, testCases []TestCasePermission) {
 	t := s.T()
 
-	xrhidProfiles := []XRHIDProfile{XRHIDUser}
+	xrhidProfiles := []XRHIDProfile{XRHIDUser, XRHIDServiceAccount}
 	for _, testCase := range testCases {
 		for _, xrhidProfile := range xrhidProfiles {
 			t.Logf("rbacProfile=%s, xrhidProfile=%s: %s", rbacProfile, xrhidProfile, testCase.Name)

--- a/internal/test/smoke/rbac_permission_test.go
+++ b/internal/test/smoke/rbac_permission_test.go
@@ -116,7 +116,6 @@ func (s *SuiteRbacPermission) doTestDomainList(t *testing.T) int {
 
 func (s *SuiteRbacPermission) commonRun(rbacProfile RBACProfile, testCases []TestCasePermission) {
 	t := s.T()
-
 	xrhidProfiles := []XRHIDProfile{XRHIDUser, XRHIDServiceAccount}
 	for _, testCase := range testCases {
 		for _, xrhidProfile := range xrhidProfiles {
@@ -191,7 +190,7 @@ func (s *SuiteRbacPermission) TestReadPermission() {
 			Expected: http.StatusUnauthorized,
 		},
 		{
-			Name:     "Test Update User idmsvc:domain:update",
+			Name:     "Test idmsvc:domain:update for patching",
 			Given:    s.prepareDomainIpa,
 			Then:     s.doTestDomainIpaPatch,
 			Expected: http.StatusUnauthorized,
@@ -227,7 +226,7 @@ func (s *SuiteRbacPermission) TestNoPermission() {
 			Expected: http.StatusUnauthorized,
 		},
 		{
-			Name:     "Test Update User idmsvc:domain:update",
+			Name:     "Test idmsvc:domain:update for patching",
 			Given:    s.prepareDomainIpa,
 			Then:     s.doTestDomainIpaPatch,
 			Expected: http.StatusUnauthorized,

--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -73,7 +73,6 @@ func (s *SuiteRegisterDomain) TearDownTest() {
 }
 
 func (s *SuiteRegisterDomain) TestRegisterDomain() {
-	xrhidEncoded := header.EncodeXRHID(&s.systemXRHID)
 	url := s.DefaultPublicBaseURL() + "/domains"
 	domainName := builder_helper.GenRandDomainName(2)
 	bodyRequest := builder_api.
@@ -90,7 +89,6 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 				URL:          url,
 				Header: http.Header{
 					header.HeaderXRequestID:              {"test_token"},
-					header.HeaderXRHID:                   {xrhidEncoded},
 					header.HeaderXRHIDMRegistrationToken: {s.token.DomainToken},
 					header.HeaderXRHIDMVersion: {
 						header.EncodeXRHIDMVersion(
@@ -108,7 +106,6 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 			Expected: TestCaseExpect{
 				StatusCode: http.StatusCreated,
 				Header: http.Header{
-					// FIXME Avoid hardcode the key name of the header
 					header.HeaderXRequestID: {"test_token"},
 					header.HeaderXRHID:      nil,
 				},

--- a/internal/test/smoke/suite_base_one_domain_test.go
+++ b/internal/test/smoke/suite_base_one_domain_test.go
@@ -33,9 +33,9 @@ func (s *SuiteBaseWithDomain) SetupTest() {
 		s.FailNow("error creating token")
 	}
 	domainName = fmt.Sprintf("domain%d.test", i)
+	domainRequest := builder_api.NewDomain(domainName).Build()
 	s.As(XRHIDSystem)
-	domain, err = s.RegisterIpaDomain(token.DomainToken, builder_api.NewDomain(domainName).Build())
-	if err != nil {
+	if domain, err = s.RegisterIpaDomain(token.DomainToken, domainRequest); err != nil {
 		s.FailNow("error creating rhel-idm domain")
 	}
 	s.Domains = append(s.Domains, domain)


### PR DESCRIPTION
This change add service accounts to the rbac smoke
tests, and complete the existing smoke tests to
provide coverage for the service accounts where
required.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/232