### PR TITLE
feat(HMS-3596): respect defined values in registration

### DIFF
--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -123,10 +123,10 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 					}
 
 					require.NotNil(t, body.Description)
-					assert.Equal(t, "", *body.Description)
+					assert.Equal(t, *bodyRequest.Description, *body.Description)
 
 					require.NotNil(t, body.AutoEnrollmentEnabled)
-					assert.False(t, *body.AutoEnrollmentEnabled)
+					assert.Equal(t, *bodyRequest.AutoEnrollmentEnabled, *body.AutoEnrollmentEnabled)
 
 					// Check rhel-idm
 					if bodyRequest != nil {

--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -141,7 +141,7 @@ func (i domainInteractor) GetByID(xrhid *identity.XRHID, params *public.ReadDoma
 // Return the orgId and the business model for Ipa information,
 // when success translation, else it returns empty string for orgId,
 // nil for the Ipa data, and an error filled.
-func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, params *api_public.RegisterDomainParams, body *public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error) {
+func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, params *api_public.RegisterDomainParams, body *public.RegisterDomainRequest) (string, *header.XRHIDMVersion, *model.Domain, error) {
 	var (
 		domainID uuid.UUID
 		domain   *model.Domain
@@ -174,12 +174,16 @@ func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, p
 		return "", nil, nil, err
 	}
 
-	// Agent request body has no/nil title, description, and auto enrollment flag
-	// default title is domain name
-	domain.Title = pointy.String(body.DomainName)
-	domain.Description = pointy.String("")
-	// new domains are disabled by default
-	domain.AutoEnrollmentEnabled = pointy.Bool(false)
+	// Set defaults for new domains when the attributes are not set.
+	if domain.Title == nil || *domain.Title == "" {
+		domain.Title = pointy.String(body.DomainName)
+	}
+	if domain.Description == nil {
+		domain.Description = pointy.String("")
+	}
+	if domain.AutoEnrollmentEnabled == nil {
+		domain.AutoEnrollmentEnabled = pointy.Bool(false)
+	}
 
 	return orgID, clientVersion, domain, nil
 }


### PR DESCRIPTION
If a system makes the registration call (domains POST) with defined:

- title
- description
- auto_enrollment_enabled

Then the values are respected (unchanged).

If values are not defined or if title is empty then defaults are set.