### PR TITLE
fix: request type of domains update PUT and PATCH

### DIFF
--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -262,7 +262,7 @@ func (a *application) RegisterDomain(
 func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, params public.UpdateDomainAgentParams) error {
 	var (
 		err         error
-		input       public.Domain
+		input       public.UpdateDomainAgentRequest
 		data        *model.Domain
 		currentData *model.Domain
 		// host          client.InventoryHost

--- a/internal/handler/impl/domain_handler.go
+++ b/internal/handler/impl/domain_handler.go
@@ -361,7 +361,7 @@ func (a *application) UpdateDomainAgent(ctx echo.Context, domain_id uuid.UUID, p
 func (a *application) UpdateDomainUser(ctx echo.Context, domain_id uuid.UUID, params public.UpdateDomainUserParams) error {
 	var (
 		err         error
-		input       public.Domain
+		input       public.UpdateDomainUserRequest
 		data        *model.Domain
 		currentData *model.Domain
 		orgID       string

--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -45,7 +45,7 @@ func (a *application) HostConf(
 	}
 
 	if tx = a.db.Begin(); tx.Error != nil {
-		slog.ErrorContext(ctx.Request().Context(), err.Error())
+		slog.ErrorContext(ctx.Request().Context(), tx.Error.Error())
 		return tx.Error
 	}
 	defer tx.Rollback()
@@ -78,7 +78,7 @@ func (a *application) HostConf(
 	}
 
 	if tx.Commit(); tx.Error != nil {
-		slog.ErrorContext(ctx.Request().Context(), err.Error())
+		slog.ErrorContext(ctx.Request().Context(), tx.Error.Error())
 		return tx.Error
 	}
 

--- a/internal/interface/interactor/domain_interactor.go
+++ b/internal/interface/interactor/domain_interactor.go
@@ -15,6 +15,6 @@ type DomainInteractor interface {
 	GetByID(xrhid *identity.XRHID, params *public.ReadDomainParams) (orgID string, err error)
 	Register(domainRegKey []byte, xrhid *identity.XRHID, params *api_public.RegisterDomainParams, body *api_public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error)
 	UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainAgentParams, body *api_public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error)
-	UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainUserParams, body *api_public.Domain) (string, *model.Domain, error)
+	UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainUserParams, body *api_public.UpdateDomainUserRequest) (string, *model.Domain, error)
 	CreateDomainToken(xrhid *identity.XRHID, params *api_public.CreateDomainTokenParams, body *api_public.DomainRegTokenRequest) (orgID string, domainType public.DomainType, err error)
 }

--- a/internal/interface/interactor/domain_interactor.go
+++ b/internal/interface/interactor/domain_interactor.go
@@ -14,7 +14,7 @@ type DomainInteractor interface {
 	List(xrhid *identity.XRHID, params *api_public.ListDomainsParams) (orgID string, offset, limit int, err error)
 	GetByID(xrhid *identity.XRHID, params *public.ReadDomainParams) (orgID string, err error)
 	Register(domainRegKey []byte, xrhid *identity.XRHID, params *api_public.RegisterDomainParams, body *api_public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error)
-	UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainAgentParams, body *api_public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error)
+	UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainAgentParams, body *api_public.UpdateDomainAgentRequest) (string, *header.XRHIDMVersion, *model.Domain, error)
 	UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainUserParams, body *api_public.UpdateDomainUserRequest) (string, *model.Domain, error)
 	CreateDomainToken(xrhid *identity.XRHID, params *api_public.CreateDomainTokenParams, body *api_public.DomainRegTokenRequest) (orgID string, domainType public.DomainType, err error)
 }

--- a/internal/test/mock/interface/interactor/domain_interactor.go
+++ b/internal/test/mock/interface/interactor/domain_interactor.go
@@ -209,7 +209,7 @@ func (_m *DomainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID,
 }
 
 // UpdateAgent provides a mock function with given fields: xrhid, UUID, params, body
-func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *public.UpdateDomainAgentParams, body *public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error) {
+func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *public.UpdateDomainAgentParams, body *public.UpdateDomainAgentRequest) (string, *header.XRHIDMVersion, *model.Domain, error) {
 	ret := _m.Called(xrhid, UUID, params, body)
 
 	if len(ret) == 0 {
@@ -220,16 +220,16 @@ func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, p
 	var r1 *header.XRHIDMVersion
 	var r2 *model.Domain
 	var r3 error
-	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error)); ok {
+	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.UpdateDomainAgentRequest) (string, *header.XRHIDMVersion, *model.Domain, error)); ok {
 		return rf(xrhid, UUID, params, body)
 	}
-	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.Domain) string); ok {
+	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.UpdateDomainAgentRequest) string); ok {
 		r0 = rf(xrhid, UUID, params, body)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.Domain) *header.XRHIDMVersion); ok {
+	if rf, ok := ret.Get(1).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.UpdateDomainAgentRequest) *header.XRHIDMVersion); ok {
 		r1 = rf(xrhid, UUID, params, body)
 	} else {
 		if ret.Get(1) != nil {
@@ -237,7 +237,7 @@ func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, p
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.Domain) *model.Domain); ok {
+	if rf, ok := ret.Get(2).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.UpdateDomainAgentRequest) *model.Domain); ok {
 		r2 = rf(xrhid, UUID, params, body)
 	} else {
 		if ret.Get(2) != nil {
@@ -245,7 +245,7 @@ func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, p
 		}
 	}
 
-	if rf, ok := ret.Get(3).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.Domain) error); ok {
+	if rf, ok := ret.Get(3).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainAgentParams, *public.UpdateDomainAgentRequest) error); ok {
 		r3 = rf(xrhid, UUID, params, body)
 	} else {
 		r3 = ret.Error(3)
@@ -255,7 +255,7 @@ func (_m *DomainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, p
 }
 
 // UpdateUser provides a mock function with given fields: xrhid, UUID, params, body
-func (_m *DomainInteractor) UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, params *public.UpdateDomainUserParams, body *public.Domain) (string, *model.Domain, error) {
+func (_m *DomainInteractor) UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, params *public.UpdateDomainUserParams, body *public.UpdateDomainUserRequest) (string, *model.Domain, error) {
 	ret := _m.Called(xrhid, UUID, params, body)
 
 	if len(ret) == 0 {
@@ -265,16 +265,16 @@ func (_m *DomainInteractor) UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, pa
 	var r0 string
 	var r1 *model.Domain
 	var r2 error
-	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.Domain) (string, *model.Domain, error)); ok {
+	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.UpdateDomainUserRequest) (string, *model.Domain, error)); ok {
 		return rf(xrhid, UUID, params, body)
 	}
-	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.Domain) string); ok {
+	if rf, ok := ret.Get(0).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.UpdateDomainUserRequest) string); ok {
 		r0 = rf(xrhid, UUID, params, body)
 	} else {
 		r0 = ret.Get(0).(string)
 	}
 
-	if rf, ok := ret.Get(1).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.Domain) *model.Domain); ok {
+	if rf, ok := ret.Get(1).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.UpdateDomainUserRequest) *model.Domain); ok {
 		r1 = rf(xrhid, UUID, params, body)
 	} else {
 		if ret.Get(1) != nil {
@@ -282,7 +282,7 @@ func (_m *DomainInteractor) UpdateUser(xrhid *identity.XRHID, UUID uuid.UUID, pa
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.Domain) error); ok {
+	if rf, ok := ret.Get(2).(func(*identity.XRHID, uuid.UUID, *public.UpdateDomainUserParams, *public.UpdateDomainUserRequest) error); ok {
 		r2 = rf(xrhid, UUID, params, body)
 	} else {
 		r2 = ret.Error(2)

--- a/internal/usecase/interactor/domain_interactor.go
+++ b/internal/usecase/interactor/domain_interactor.go
@@ -170,7 +170,7 @@ func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, p
 	}
 
 	// Read the body payload
-	if domain, err = i.commonRegisterUpdate(orgID, domainID, body); err != nil {
+	if domain, err = i.translateDomain(orgID, domainID, body); err != nil {
 		return "", nil, nil, err
 	}
 
@@ -191,7 +191,11 @@ func (i domainInteractor) Register(domainRegKey []byte, xrhid *identity.XRHID, p
 // Return the orgId and the business model for Ipa information,
 // when success translation, else it returns empty string for orgId,
 // nil for the Ipa data, and an error filled.
-func (i domainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, params *api_public.UpdateDomainAgentParams, body *public.Domain) (string, *header.XRHIDMVersion, *model.Domain, error) {
+func (i domainInteractor) UpdateAgent(
+	xrhid *identity.XRHID, UUID uuid.UUID,
+	params *api_public.UpdateDomainAgentParams,
+	body *public.UpdateDomainAgentRequest,
+) (string, *header.XRHIDMVersion, *model.Domain, error) {
 	var (
 		domain *model.Domain
 		err    error
@@ -211,7 +215,7 @@ func (i domainInteractor) UpdateAgent(xrhid *identity.XRHID, UUID uuid.UUID, par
 	}
 
 	// Read the body payload
-	if domain, err = i.commonRegisterUpdate(orgID, UUID, body); err != nil {
+	if domain, err = i.translateUpdateDomainAgent(orgID, UUID, body); err != nil {
 		return "", nil, nil, err
 	}
 	return orgID, clientVersion, domain, nil
@@ -278,48 +282,49 @@ func (i domainInteractor) CreateDomainToken(
 
 // --------- Private methods -----------
 
-func (i domainInteractor) registerOrUpdateRhelIdm(body *public.Domain, domainIpa *model.Ipa) error {
-	domainIpa.RealmName = pointy.String(body.RhelIdm.RealmName)
+// translateIpaModel translates the public.DomainIpa to the model.Ipa
+func (i domainInteractor) translateDomainIpa(body *public.DomainIpa, domainIpa *model.Ipa) error {
+	domainIpa.RealmName = pointy.String(body.RealmName)
 
 	// Translate realm domains
-	i.registerOrUpdateRhelIdmRealmDomains(body, domainIpa)
+	i.translateRealmDomains(body, domainIpa)
 
 	// Certificate list
-	i.registerOrUpdateRhelIdmCaCerts(body, domainIpa)
+	i.translateIdmCaCerts(body, domainIpa)
 
 	// Server list
-	i.registerOrUpdateRhelIdmServers(body, domainIpa)
+	i.translateIdmServers(body, domainIpa)
 
 	// Location list
-	i.registerOrUpdateRhelIdmLocations(body, domainIpa)
+	i.translateIdmLocations(body, domainIpa)
 
 	return nil
 }
 
-func (i domainInteractor) registerOrUpdateRhelIdmRealmDomains(body *public.Domain, domainIpa *model.Ipa) {
-	if body.RhelIdm.RealmDomains == nil {
+func (i domainInteractor) translateRealmDomains(body *public.DomainIpa, domainIpa *model.Ipa) {
+	if body.RealmDomains == nil {
 		domainIpa.RealmDomains = pq.StringArray{}
 		return
 	}
 	domainIpa.RealmDomains = make(pq.StringArray, 0)
 	domainIpa.RealmDomains = append(
 		domainIpa.RealmDomains,
-		body.RhelIdm.RealmDomains...,
+		body.RealmDomains...,
 	)
 }
 
-func (i domainInteractor) registerOrUpdateRhelIdmCaCerts(body *public.Domain, domainIpa *model.Ipa) {
-	if body.RhelIdm.CaCerts == nil {
+func (i domainInteractor) translateIdmCaCerts(body *public.DomainIpa, domainIpa *model.Ipa) {
+	if body.CaCerts == nil {
 		domainIpa.CaCerts = []model.IpaCert{}
 		return
 	}
-	domainIpa.CaCerts = make([]model.IpaCert, len(body.RhelIdm.CaCerts))
-	for idx := range body.RhelIdm.CaCerts {
-		i.registerOrUpdateRhelIdmCaCertOne(&domainIpa.CaCerts[idx], &body.RhelIdm.CaCerts[idx])
+	domainIpa.CaCerts = make([]model.IpaCert, len(body.CaCerts))
+	for idx := range body.CaCerts {
+		i.translateIdmCaCert(&domainIpa.CaCerts[idx], &body.CaCerts[idx])
 	}
 }
 
-func (i domainInteractor) registerOrUpdateRhelIdmCaCertOne(caCert *model.IpaCert, cert *api_public.Certificate) {
+func (i domainInteractor) translateIdmCaCert(caCert *model.IpaCert, cert *api_public.Certificate) {
 	caCert.Nickname = cert.Nickname
 	caCert.Issuer = cert.Issuer
 	caCert.Subject = cert.Subject
@@ -329,13 +334,13 @@ func (i domainInteractor) registerOrUpdateRhelIdmCaCertOne(caCert *model.IpaCert
 	caCert.Pem = cert.Pem
 }
 
-func (i domainInteractor) registerOrUpdateRhelIdmServers(body *public.Domain, domainIpa *model.Ipa) {
-	if body.RhelIdm.Servers == nil {
+func (i domainInteractor) translateIdmServers(body *public.DomainIpa, domainIpa *model.Ipa) {
+	if body.Servers == nil {
 		domainIpa.Servers = []model.IpaServer{}
 		return
 	}
-	domainIpa.Servers = make([]model.IpaServer, len(body.RhelIdm.Servers))
-	for idx, server := range body.RhelIdm.Servers {
+	domainIpa.Servers = make([]model.IpaServer, len(body.Servers))
+	for idx, server := range body.Servers {
 		domainIpa.Servers[idx].FQDN = server.Fqdn
 		if server.SubscriptionManagerId != nil {
 			domainIpa.Servers[idx].RHSMId = pointy.String(server.SubscriptionManagerId.String())
@@ -348,13 +353,13 @@ func (i domainInteractor) registerOrUpdateRhelIdmServers(body *public.Domain, do
 	}
 }
 
-func (i domainInteractor) registerOrUpdateRhelIdmLocations(body *public.Domain, domainIpa *model.Ipa) {
-	if body.RhelIdm.Locations == nil {
+func (i domainInteractor) translateIdmLocations(body *public.DomainIpa, domainIpa *model.Ipa) {
+	if body.Locations == nil {
 		domainIpa.Locations = []model.IpaLocation{}
 		return
 	}
-	domainIpa.Locations = make([]model.IpaLocation, len(body.RhelIdm.Locations))
-	for idx, location := range body.RhelIdm.Locations {
+	domainIpa.Locations = make([]model.IpaLocation, len(body.Locations))
+	for idx, location := range body.Locations {
 		domainIpa.Locations[idx].Name = location.Name
 		domainIpa.Locations[idx].Description = location.Description
 	}
@@ -394,7 +399,8 @@ func (i domainInteractor) guardUserUpdate(body *public.UpdateDomainUserRequest) 
 	return nil
 }
 
-func (i domainInteractor) commonRegisterUpdate(orgID string, UUID uuid.UUID, body *public.Domain) (domain *model.Domain, err error) {
+// translateDomain translates the public.Domain to the model.Domain
+func (i domainInteractor) translateDomain(orgID string, UUID uuid.UUID, body *public.Domain) (domain *model.Domain, err error) {
 	domain = &model.Domain{}
 	domain.OrgId = orgID
 	domain.DomainUuid = UUID
@@ -406,7 +412,27 @@ func (i domainInteractor) commonRegisterUpdate(orgID string, UUID uuid.UUID, bod
 	case api_public.DomainType(api_public.RhelIdm):
 		domain.Type = pointy.Uint(model.DomainTypeIpa)
 		domain.IpaDomain = &model.Ipa{}
-		err = i.registerOrUpdateRhelIdm(body, domain.IpaDomain)
+		err = i.translateDomainIpa(body.RhelIdm, domain.IpaDomain)
+	default:
+		err = fmt.Errorf("Unsupported domain_type='%s'", body.DomainType)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return domain, nil
+}
+
+// translateUpdateDomainAgent translates the public.UpdateDomainAgentRequest to the model.Domain
+func (i domainInteractor) translateUpdateDomainAgent(orgID string, UUID uuid.UUID, body *public.UpdateDomainAgentRequest) (domain *model.Domain, err error) {
+	domain = &model.Domain{}
+	domain.OrgId = orgID
+	domain.DomainUuid = UUID
+	domain.DomainName = pointy.String(body.DomainName)
+	switch body.DomainType {
+	case api_public.DomainType(api_public.RhelIdm):
+		domain.Type = pointy.Uint(model.DomainTypeIpa)
+		domain.IpaDomain = &model.Ipa{}
+		err = i.translateDomainIpa(&body.RhelIdm, domain.IpaDomain)
 	default:
 		err = fmt.Errorf("Unsupported domain_type='%s'", body.DomainType)
 	}


### PR DESCRIPTION
This is a fix/refactoring where the `domain_handler` is changed to use correct request type instead of `public.Domain` for PATCH and PUT. 

The `domains_interactor` is modified to reflect the changes.

This was made when working on HMS-2991 but it turned out that these changes are not needed for the ticket.