### PR TITLE
feat(HMS-4276): use contextual logs

### DIFF
--- a/docs/dev/00-frameworks-and-libraries.md
+++ b/docs/dev/00-frameworks-and-libraries.md
@@ -36,3 +36,4 @@
 - [Metrics](06-metrics.md)
 - [Configurations](07-configs.md)
 - [RBAC](08-rbac.md)
+- [Logs](09-logs.md)

--- a/docs/dev/09-logs.md
+++ b/docs/dev/09-logs.md
@@ -1,0 +1,38 @@
+# Logging
+
+A contextual log is added to every request that allow
+to link messages based on tracking the `request-id` field.
+
+The request scoped log is stored in a `context.Context`
+instance and we can recover the log instance from it by
+using the primitive `LogFromCtx` function; for instance:
+
+```go
+    // Recover request log instance
+    logger := app_context.LogFromCtx(ctx)
+
+    // Print directly an error by
+    logger.Error("my error message")
+
+    // Print informative message by
+    logger.Info("my action was successful")
+```
+
+The above add to every message the `request-id` recovered
+from the request headers. This allow to link all the
+messages for a sequence of actions.
+
+## Guidelines
+
+- Only the http handler will use the framework dependent
+  context.
+- Beyond the http handler, we will inject the `context.Context`
+  instance because it is framework independent.
+- For the deep levels, print out the error returned from the
+  called library/framework. For higher levels, print out a
+  description of the context where it happens. The reason is
+  when we see the logs we will be told the history of
+  what was wrong, starting with the root reason returned
+  by the `err` instance.
+- Enable the `location: true` to print out information about
+  the exact location where the log message is printed out.

--- a/internal/handler/impl/domain_handler_private.go
+++ b/internal/handler/impl/domain_handler_private.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -10,11 +11,13 @@ import (
 	"github.com/openlyinc/pointy"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	internal_errors "github.com/podengo-project/idmsvc-backend/internal/errors"
+	app_context "github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
 	"gorm.io/gorm"
 )
 
 func (a *application) findIpaById(tx *gorm.DB, orgId string, UUID uuid.UUID) (data *model.Domain, err error) {
-	if data, err = a.domain.repository.FindByID(tx, orgId, UUID); err != nil {
+	ctx := app_context.CtxWithDB(context.Background(), tx)
+	if data, err = a.domain.repository.FindByID(ctx, orgId, UUID); err != nil {
 		return nil, err
 	}
 	if *data.Type != model.DomainTypeIpa {

--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/labstack/echo/v4"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	app_context "github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
 	"gorm.io/gorm"
 )
 
@@ -22,7 +23,8 @@ func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningK
 	}
 	defer tx.Rollback()
 
-	if keys, revokedKids, err = a.hostconfjwk.repository.GetPublicKeyArray(tx); err != nil {
+	c := app_context.CtxWithDB(ctx.Request().Context(), tx)
+	if keys, revokedKids, err = a.hostconfjwk.repository.GetPublicKeyArray(c); err != nil {
 		return err
 	}
 

--- a/internal/interface/repository/domain_repository.go
+++ b/internal/interface/repository/domain_repository.go
@@ -1,12 +1,12 @@
 package repository
 
 import (
+	"context"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
-	"gorm.io/gorm"
 )
 
 type DomainRegToken struct {
@@ -18,13 +18,13 @@ type DomainRegToken struct {
 
 // DomainRepository interface
 type DomainRepository interface {
-	List(db *gorm.DB, orgID string, offset int, limit int) (output []model.Domain, count int64, err error)
-	// PartialUpdate(db *gorm.DB, orgId string, data *model.Domain) (output model.Domain, err error)
-	// Update(db *gorm.DB, orgId string, data *model.Domain) (output model.Domain, err error)
-	FindByID(db *gorm.DB, orgID string, UUID uuid.UUID) (output *model.Domain, err error)
-	DeleteById(db *gorm.DB, orgID string, UUID uuid.UUID) (err error)
-	Register(db *gorm.DB, orgID string, data *model.Domain) (err error)
-	UpdateAgent(db *gorm.DB, orgID string, data *model.Domain) (err error)
-	UpdateUser(db *gorm.DB, orgID string, data *model.Domain) (err error)
-	CreateDomainToken(key []byte, validity time.Duration, orgID string, domainType public.DomainType) (token *DomainRegToken, err error)
+	List(ctx context.Context, orgID string, offset, limit int) (output []model.Domain, count int64, err error)
+	// PartialUpdate(ctx context.Context, orgId string, data *model.Domain) (output model.Domain, err error)
+	// Update(ctx context.Context, orgId string, data *model.Domain) (output model.Domain, err error)
+	FindByID(ctx context.Context, orgID string, UUID uuid.UUID) (output *model.Domain, err error)
+	DeleteById(ctx context.Context, orgID string, UUID uuid.UUID) (err error)
+	Register(ctx context.Context, orgID string, data *model.Domain) (err error)
+	UpdateAgent(ctx context.Context, orgID string, data *model.Domain) (err error)
+	UpdateUser(ctx context.Context, orgID string, data *model.Domain) (err error)
+	CreateDomainToken(ctx context.Context, key []byte, validity time.Duration, orgID string, domainType public.DomainType) (token *DomainRegToken, err error)
 }

--- a/internal/interface/repository/host_repository.go
+++ b/internal/interface/repository/host_repository.go
@@ -1,16 +1,17 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
-	"gorm.io/gorm"
 )
 
 // HostRepository interface
 type HostRepository interface {
-	MatchDomain(db *gorm.DB, options *interactor.HostConfOptions) (output *model.Domain, err error)
+	MatchDomain(ctx context.Context, options *interactor.HostConfOptions) (output *model.Domain, err error)
 	// TODO: hack, actual implementation will take gorm.DB argument
-	SignHostConfToken(privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (hctoken public.HostToken, err error)
+	SignHostConfToken(ctx context.Context, privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (hctoken public.HostToken, err error)
 }

--- a/internal/interface/repository/hostconf_jwk_repository.go
+++ b/internal/interface/repository/hostconf_jwk_repository.go
@@ -1,17 +1,18 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/lestrrat-go/jwx/v2/jwk"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
-	"gorm.io/gorm"
 )
 
 type HostconfJwkRepository interface {
-	InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk) (err error)
-	RevokeJWK(db *gorm.DB, kid string) (hcjwk *model.HostconfJwk, err error)
-	ListJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error)
-	PurgeExpiredJWKs(db *gorm.DB) (hcjwks []model.HostconfJwk, err error)
-	GetPublicKeyArray(db *gorm.DB) (pubkeys []string, revokedKids []string, err error)
+	InsertJWK(ctx context.Context, hcjwk *model.HostconfJwk) (err error)
+	RevokeJWK(ctx context.Context, kid string) (hcjwk *model.HostconfJwk, err error)
+	ListJWKs(ctx context.Context) (hcjwks []model.HostconfJwk, err error)
+	PurgeExpiredJWKs(ctx context.Context) (hcjwks []model.HostconfJwk, err error)
+	GetPublicKeyArray(ctx context.Context) (pubkeys, revokedKids []string, err error)
 	// TODO: refactor code to use jwk.Set instead of []jwk.Key
-	GetPrivateSigningKeys(db *gorm.DB) (privkeys []jwk.Key, err error)
+	GetPrivateSigningKeys(ctx context.Context) (privkeys []jwk.Key, err error)
 }

--- a/internal/test/mock/interface/repository/domain_repository.go
+++ b/internal/test/mock/interface/repository/domain_repository.go
@@ -3,9 +3,10 @@
 package repository
 
 import (
+	context "context"
+
 	model "github.com/podengo-project/idmsvc-backend/internal/domain/model"
 	mock "github.com/stretchr/testify/mock"
-	gorm "gorm.io/gorm"
 
 	public "github.com/podengo-project/idmsvc-backend/internal/api/public"
 
@@ -21,9 +22,9 @@ type DomainRepository struct {
 	mock.Mock
 }
 
-// CreateDomainToken provides a mock function with given fields: key, validity, orgID, domainType
-func (_m *DomainRepository) CreateDomainToken(key []byte, validity time.Duration, orgID string, domainType public.DomainType) (*repository.DomainRegToken, error) {
-	ret := _m.Called(key, validity, orgID, domainType)
+// CreateDomainToken provides a mock function with given fields: ctx, key, validity, orgID, domainType
+func (_m *DomainRepository) CreateDomainToken(ctx context.Context, key []byte, validity time.Duration, orgID string, domainType public.DomainType) (*repository.DomainRegToken, error) {
+	ret := _m.Called(ctx, key, validity, orgID, domainType)
 
 	if len(ret) == 0 {
 		panic("no return value specified for CreateDomainToken")
@@ -31,19 +32,19 @@ func (_m *DomainRepository) CreateDomainToken(key []byte, validity time.Duration
 
 	var r0 *repository.DomainRegToken
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]byte, time.Duration, string, public.DomainType) (*repository.DomainRegToken, error)); ok {
-		return rf(key, validity, orgID, domainType)
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, time.Duration, string, public.DomainType) (*repository.DomainRegToken, error)); ok {
+		return rf(ctx, key, validity, orgID, domainType)
 	}
-	if rf, ok := ret.Get(0).(func([]byte, time.Duration, string, public.DomainType) *repository.DomainRegToken); ok {
-		r0 = rf(key, validity, orgID, domainType)
+	if rf, ok := ret.Get(0).(func(context.Context, []byte, time.Duration, string, public.DomainType) *repository.DomainRegToken); ok {
+		r0 = rf(ctx, key, validity, orgID, domainType)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*repository.DomainRegToken)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func([]byte, time.Duration, string, public.DomainType) error); ok {
-		r1 = rf(key, validity, orgID, domainType)
+	if rf, ok := ret.Get(1).(func(context.Context, []byte, time.Duration, string, public.DomainType) error); ok {
+		r1 = rf(ctx, key, validity, orgID, domainType)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -51,17 +52,17 @@ func (_m *DomainRepository) CreateDomainToken(key []byte, validity time.Duration
 	return r0, r1
 }
 
-// DeleteById provides a mock function with given fields: db, orgID, UUID
-func (_m *DomainRepository) DeleteById(db *gorm.DB, orgID string, UUID uuid.UUID) error {
-	ret := _m.Called(db, orgID, UUID)
+// DeleteById provides a mock function with given fields: ctx, orgID, UUID
+func (_m *DomainRepository) DeleteById(ctx context.Context, orgID string, UUID uuid.UUID) error {
+	ret := _m.Called(ctx, orgID, UUID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DeleteById")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, uuid.UUID) error); ok {
-		r0 = rf(db, orgID, UUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) error); ok {
+		r0 = rf(ctx, orgID, UUID)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -69,9 +70,9 @@ func (_m *DomainRepository) DeleteById(db *gorm.DB, orgID string, UUID uuid.UUID
 	return r0
 }
 
-// FindByID provides a mock function with given fields: db, orgID, UUID
-func (_m *DomainRepository) FindByID(db *gorm.DB, orgID string, UUID uuid.UUID) (*model.Domain, error) {
-	ret := _m.Called(db, orgID, UUID)
+// FindByID provides a mock function with given fields: ctx, orgID, UUID
+func (_m *DomainRepository) FindByID(ctx context.Context, orgID string, UUID uuid.UUID) (*model.Domain, error) {
+	ret := _m.Called(ctx, orgID, UUID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for FindByID")
@@ -79,19 +80,19 @@ func (_m *DomainRepository) FindByID(db *gorm.DB, orgID string, UUID uuid.UUID) 
 
 	var r0 *model.Domain
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, uuid.UUID) (*model.Domain, error)); ok {
-		return rf(db, orgID, UUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) (*model.Domain, error)); ok {
+		return rf(ctx, orgID, UUID)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, uuid.UUID) *model.Domain); ok {
-		r0 = rf(db, orgID, UUID)
+	if rf, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) *model.Domain); ok {
+		r0 = rf(ctx, orgID, UUID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Domain)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB, string, uuid.UUID) error); ok {
-		r1 = rf(db, orgID, UUID)
+	if rf, ok := ret.Get(1).(func(context.Context, string, uuid.UUID) error); ok {
+		r1 = rf(ctx, orgID, UUID)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -99,9 +100,9 @@ func (_m *DomainRepository) FindByID(db *gorm.DB, orgID string, UUID uuid.UUID) 
 	return r0, r1
 }
 
-// List provides a mock function with given fields: db, orgID, offset, limit
-func (_m *DomainRepository) List(db *gorm.DB, orgID string, offset int, limit int) ([]model.Domain, int64, error) {
-	ret := _m.Called(db, orgID, offset, limit)
+// List provides a mock function with given fields: ctx, orgID, offset, limit
+func (_m *DomainRepository) List(ctx context.Context, orgID string, offset int, limit int) ([]model.Domain, int64, error) {
+	ret := _m.Called(ctx, orgID, offset, limit)
 
 	if len(ret) == 0 {
 		panic("no return value specified for List")
@@ -110,25 +111,25 @@ func (_m *DomainRepository) List(db *gorm.DB, orgID string, offset int, limit in
 	var r0 []model.Domain
 	var r1 int64
 	var r2 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, int, int) ([]model.Domain, int64, error)); ok {
-		return rf(db, orgID, offset, limit)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int) ([]model.Domain, int64, error)); ok {
+		return rf(ctx, orgID, offset, limit)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, int, int) []model.Domain); ok {
-		r0 = rf(db, orgID, offset, limit)
+	if rf, ok := ret.Get(0).(func(context.Context, string, int, int) []model.Domain); ok {
+		r0 = rf(ctx, orgID, offset, limit)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.Domain)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB, string, int, int) int64); ok {
-		r1 = rf(db, orgID, offset, limit)
+	if rf, ok := ret.Get(1).(func(context.Context, string, int, int) int64); ok {
+		r1 = rf(ctx, orgID, offset, limit)
 	} else {
 		r1 = ret.Get(1).(int64)
 	}
 
-	if rf, ok := ret.Get(2).(func(*gorm.DB, string, int, int) error); ok {
-		r2 = rf(db, orgID, offset, limit)
+	if rf, ok := ret.Get(2).(func(context.Context, string, int, int) error); ok {
+		r2 = rf(ctx, orgID, offset, limit)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -136,17 +137,17 @@ func (_m *DomainRepository) List(db *gorm.DB, orgID string, offset int, limit in
 	return r0, r1, r2
 }
 
-// Register provides a mock function with given fields: db, orgID, data
-func (_m *DomainRepository) Register(db *gorm.DB, orgID string, data *model.Domain) error {
-	ret := _m.Called(db, orgID, data)
+// Register provides a mock function with given fields: ctx, orgID, data
+func (_m *DomainRepository) Register(ctx context.Context, orgID string, data *model.Domain) error {
+	ret := _m.Called(ctx, orgID, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Register")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, *model.Domain) error); ok {
-		r0 = rf(db, orgID, data)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *model.Domain) error); ok {
+		r0 = rf(ctx, orgID, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -154,17 +155,17 @@ func (_m *DomainRepository) Register(db *gorm.DB, orgID string, data *model.Doma
 	return r0
 }
 
-// UpdateAgent provides a mock function with given fields: db, orgID, data
-func (_m *DomainRepository) UpdateAgent(db *gorm.DB, orgID string, data *model.Domain) error {
-	ret := _m.Called(db, orgID, data)
+// UpdateAgent provides a mock function with given fields: ctx, orgID, data
+func (_m *DomainRepository) UpdateAgent(ctx context.Context, orgID string, data *model.Domain) error {
+	ret := _m.Called(ctx, orgID, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateAgent")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, *model.Domain) error); ok {
-		r0 = rf(db, orgID, data)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *model.Domain) error); ok {
+		r0 = rf(ctx, orgID, data)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -172,17 +173,17 @@ func (_m *DomainRepository) UpdateAgent(db *gorm.DB, orgID string, data *model.D
 	return r0
 }
 
-// UpdateUser provides a mock function with given fields: db, orgID, data
-func (_m *DomainRepository) UpdateUser(db *gorm.DB, orgID string, data *model.Domain) error {
-	ret := _m.Called(db, orgID, data)
+// UpdateUser provides a mock function with given fields: ctx, orgID, data
+func (_m *DomainRepository) UpdateUser(ctx context.Context, orgID string, data *model.Domain) error {
+	ret := _m.Called(ctx, orgID, data)
 
 	if len(ret) == 0 {
 		panic("no return value specified for UpdateUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string, *model.Domain) error); ok {
-		r0 = rf(db, orgID, data)
+	if rf, ok := ret.Get(0).(func(context.Context, string, *model.Domain) error); ok {
+		r0 = rf(ctx, orgID, data)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/internal/test/mock/interface/repository/host_repository.go
+++ b/internal/test/mock/interface/repository/host_repository.go
@@ -3,9 +3,10 @@
 package repository
 
 import (
+	context "context"
+
 	jwk "github.com/lestrrat-go/jwx/v2/jwk"
 	interactor "github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
-	gorm "gorm.io/gorm"
 
 	mock "github.com/stretchr/testify/mock"
 
@@ -17,9 +18,9 @@ type HostRepository struct {
 	mock.Mock
 }
 
-// MatchDomain provides a mock function with given fields: db, options
-func (_m *HostRepository) MatchDomain(db *gorm.DB, options *interactor.HostConfOptions) (*model.Domain, error) {
-	ret := _m.Called(db, options)
+// MatchDomain provides a mock function with given fields: ctx, options
+func (_m *HostRepository) MatchDomain(ctx context.Context, options *interactor.HostConfOptions) (*model.Domain, error) {
+	ret := _m.Called(ctx, options)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MatchDomain")
@@ -27,19 +28,19 @@ func (_m *HostRepository) MatchDomain(db *gorm.DB, options *interactor.HostConfO
 
 	var r0 *model.Domain
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, *interactor.HostConfOptions) (*model.Domain, error)); ok {
-		return rf(db, options)
+	if rf, ok := ret.Get(0).(func(context.Context, *interactor.HostConfOptions) (*model.Domain, error)); ok {
+		return rf(ctx, options)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB, *interactor.HostConfOptions) *model.Domain); ok {
-		r0 = rf(db, options)
+	if rf, ok := ret.Get(0).(func(context.Context, *interactor.HostConfOptions) *model.Domain); ok {
+		r0 = rf(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.Domain)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB, *interactor.HostConfOptions) error); ok {
-		r1 = rf(db, options)
+	if rf, ok := ret.Get(1).(func(context.Context, *interactor.HostConfOptions) error); ok {
+		r1 = rf(ctx, options)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -47,9 +48,9 @@ func (_m *HostRepository) MatchDomain(db *gorm.DB, options *interactor.HostConfO
 	return r0, r1
 }
 
-// SignHostConfToken provides a mock function with given fields: privs, options, domain
-func (_m *HostRepository) SignHostConfToken(privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (string, error) {
-	ret := _m.Called(privs, options, domain)
+// SignHostConfToken provides a mock function with given fields: ctx, privs, options, domain
+func (_m *HostRepository) SignHostConfToken(ctx context.Context, privs []jwk.Key, options *interactor.HostConfOptions, domain *model.Domain) (string, error) {
+	ret := _m.Called(ctx, privs, options, domain)
 
 	if len(ret) == 0 {
 		panic("no return value specified for SignHostConfToken")
@@ -57,17 +58,17 @@ func (_m *HostRepository) SignHostConfToken(privs []jwk.Key, options *interactor
 
 	var r0 string
 	var r1 error
-	if rf, ok := ret.Get(0).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) (string, error)); ok {
-		return rf(privs, options, domain)
+	if rf, ok := ret.Get(0).(func(context.Context, []jwk.Key, *interactor.HostConfOptions, *model.Domain) (string, error)); ok {
+		return rf(ctx, privs, options, domain)
 	}
-	if rf, ok := ret.Get(0).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) string); ok {
-		r0 = rf(privs, options, domain)
+	if rf, ok := ret.Get(0).(func(context.Context, []jwk.Key, *interactor.HostConfOptions, *model.Domain) string); ok {
+		r0 = rf(ctx, privs, options, domain)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func([]jwk.Key, *interactor.HostConfOptions, *model.Domain) error); ok {
-		r1 = rf(privs, options, domain)
+	if rf, ok := ret.Get(1).(func(context.Context, []jwk.Key, *interactor.HostConfOptions, *model.Domain) error); ok {
+		r1 = rf(ctx, privs, options, domain)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/internal/test/mock/interface/repository/hostconf_jwk_repository.go
+++ b/internal/test/mock/interface/repository/hostconf_jwk_repository.go
@@ -3,9 +3,10 @@
 package repository
 
 import (
+	context "context"
+
 	jwk "github.com/lestrrat-go/jwx/v2/jwk"
 	mock "github.com/stretchr/testify/mock"
-	gorm "gorm.io/gorm"
 
 	model "github.com/podengo-project/idmsvc-backend/internal/infrastructure/token/hostconf_jwk/model"
 )
@@ -15,9 +16,9 @@ type HostconfJwkRepository struct {
 	mock.Mock
 }
 
-// GetPrivateSigningKeys provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) ([]jwk.Key, error) {
-	ret := _m.Called(db)
+// GetPrivateSigningKeys provides a mock function with given fields: ctx
+func (_m *HostconfJwkRepository) GetPrivateSigningKeys(ctx context.Context) ([]jwk.Key, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPrivateSigningKeys")
@@ -25,19 +26,19 @@ func (_m *HostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) ([]jwk.Key, 
 
 	var r0 []jwk.Key
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]jwk.Key, error)); ok {
-		return rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]jwk.Key, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB) []jwk.Key); ok {
-		r0 = rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) []jwk.Key); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]jwk.Key)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB) error); ok {
-		r1 = rf(db)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -45,9 +46,9 @@ func (_m *HostconfJwkRepository) GetPrivateSigningKeys(db *gorm.DB) ([]jwk.Key, 
 	return r0, r1
 }
 
-// GetPublicKeyArray provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, []string, error) {
-	ret := _m.Called(db)
+// GetPublicKeyArray provides a mock function with given fields: ctx
+func (_m *HostconfJwkRepository) GetPublicKeyArray(ctx context.Context) ([]string, []string, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPublicKeyArray")
@@ -56,27 +57,27 @@ func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, []str
 	var r0 []string
 	var r1 []string
 	var r2 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]string, []string, error)); ok {
-		return rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]string, []string, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB) []string); ok {
-		r0 = rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) []string); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB) []string); ok {
-		r1 = rf(db)
+	if rf, ok := ret.Get(1).(func(context.Context) []string); ok {
+		r1 = rf(ctx)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(*gorm.DB) error); ok {
-		r2 = rf(db)
+	if rf, ok := ret.Get(2).(func(context.Context) error); ok {
+		r2 = rf(ctx)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -84,17 +85,17 @@ func (_m *HostconfJwkRepository) GetPublicKeyArray(db *gorm.DB) ([]string, []str
 	return r0, r1, r2
 }
 
-// InsertJWK provides a mock function with given fields: db, hcjwk
-func (_m *HostconfJwkRepository) InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk) error {
-	ret := _m.Called(db, hcjwk)
+// InsertJWK provides a mock function with given fields: ctx, hcjwk
+func (_m *HostconfJwkRepository) InsertJWK(ctx context.Context, hcjwk *model.HostconfJwk) error {
+	ret := _m.Called(ctx, hcjwk)
 
 	if len(ret) == 0 {
 		panic("no return value specified for InsertJWK")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, *model.HostconfJwk) error); ok {
-		r0 = rf(db, hcjwk)
+	if rf, ok := ret.Get(0).(func(context.Context, *model.HostconfJwk) error); ok {
+		r0 = rf(ctx, hcjwk)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -102,9 +103,9 @@ func (_m *HostconfJwkRepository) InsertJWK(db *gorm.DB, hcjwk *model.HostconfJwk
 	return r0
 }
 
-// ListJWKs provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) ListJWKs(db *gorm.DB) ([]model.HostconfJwk, error) {
-	ret := _m.Called(db)
+// ListJWKs provides a mock function with given fields: ctx
+func (_m *HostconfJwkRepository) ListJWKs(ctx context.Context) ([]model.HostconfJwk, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ListJWKs")
@@ -112,19 +113,19 @@ func (_m *HostconfJwkRepository) ListJWKs(db *gorm.DB) ([]model.HostconfJwk, err
 
 	var r0 []model.HostconfJwk
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]model.HostconfJwk, error)); ok {
-		return rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]model.HostconfJwk, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB) []model.HostconfJwk); ok {
-		r0 = rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) []model.HostconfJwk); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.HostconfJwk)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB) error); ok {
-		r1 = rf(db)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -132,9 +133,9 @@ func (_m *HostconfJwkRepository) ListJWKs(db *gorm.DB) ([]model.HostconfJwk, err
 	return r0, r1
 }
 
-// PurgeExpiredJWKs provides a mock function with given fields: db
-func (_m *HostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) ([]model.HostconfJwk, error) {
-	ret := _m.Called(db)
+// PurgeExpiredJWKs provides a mock function with given fields: ctx
+func (_m *HostconfJwkRepository) PurgeExpiredJWKs(ctx context.Context) ([]model.HostconfJwk, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PurgeExpiredJWKs")
@@ -142,19 +143,19 @@ func (_m *HostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) ([]model.Hostconf
 
 	var r0 []model.HostconfJwk
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB) ([]model.HostconfJwk, error)); ok {
-		return rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) ([]model.HostconfJwk, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB) []model.HostconfJwk); ok {
-		r0 = rf(db)
+	if rf, ok := ret.Get(0).(func(context.Context) []model.HostconfJwk); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]model.HostconfJwk)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB) error); ok {
-		r1 = rf(db)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -162,9 +163,9 @@ func (_m *HostconfJwkRepository) PurgeExpiredJWKs(db *gorm.DB) ([]model.Hostconf
 	return r0, r1
 }
 
-// RevokeJWK provides a mock function with given fields: db, kid
-func (_m *HostconfJwkRepository) RevokeJWK(db *gorm.DB, kid string) (*model.HostconfJwk, error) {
-	ret := _m.Called(db, kid)
+// RevokeJWK provides a mock function with given fields: ctx, kid
+func (_m *HostconfJwkRepository) RevokeJWK(ctx context.Context, kid string) (*model.HostconfJwk, error) {
+	ret := _m.Called(ctx, kid)
 
 	if len(ret) == 0 {
 		panic("no return value specified for RevokeJWK")
@@ -172,19 +173,19 @@ func (_m *HostconfJwkRepository) RevokeJWK(db *gorm.DB, kid string) (*model.Host
 
 	var r0 *model.HostconfJwk
 	var r1 error
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string) (*model.HostconfJwk, error)); ok {
-		return rf(db, kid)
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*model.HostconfJwk, error)); ok {
+		return rf(ctx, kid)
 	}
-	if rf, ok := ret.Get(0).(func(*gorm.DB, string) *model.HostconfJwk); ok {
-		r0 = rf(db, kid)
+	if rf, ok := ret.Get(0).(func(context.Context, string) *model.HostconfJwk); ok {
+		r0 = rf(ctx, kid)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.HostconfJwk)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(*gorm.DB, string) error); ok {
-		r1 = rf(db, kid)
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, kid)
 	} else {
 		r1 = ret.Error(1)
 	}


### PR DESCRIPTION
Provide contextual information to the log messages to
enhance the traceability.

TODO

- [x] Polish the middleware, and add unit tests.
- [x] Migrate from experimental to final for `log/slog`.
- [x] Per endpoint add the changes, and enhance the produced messages.
    - [x] GET /domains
    - [x] POST /domains/token
    - [x] POST /domains
    - [x] PATCH /domains/:domain_id
    - [x] PUT /domains/:domain_id
    - [x] GET /domains/:domain_id
    - [x] DELETE /domains/:domain_id
    - [x] POST /host_conf
    - [x] GET /signing-keys
- [x] Clean-up code.

----

https://issues.redhat.com/browse/HMS-4276

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/276