### PR TITLE
test: fix nil pointer dereference in smoke/register_test.go

### DIFF
--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -126,7 +126,11 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 					assert.Equal(t, *bodyRequest.Description, *body.Description)
 
 					require.NotNil(t, body.AutoEnrollmentEnabled)
-					assert.Equal(t, *bodyRequest.AutoEnrollmentEnabled, *body.AutoEnrollmentEnabled)
+					if bodyRequest.AutoEnrollmentEnabled != nil && body.AutoEnrollmentEnabled != nil {
+						assert.Equal(t, *bodyRequest.AutoEnrollmentEnabled, *body.AutoEnrollmentEnabled)
+					} else {
+						assert.False(t, *body.AutoEnrollmentEnabled)
+					}
 
 					// Check rhel-idm
 					if bodyRequest != nil {


### PR DESCRIPTION
The test was intermittently failing with:

```
    panic.go:261: test panicked: runtime error: invalid memory address or nil pointer dereference
        goroutine 85 [running]:
        runtime/debug.Stack()
        	/usr/local/go/src/runtime/debug/stack.go:24 +0x5e
        github.com/stretchr/testify/suite.failOnPanic(0xc000583d40, {0x1bbac60, 0x2f99620})
        	/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:89 +0x37
        github.com/stretchr/testify/suite.Run.func1.1()
        	/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:188 +0x25d
        panic({0x1bbac60?, 0x2f99620?})
        	/usr/local/go/src/runtime/panic.go:914 +0x21f
        github.com/podengo-project/idmsvc-backend/internal/test/smoke.(*SuiteRegisterDomain).TestRegisterDomain.func1(0xc000c22000?, 0xc000a96910)
        	/__w/idmsvc-backend/idmsvc-backend/internal/test/smoke/register_test.go:129 +0x2c5
        github.com/podengo-project/idmsvc-backend/internal/test/smoke.(*SuiteRegisterDomain).TestRegisterDomain.WrapBodyFuncDomainResponse.func3(0xc00088f478?, {0xc000c22000, 0x26df, 0x3000})
        	/__w/idmsvc-backend/idmsvc-backend/internal/test/smoke/register_test.go:47 +0x8b
        github.com/podengo-project/idmsvc-backend/internal/test/smoke.(*SuiteBase).RunTestCase(0xc000537680, 0xc00088f5e0)
        	/__w/idmsvc-backend/idmsvc-backend/internal/test/smoke/suite_base_test.go:687 +0x6ab
        github.com/podengo-project/idmsvc-backend/internal/test/smoke.(*SuiteBase).RunTestCases(0xc000537680, {0xc00088f5e0, 0x1, 0x18?})
        	/__w/idmsvc-backend/idmsvc-backend/internal/test/smoke/suite_base_test.go:700 +0x98
        github.com/podengo-project/idmsvc-backend/internal/test/smoke.(*SuiteRegisterDomain).TestRegisterDomain(0xc000537680)
        	/__w/idmsvc-backend/idmsvc-backend/internal/test/smoke/register_test.go:157 +0x50f
        reflect.Value.call({0xc0005587c0?, 0xc0004ad950?, 0xc00088fd48?}, {0x1d539b4, 0x4}, {0xc00088fe70, 0x1, 0xc00088fd78?})
        	/usr/local/go/src/reflect/value.go:596 +0xce7
        reflect.Value.Call({0xc0005587c0?, 0xc0004ad950?, 0xc000537680?}, {0xc00088fe70?, 0x53ad4d?, 0x2c29828?})
        	/usr/local/go/src/reflect/value.go:380 +0xb9
        github.com/stretchr/testify/suite.Run.func1(0xc000583d40)
        	/go/pkg/mod/github.com/stretchr/testify@v1.9.0/suite/suite.go:202 +0x467
        testing.tRunner(0xc000583d40, 0xc000876090)
        	/usr/local/go/src/testing/testing.go:1595 +0xff
        created by testing.(*T).Run in goroutine 4
        	/usr/local/go/src/testing/testing.go:1648 +0x3ad
```

Probably caused by 624850f9dbfcfafafcf83a67ba4c549d6d5e543f. E.g. seen here: https://github.com/podengo-project/idmsvc-backend/actions/runs/9789411750/job/27030465991 