### PR TITLE
bump(rhin-1706): base container image

### DIFF
--- a/build/package/Dockerfile
+++ b/build/package/Dockerfile
@@ -3,7 +3,7 @@
 ##
 
 # https://catalog.redhat.com/software/containers/ubi9/go-toolset/61e5c00b4ec9945c18787690
-FROM registry.access.redhat.com/ubi9/go-toolset:1.21.9-1.1714671022@sha256:15e7344d24e3d191c6595fe043323bde27c25e1220f8cc77cd6c5cd5d1ff10c2 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.21.11-2.1720624888@sha256:5c948cdfd0132e982426bc9d3a81eeae66871080ef274abdde1a4a8303509188 as builder
 LABEL idmsvc-backend=builder
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1
@@ -15,7 +15,7 @@ RUN make get-deps build
 
 
 # https://catalog.redhat.com/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d
-FROM registry.access.redhat.com/ubi9/ubi-minimal:9.4-949.1714662671@sha256:cb6f20b9225031c8d704af95932c0331cfe0b229cd5b3dd805681d92a439186e
+FROM registry.access.redhat.com/ubi9-minimal@sha256:a7d837b00520a32502ada85ae339e33510cdfdbc8d2ddf460cc838e12ec5fa5a
 LABEL idmsvc-backend=backend
 # https://developers.redhat.com/articles/2022/05/31/your-go-application-fips-compliant
 ENV OPENSSL_FORCE_FIPS_MODE=1


### PR DESCRIPTION
This change bump the base container image to the
current most recent version.