### PR TITLE
Update IQE_SEL_IMAGE value to use quay.io images

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -147,7 +147,7 @@ parameters:
   - name: IQE_TEST_IMPORTANCE
     value: ''
   - name: IQE_SEL_IMAGE
-    value: 'docker.io/selenium/standalone-chrome:4.18.1-20240224'
+    value: 'quay.io/cloudservices/selenium-standalone-chrome:4.18.1-20240224'
   - name: IQE_BROWSERLOG
     value: "1"
   - name: IQE_NETLOG


### PR DESCRIPTION
Description: Docker images are not Supported and when Pipeline is trigger auto-promoter reported
Error: Image is not in imagePatterns: docker.io/selenium/standalone-chrome:4.18.1-20240224