### PR TITLE
fix(HMS-4366): fix: using wrong OrgID

### DIFF
--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -202,7 +202,7 @@ func (i domainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, par
 	if params == nil {
 		return "", nil, nil, internal_errors.NilArgError("params")
 	}
-	orgID := xrhid.Identity.Internal.OrgID
+	orgID := xrhid.Identity.OrgID
 
 	// Retrieve the ipa-hcc version information
 	clientVersion := header.NewXRHIDMVersionWithHeader(params.XRhIdmVersion)
@@ -235,7 +235,7 @@ func (i domainInteractor) UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, para
 	if params == nil {
 		return "", nil, internal_errors.NilArgError("params")
 	}
-	orgID := xrhid.Identity.Internal.OrgID
+	orgID := xrhid.Identity.OrgID
 
 	// Read the body payload
 	domain = i.commonRegisterUpdateUser(orgID, UUID, body)


### PR DESCRIPTION
The operations UpdateAgent and UpdateUser where referencing a wrong OrgID value from the XRHID structure. It has to reference Identity.OrgID which is set by the context when the XRHID enforcement is accepted, if fallback behavior is detected.

See: https://github.com/RedHatInsights/platform-go-middlewares/blob/master/identity/identity.go#L268