### PR TITLE
feat(HMS-4276): add context primitives

### DIFF
--- a/internal/infrastructure/context/gorm.go
+++ b/internal/infrastructure/context/gorm.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type keyDB string
+
+// CtxWithDB create a context that contain the specified
+// *gorm.DB value.
+func CtxWithDB(ctx context.Context, db *gorm.DB) context.Context {
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	if db == nil {
+		panic("'db' is nil")
+	}
+	key := keyDB("db")
+	return context.WithValue(ctx, key, db)
+}
+
+// DBFromCtx get a db from a specified context.
+func DBFromCtx(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	key := keyDB("db")
+	db, ok := ctx.Value(key).(*gorm.DB)
+	if !ok {
+		panic("'db' could not be read")
+	}
+	return db
+}

--- a/internal/infrastructure/context/gorm_test.go
+++ b/internal/infrastructure/context/gorm_test.go
@@ -1,0 +1,45 @@
+package context
+
+import (
+	"context"
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithDB(t *testing.T) {
+	require.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = CtxWithDB(nil, nil)
+	})
+
+	ctx := context.TODO()
+	require.PanicsWithValue(t, "'db' is nil", func() {
+		_ = CtxWithDB(ctx, nil)
+	})
+
+	_, dbMock, err := test.NewSqlMock(nil)
+	require.NoError(t, err)
+	assert.NotPanics(t, func() {
+		ctx = CtxWithDB(ctx, dbMock)
+	})
+}
+
+func TestDBFromCtx(t *testing.T) {
+	require.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = DBFromCtx(nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'db' could not be read", func() {
+		_ = DBFromCtx(ctx)
+	})
+
+	_, dbMock, err := test.NewSqlMock(nil)
+	require.NoError(t, err)
+	ctx = CtxWithDB(ctx, dbMock)
+
+	db := DBFromCtx(ctx)
+	require.NotNil(t, db)
+}

--- a/internal/infrastructure/context/slog.go
+++ b/internal/infrastructure/context/slog.go
@@ -1,0 +1,34 @@
+package context
+
+import (
+	"context"
+	"log/slog"
+)
+
+type keySlog string
+
+// CtxWithLog create a context that contain the specified
+// *slog.Logger value.
+func CtxWithLog(ctx context.Context, log *slog.Logger) context.Context {
+	key := keySlog("log")
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	if log == nil {
+		panic("'log' is nil")
+	}
+	return context.WithValue(ctx, key, log)
+}
+
+// LogFromCtx get a log from a specified context.
+func LogFromCtx(ctx context.Context) *slog.Logger {
+	key := keySlog("log")
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	l, ok := ctx.Value(key).(*slog.Logger)
+	if !ok {
+		panic("'log' could not be read")
+	}
+	return l
+}

--- a/internal/infrastructure/context/slog_test.go
+++ b/internal/infrastructure/context/slog_test.go
@@ -1,0 +1,47 @@
+package context
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithLog(t *testing.T) {
+	assert.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = CtxWithLog(nil, nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'log' is nil", func() {
+		_ = CtxWithLog(ctx, nil)
+	})
+	require.NotNil(t, ctx)
+
+	assert.NotPanics(t, func() {
+		ctx = CtxWithLog(ctx, slog.Default())
+	})
+	require.NotNil(t, ctx)
+}
+
+func TestLogFromCtx(t *testing.T) {
+	var log *slog.Logger
+
+	assert.PanicsWithValue(t, "'ctx' is nil", func() {
+		log = LogFromCtx(nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'log' could not be read", func() {
+		log = LogFromCtx(ctx)
+	})
+	require.Nil(t, log)
+
+	assert.NotPanics(t, func() {
+		ctx = CtxWithLog(ctx, slog.Default())
+		log = LogFromCtx(ctx)
+	})
+	require.NotNil(t, log)
+}


### PR DESCRIPTION
This change add primitives to add
`log` and `db` connector reference to the
`context.Context` for the request context,
and to recover from the `context.Context`.

The `db` connection belong to the request
scope too, so to keep consistency it is
added too.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/262

https://issues.redhat.com/browse/HMS-4276
