### PR TITLE
bump(rhin-1706): python requirements

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 -r requirements.txt
-wheel>=0.38.4,<0.39.0
+wheel>=0.43.0,<0.44.0
 pre-commit>=2.21.0,<2.22.0
-crc-bonfire>=5.7.0,<5.8.0
+crc-bonfire>=5.10.0,<5.11.0
 json2yaml>=1.2.0,<1.3.0
-requests>=2.31.0,<2.32.0
-yamlfix
+requests>=2.32.0,<2.33.0
+yamlfix>=1.16.0,<1.17.0


### PR DESCRIPTION
This change bump the dependencies to the latest versions but 'pre-commit' which has a bigger version change.