### PR TITLE
feat(HMS-3968): add service account to enforcement

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity_test.go
+++ b/internal/infrastructure/middleware/enforce_identity_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
 	"github.com/openlyinc/pointy"
@@ -57,47 +58,6 @@ func helperNewEchoEnforceIdentity(m echo.MiddlewareFunc) *echo.Echo {
 	e.Add("GET", testPath, h)
 
 	return e
-}
-
-// FIXME
-func helperGenerateUserIdentity(orgId string, username string) *identity.XRHID {
-	return &identity.XRHID{
-		Identity: identity.Identity{
-			AccountNumber: "12345",
-			OrgID:         orgId,
-			Internal: identity.Internal{
-				OrgID: orgId,
-			},
-			Type: "User",
-			User: &identity.User{
-				Username: username,
-				UserID:   "12345",
-				Active:   true,
-				Internal: true,
-				OrgAdmin: true,
-				Locale:   "en",
-			},
-		},
-	}
-}
-
-func helperGenerateSystemIdentity(orgId string, commonName string) *identity.XRHID {
-	// See: https://github.com/coderbydesign/identity-schemas/blob/add-validator/3scale/identities/cert.json
-	return &identity.XRHID{
-		Identity: identity.Identity{
-			OrgID:         orgId,
-			AccountNumber: "11111",
-			AuthType:      "cert-auth",
-			Type:          "System",
-			Internal: identity.Internal{
-				OrgID: orgId,
-			},
-			System: &identity.System{
-				CommonName: commonName,
-				CertType:   "system",
-			},
-		},
-	}
 }
 
 func helperSkipper(data bool) echo_middleware.Skipper {
@@ -335,6 +295,16 @@ func TestEnforceUserPredicate(t *testing.T) {
 			Expected: fmt.Errorf("'Identity.Type=System' is not 'User'"),
 		},
 		{
+			Name: "Identity with User nil",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type: "User",
+					User: nil,
+				},
+			},
+			Expected: fmt.Errorf("'Identity.User' is nil"),
+		},
+		{
 			Name: "Identity with disabled user",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
@@ -410,6 +380,16 @@ func TestEnforceSystemPredicate(t *testing.T) {
 			Expected: fmt.Errorf("'Identity.Type' must be 'System'"),
 		},
 		{
+			Name: "'Identity.System' is not nil",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:   "System",
+					System: nil,
+				},
+			},
+			Expected: fmt.Errorf("'Identity.System' is nil"),
+		},
+		{
 			Name: "'CertType' is not 'system'",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
@@ -453,7 +433,6 @@ func TestEnforceSystemPredicate(t *testing.T) {
 		t.Log(testCase.Name)
 		err := EnforceSystemPredicate(testCase.Given)
 		if testCase.Expected != nil {
-			require.NotNil(t, err)
 			assert.EqualError(t, err, testCase.Expected.Error())
 		} else {
 			assert.Nil(t, err)
@@ -489,14 +468,24 @@ func TestEnforceIdentityOrder(t *testing.T) {
 				},
 			},
 		))
-	// xrhid := `{"identity":{"org_id":"12345","internal":{"org_id":"12345"},"user":{"username":"sapheaded","email":"hooked@bought.biz","first_name":"Leslie","last_name":"Jacobs","is_active":false,"is_org_admin":false,"is_internal":false,"locale":"km","user_id":"jeweljeweler"},"system":{},"associate":{"Role":null,"email":"","givenName":"","rhatUUID":"","surname":""},"x509":{"subject_dn":"","issuer_dn":""},"service_account":{"client_id":"","username":""},"type":"User","auth_type":"basic-auth"},"entitlements":null}`
-	xrhid := header.EncodeXRHID(helperGenerateUserIdentity("12345", "test"))
+	xrhid := &identity.XRHID{}
+	*xrhid = api.NewUserXRHID().
+		WithAccountNumber("12345").
+		WithOrgID("12345").
+		WithUsername("test").
+		WithUserID("12345").
+		WithActive(true).
+		WithInternal(true).
+		WithOrgAdmin(true).
+		WithLocale("en").
+		Build()
+	xrhidRaw := header.EncodeXRHID(xrhid)
 	for i := 0; i < 1000; i++ {
 		order["first"] = time.Time{}
 		order["second"] = time.Time{}
 		res := httptest.NewRecorder()
 		req := httptest.NewRequest(http.MethodGet, "/test", nil)
-		req.Header.Add(header.HeaderXRHID, xrhid)
+		req.Header.Add(header.HeaderXRHID, xrhidRaw)
 		e.ServeHTTP(res, req)
 
 		// Check expectations
@@ -572,6 +561,102 @@ func TestNewEnforceOr(t *testing.T) {
 		err := predicate(nil)
 		if testCase.Expected != nil {
 			require.Error(t, err)
+			assert.EqualError(t, err, testCase.Expected.Error())
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestEnforceServiceAccountPredicate(t *testing.T) {
+	type TestCase struct {
+		Name     string
+		Given    *identity.XRHID
+		Expected error
+	}
+	testCases := []TestCase{
+		{
+			Name:     "nil argument",
+			Given:    nil,
+			Expected: fmt.Errorf("'data' cannot be nil"),
+		},
+		{
+			Name: "'Identity.Type' is not 'ServiceAccount'",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type: "System",
+				},
+			},
+			Expected: fmt.Errorf("'Identity.Type' must be 'ServiceAccount'"),
+		},
+		{
+			Name: "'Identity.AuthType' must be 'jwt-auth'",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:     "ServiceAccount",
+					AuthType: "cert",
+				},
+			},
+			Expected: fmt.Errorf("'Identity.AuthType' is not 'jwt-auth'"),
+		},
+		{
+			Name: "'Identity.ServiceAccount' is nil",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:           "ServiceAccount",
+					AuthType:       "jwt-auth",
+					ServiceAccount: nil,
+				},
+			},
+			Expected: fmt.Errorf("'Identity.ServiceAccount' is nil"),
+		},
+		{
+			Name: "'Identity.ServiceAccount.ClientId' is empty",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:     "ServiceAccount",
+					AuthType: "jwt-auth",
+					ServiceAccount: &identity.ServiceAccount{
+						ClientId: "",
+					},
+				},
+			},
+			Expected: fmt.Errorf("'Identity.ServiceAccount.ClientId' is empty"),
+		},
+		{
+			Name: "'Identity.ServiceAccount.Username' is empty",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:     "ServiceAccount",
+					AuthType: "jwt-auth",
+					ServiceAccount: &identity.ServiceAccount{
+						ClientId: uuid.NewString(),
+						Username: "",
+					},
+				},
+			},
+			Expected: fmt.Errorf("'Identity.ServiceAccount.Username' is empty"),
+		},
+		{
+			Name: "Success ServiceAccount predicate",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type:     "ServiceAccount",
+					AuthType: "jwt-auth",
+					ServiceAccount: &identity.ServiceAccount{
+						ClientId: uuid.NewString(),
+						Username: "test-user",
+					},
+				},
+			},
+			Expected: nil,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+		err := EnforceServiceAccountPredicate(testCase.Given)
+		if testCase.Expected != nil {
 			assert.EqualError(t, err, testCase.Expected.Error())
 		} else {
 			assert.NoError(t, err)

--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -153,6 +153,7 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 					Predicate: middleware.NewEnforceOr(
 						middleware.EnforceSystemPredicate,
 						middleware.EnforceUserPredicate,
+						middleware.EnforceServiceAccountPredicate,
 					),
 				},
 			},
@@ -169,13 +170,16 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 			},
 		},
 	)
-	userIdentityMiddleware := middleware.EnforceIdentityWithConfig(
+	userAndSAIdentityMiddleware := middleware.EnforceIdentityWithConfig(
 		&middleware.IdentityConfig{
 			Skipper: skipperUserPredicate,
 			Predicates: []middleware.IdentityPredicateEntry{
 				{
-					Name:      "user-identity",
-					Predicate: middleware.EnforceUserPredicate,
+					Name: "user-and-sa-identity",
+					Predicate: middleware.NewEnforceOr(
+						middleware.EnforceUserPredicate,
+						middleware.EnforceServiceAccountPredicate,
+					),
 				},
 			},
 		},
@@ -213,7 +217,7 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 		fakeIdentityMiddleware,
 		mixedIdentityMiddleware,
 		systemIdentityMiddleware,
-		userIdentityMiddleware,
+		userAndSAIdentityMiddleware,
 		rbacMiddleware,
 		metricsMiddleware,
 		echo_middleware.Secure(),

--- a/internal/test/builder/api/builder_user_xrhid.go
+++ b/internal/test/builder/api/builder_user_xrhid.go
@@ -21,6 +21,9 @@ type UserXRHID interface {
 	WithUsername(value string) UserXRHID
 	WithEmail(value string) UserXRHID
 	WithActive(value bool) UserXRHID
+	WithInternal(value bool) UserXRHID
+	WithOrgAdmin(value bool) UserXRHID
+	WithLocale(value string) UserXRHID
 	// TODO Add more methods as they are needed
 }
 
@@ -114,5 +117,20 @@ func (b *userXRHID) WithEmail(value string) UserXRHID {
 
 func (b *userXRHID) WithActive(value bool) UserXRHID {
 	b.Identity.User.Active = value
+	return b
+}
+
+func (b *userXRHID) WithInternal(value bool) UserXRHID {
+	b.Identity.User.Internal = value
+	return b
+}
+
+func (b *userXRHID) WithOrgAdmin(value bool) UserXRHID {
+	b.Identity.User.OrgAdmin = value
+	return b
+}
+
+func (b *userXRHID) WithLocale(value string) UserXRHID {
+	b.Identity.User.Locale = value
 	return b
 }

--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -253,9 +253,6 @@ func (i domainInteractor) CreateDomainToken(
 	if xrhid == nil {
 		return "", "", internal_errors.NilArgError("xrhid")
 	}
-	if xrhid.Identity.Type != "User" {
-		return "", "", fmt.Errorf("invalid identity type '%s'", xrhid.Identity.Type)
-	}
 	if params == nil {
 		return "", "", internal_errors.NilArgError("params")
 	}


### PR DESCRIPTION
This change provide a new enforcement predicate for the
service accounts so it is checked the type and some data
are provided. It adds the new enforcement to the
middleware at the service router configuration. Finally
it add unit tests to cover the new enforcement predicate.

This PR implements: https://issues.redhat.com/browse/HMS-4280

That make easier the integration of smoke and integration tests for RBAC.