### PR TITLE
fix(HMS-3968): multi-error enforce and minor fixes

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity.go
+++ b/internal/infrastructure/middleware/enforce_identity.go
@@ -75,6 +75,9 @@ func EnforceSystemPredicate(data *identity.XRHID) error {
 	if data.Identity.Type != "System" {
 		return fmt.Errorf("'Identity.Type' must be 'System'")
 	}
+	if data.Identity.AuthType != "cert-auth" {
+		return fmt.Errorf("'Identity.AuthType' is not 'cert-auth'")
+	}
 	if data.Identity.System == nil {
 		return fmt.Errorf("'Identity.System' is nil")
 	}

--- a/internal/infrastructure/middleware/enforce_identity.go
+++ b/internal/infrastructure/middleware/enforce_identity.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/labstack/echo/v4"
@@ -117,17 +118,15 @@ func EnforceServiceAccountPredicate(data *identity.XRHID) error {
 // logical OR with existing predicates.
 func NewEnforceOr(predicates ...IdentityPredicate) IdentityPredicate {
 	return func(data *identity.XRHID) error {
-		var firsterr error
+		var allErrors error
 		for i := range predicates {
 			if err := predicates[i](data); err == nil {
 				return nil
 			} else {
-				if firsterr == nil {
-					firsterr = err
-				}
+				allErrors = errors.Join(allErrors, err)
 			}
 		}
-		return firsterr
+		return allErrors
 	}
 }
 

--- a/internal/infrastructure/middleware/enforce_identity_test.go
+++ b/internal/infrastructure/middleware/enforce_identity_test.go
@@ -380,11 +380,21 @@ func TestEnforceSystemPredicate(t *testing.T) {
 			Expected: fmt.Errorf("'Identity.Type' must be 'System'"),
 		},
 		{
+			Name: "'Identity.AuthType' is not 'cert-auth'",
+			Given: &identity.XRHID{
+				Identity: identity.Identity{
+					Type: "System",
+				},
+			},
+			Expected: fmt.Errorf("'Identity.AuthType' is not 'cert-auth'"),
+		},
+		{
 			Name: "'Identity.System' is not nil",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
-					Type:   "System",
-					System: nil,
+					AuthType: "cert-auth",
+					Type:     "System",
+					System:   nil,
 				},
 			},
 			Expected: fmt.Errorf("'Identity.System' is nil"),
@@ -393,7 +403,8 @@ func TestEnforceSystemPredicate(t *testing.T) {
 			Name: "'CertType' is not 'system'",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
-					Type: "System",
+					AuthType: "cert-auth",
+					Type:     "System",
 					System: &identity.System{
 						CertType: "anothevalue",
 					},
@@ -405,7 +416,8 @@ func TestEnforceSystemPredicate(t *testing.T) {
 			Name: "'CommonName' is empty",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
-					Type: "System",
+					AuthType: "cert-auth",
+					Type:     "System",
 					System: &identity.System{
 						CertType:   "system",
 						CommonName: "",
@@ -418,7 +430,8 @@ func TestEnforceSystemPredicate(t *testing.T) {
 			Name: "Success case",
 			Given: &identity.XRHID{
 				Identity: identity.Identity{
-					Type: "System",
+					AuthType: "cert-auth",
+					Type:     "System",
 					System: &identity.System{
 						CertType:   "system",
 						CommonName: "10fbb716-ca5d-11ed-b384-482ae3863d30",

--- a/internal/infrastructure/middleware/enforce_identity_test.go
+++ b/internal/infrastructure/middleware/enforce_identity_test.go
@@ -543,7 +543,7 @@ func TestNewEnforceOr(t *testing.T) {
 				First:  newIdentityAlwaysFalse(errors.New("Failing both: first predicate")),
 				Second: newIdentityAlwaysFalse(errors.New("Failing both: second predicate")),
 			},
-			Expected: fmt.Errorf("Failing both: first predicate"),
+			Expected: fmt.Errorf("Failing both: first predicate\nFailing both: second predicate"),
 		},
 		{
 			Name: "Success",

--- a/internal/test/builder/api/builder_system_xrhid.go
+++ b/internal/test/builder/api/builder_system_xrhid.go
@@ -33,7 +33,7 @@ func NewSystemXRHID() SystemXRHID {
 			EmployeeAccountNumber: strconv.Itoa(int(builder_helper.GenRandNum(1, 100000))),
 			OrgID:                 orgID,
 			Type:                  "System",
-			AuthType:              authType[int(builder_helper.GenRandNum(0, 1))],
+			AuthType:              "cert-auth",
 			Internal: identity.Internal{
 				OrgID:    orgID,
 				AuthTime: float32(time.Now().Sub(time.Time{})),


### PR DESCRIPTION
This change are a set of small changes observed during the
review at https://github.com/podengo-project/idmsvc-backend/pull/236

- Add multi-error for OR logical enforcement.
- Add check for Identity.AuthType==`cert-auth` enforcement for System endpoints.
- A unit test for the router started to fails. The fix is added here, but this was not observed on the pipeline.