### PR TITLE
fix(HMS-2991): fail on changing of realm in domains PUT

### DIFF
--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -330,6 +330,15 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 		)
 	}
 
+	if data.IpaDomain != nil && currentData.IpaDomain != nil &&
+		data.IpaDomain.RealmName != nil && currentData.IpaDomain.RealmName != nil &&
+		*data.IpaDomain.RealmName != *currentData.IpaDomain.RealmName {
+		return internal_errors.NewHTTPErrorF(
+			http.StatusBadRequest,
+			"'realm_name' may not be changed",
+		)
+	}
+
 	if err = a.fillDomain(currentData, data); err != nil {
 		return err
 	}


### PR DESCRIPTION
Return 400 bad request when realm name is about to be changed as it is not possible to change a realm of an IPA server.

Note: the ticket discusses implementation in interactor and using `readOnly` property in API spec.  But this this is no-go as the check needs to be performed after loading the entry from DB (thus after interactor and all middlewares). 

As for review of other fields, the fields are mostly limited by the data structure of requests. To me, only the the RealmName seems as the field to check. PATH method (`UpdateDomainUserRequest` struct` is already quite limited and all fields are changeable). 