### PR TITLE
chore(HMS-3968): update test scripts

### DIFF
--- a/test/scripts/common.inc
+++ b/test/scripts/common.inc
@@ -24,6 +24,10 @@ BASEDIR="$(dirname "$(dirname "${SRCDIR}")")"
 REPOBASEDIR="$(git rev-parse --show-toplevel)"
 export REPOBASEDIR
 export XRHIDGEN="${REPOBASEDIR}/tools/bin/xrhidgen"
+# "jwt-auth" "cert-auth"
+export AUTH_TYPE="${AUTH_TYPE:-jwt-auth}"
+
+XRHID_CLIENT_ID="${XRHID_CLIENT_ID:-$(uuidgen)}"
 
 if [[ ! -x "${XRHIDGEN}" ]]; then
     error "${XRHIDGEN} is missing, run 'make install-tools'"
@@ -39,9 +43,36 @@ base64nowrap() {
 }
 
 identity_user() {
-    "${XRHIDGEN}" -org-id "${ORG_ID}" user -is-active=true -is-org-admin=true -user-id test -username test | base64nowrap
+    "${XRHIDGEN}" -org-id "${ORG_ID}" -auth-type "${AUTH_TYPE}" user -is-active=true -is-org-admin=true -user-id test -username test | base64nowrap
 }
 
 identity_system() {
-    "${XRHIDGEN}" -org-id "${ORG_ID}" system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64nowrap
+    "${XRHIDGEN}" -org-id "${ORG_ID}" -auth-type "${AUTH_TYPE}" system -cn "6f324116-b3d2-11ed-8a37-482ae3863d30" -cert-type system | base64nowrap
 }
+
+identity_service_account() {
+    "${XRHIDGEN}" -org-id "${ORG_ID}" -auth-type "${AUTH_TYPE}" service-account -client-id "${XRHID_CLIENT_ID}" -username test | base64nowrap
+}
+
+XRHID_AS="${XRHID_AS:-user}"
+case "${XRHID_AS}" in
+    "user" )
+        identity_generator() {
+            identity_user "$@"
+        }
+        ;;
+    "system" )
+        identity_generator() {
+            identity_system "$@"
+        }
+        ;;
+    "service-account" )
+        identity_generator() {
+            identity_service_account "$@"
+        }
+        ;;
+    * )
+        error "XRHID_AS='${XRHID_AS}' not supported"
+        ;;
+esac
+export -f identity_generator

--- a/test/scripts/ephe-domains-delete.sh
+++ b/test/scripts/ephe-domains-delete.sh
@@ -7,7 +7,7 @@ UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_generator)}"
 export X_RH_IDM_REGISTRATION_TOKEN="${TOKEN}"
 X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION

--- a/test/scripts/ephe-domains-list.sh
+++ b/test/scripts/ephe-domains-list.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_generator)}"
 
 exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains"

--- a/test/scripts/ephe-domains-patch.sh
+++ b/test/scripts/ephe-domains-patch.sh
@@ -7,7 +7,7 @@ UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_generator)}"
 unset X_RH_IDM_REGISTRATION_TOKEN
 X_RH_IDM_VERSION="$IDM_VERSION"
 export X_RH_IDM_VERSION

--- a/test/scripts/ephe-domains-read.sh
+++ b/test/scripts/ephe-domains-read.sh
@@ -7,6 +7,6 @@ UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_generator)}"
 
 exec "${REPOBASEDIR}/scripts/curl.sh" -i "${BASE_URL}/domains/${UUID}"

--- a/test/scripts/ephe-domains-token.sh
+++ b/test/scripts/ephe-domains-token.sh
@@ -4,6 +4,6 @@ set -eo pipefail
 source "$(dirname "${BASH_SOURCE[0]}")/ephe.inc"
 
 unset X_RH_IDENTITY
-export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_user)}"
+export X_RH_FAKE_IDENTITY="${X_RH_FAKE_IDENTITY:-$(identity_generator)}"
 
 exec "${REPOBASEDIR}/scripts/curl.sh" -i -X POST -d '{"domain_type": "rhel-idm"}' "${BASE_URL}/domains/token"

--- a/test/scripts/local-domains-delete.sh
+++ b/test/scripts/local-domains-delete.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
 unset X_RH_IDM_VERSION

--- a/test/scripts/local-domains-list.sh
+++ b/test/scripts/local-domains-list.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 unset X_RH_IDM_VERSION

--- a/test/scripts/local-domains-patch.sh
+++ b/test/scripts/local-domains-patch.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset CREDS
 unset X_RH_IDM_REGISTRATION_TOKEN
 

--- a/test/scripts/local-domains-read.sh
+++ b/test/scripts/local-domains-read.sh
@@ -6,7 +6,7 @@ source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 UUID="$1"
 [ "${UUID}" != "" ] || error "UUID is empty"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 

--- a/test/scripts/local-domains-register.sh
+++ b/test/scripts/local-domains-register.sh
@@ -1,12 +1,15 @@
 #!/bin/bash
 set -eo pipefail
 
+export XRHID_AS="${XRHID_AS:-system}"
+export AUTH_TYPE="${AUTH_TYPE:-cert-auth}"
+
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 TOKEN="$1"
 [ "${TOKEN}" != "" ] || error "TOKEN is empty"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_system)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset CREDS
 export X_RH_IDM_REGISTRATION_TOKEN="$TOKEN"
 X_RH_IDM_VERSION="$IDM_VERSION"

--- a/test/scripts/local-domains-token.sh
+++ b/test/scripts/local-domains-token.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
-export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_user)}"
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 

--- a/test/scripts/local-domains-update.sh
+++ b/test/scripts/local-domains-update.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
+export XRHID_AS="${XRHID_AS:-system}"
+export AUTH_TYPE="${AUTH_TYPE:-cert-auth}"
+
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 UUID="$1"

--- a/test/scripts/local-hostconf.sh
+++ b/test/scripts/local-hostconf.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 set -eo pipefail
 
+export XRHID_AS="${XRHID_AS:-system}"
+export AUTH_TYPE="${AUTH_TYPE:-cert-auth}"
+
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
 INVENTORY_ID=$"$1"

--- a/test/scripts/local-signing-keys.sh
+++ b/test/scripts/local-signing-keys.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
+export XRHID_AS="${XRHID_AS:-system}"
+export AUTH_TYPE="${AUTH_TYPE:-cert-auth}"
+
 source "$(dirname "${BASH_SOURCE[0]}")/local.inc"
 
-unset X_RH_IDENTITY
+export X_RH_IDENTITY="${X_RH_IDENTITY:-$(identity_generator)}"
 unset X_RH_FAKE_IDENTITY
 unset CREDS
 


### PR DESCRIPTION
This change add service account support to the helper scripts
at `./scripts/test/*.sh` files.

We can specify `XRHID_AS={user,system,service-account}`, by
default it is used `user` account.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/233