### PR TITLE
feat(HMS-4276): add contextual log middleware

### DIFF
--- a/internal/infrastructure/context/gorm.go
+++ b/internal/infrastructure/context/gorm.go
@@ -1,0 +1,35 @@
+package context
+
+import (
+	"context"
+
+	"gorm.io/gorm"
+)
+
+type keyDB string
+
+// CtxWithDB create a context that contain the specified
+// *gorm.DB value.
+func CtxWithDB(ctx context.Context, db *gorm.DB) context.Context {
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	if db == nil {
+		panic("'db' is nil")
+	}
+	key := keyDB("db")
+	return context.WithValue(ctx, key, db)
+}
+
+// DBFromCtx get a db from a specified context.
+func DBFromCtx(ctx context.Context) *gorm.DB {
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	key := keyDB("db")
+	db, ok := ctx.Value(key).(*gorm.DB)
+	if !ok {
+		panic("'db' could not be read")
+	}
+	return db
+}

--- a/internal/infrastructure/context/gorm_test.go
+++ b/internal/infrastructure/context/gorm_test.go
@@ -1,0 +1,45 @@
+package context
+
+import (
+	"context"
+	"testing"
+
+	"github.com/podengo-project/idmsvc-backend/internal/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithDB(t *testing.T) {
+	require.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = CtxWithDB(nil, nil)
+	})
+
+	ctx := context.TODO()
+	require.PanicsWithValue(t, "'db' is nil", func() {
+		_ = CtxWithDB(ctx, nil)
+	})
+
+	_, dbMock, err := test.NewSqlMock(nil)
+	require.NoError(t, err)
+	assert.NotPanics(t, func() {
+		ctx = CtxWithDB(ctx, dbMock)
+	})
+}
+
+func TestDBFromCtx(t *testing.T) {
+	require.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = DBFromCtx(nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'db' could not be read", func() {
+		_ = DBFromCtx(ctx)
+	})
+
+	_, dbMock, err := test.NewSqlMock(nil)
+	require.NoError(t, err)
+	ctx = CtxWithDB(ctx, dbMock)
+
+	db := DBFromCtx(ctx)
+	require.NotNil(t, db)
+}

--- a/internal/infrastructure/context/slog.go
+++ b/internal/infrastructure/context/slog.go
@@ -1,0 +1,34 @@
+package context
+
+import (
+	"context"
+	"log/slog"
+)
+
+type keySlog string
+
+// CtxWithLog create a context that contain the specified
+// *slog.Logger value.
+func CtxWithLog(ctx context.Context, log *slog.Logger) context.Context {
+	key := keySlog("log")
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	if log == nil {
+		panic("'log' is nil")
+	}
+	return context.WithValue(ctx, key, log)
+}
+
+// LogFromCtx get a log from a specified context.
+func LogFromCtx(ctx context.Context) *slog.Logger {
+	key := keySlog("log")
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	l, ok := ctx.Value(key).(*slog.Logger)
+	if !ok {
+		panic("'log' could not be read")
+	}
+	return l
+}

--- a/internal/infrastructure/context/slog_test.go
+++ b/internal/infrastructure/context/slog_test.go
@@ -1,0 +1,47 @@
+package context
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCtxWithLog(t *testing.T) {
+	assert.PanicsWithValue(t, "'ctx' is nil", func() {
+		_ = CtxWithLog(nil, nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'log' is nil", func() {
+		_ = CtxWithLog(ctx, nil)
+	})
+	require.NotNil(t, ctx)
+
+	assert.NotPanics(t, func() {
+		ctx = CtxWithLog(ctx, slog.Default())
+	})
+	require.NotNil(t, ctx)
+}
+
+func TestLogFromCtx(t *testing.T) {
+	var log *slog.Logger
+
+	assert.PanicsWithValue(t, "'ctx' is nil", func() {
+		log = LogFromCtx(nil)
+	})
+
+	ctx := context.TODO()
+	assert.PanicsWithValue(t, "'log' could not be read", func() {
+		log = LogFromCtx(ctx)
+	})
+	require.Nil(t, log)
+
+	assert.NotPanics(t, func() {
+		ctx = CtxWithLog(ctx, slog.Default())
+		log = LogFromCtx(ctx)
+	})
+	require.NotNil(t, log)
+}

--- a/internal/infrastructure/logger/middleware.go
+++ b/internal/infrastructure/logger/middleware.go
@@ -6,6 +6,7 @@ import (
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	app_context "github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
 )
 
 // This requires the following values to be set in
@@ -19,6 +20,9 @@ func MiddlewareLogValues(c echo.Context, v middleware.RequestLoggerValues) error
 	var logLevel slog.Level
 	var logAttr []slog.Attr = make([]slog.Attr, 5)
 
+	ctx := c.Request().Context()
+	log := app_context.LogFromCtx(ctx)
+
 	req := c.Request()
 	res := c.Response()
 
@@ -28,7 +32,6 @@ func MiddlewareLogValues(c echo.Context, v middleware.RequestLoggerValues) error
 	}
 
 	logAttr = append(logAttr,
-		slog.String("request_id", request_id),
 		slog.String("method", v.Method),
 		slog.String("uri", v.URI),
 		slog.Int("status", v.Status),
@@ -40,8 +43,8 @@ func MiddlewareLogValues(c echo.Context, v middleware.RequestLoggerValues) error
 		logAttr = append(logAttr, slog.String("err", v.Error.Error()))
 	}
 
-	slog.LogAttrs(
-		c.Request().Context(),
+	log.LogAttrs(
+		ctx,
 		logLevel,
 		"http_request",
 		logAttr...,

--- a/internal/infrastructure/middleware/logger.go
+++ b/internal/infrastructure/middleware/logger.go
@@ -1,0 +1,51 @@
+package middleware
+
+import (
+	"log/slog"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/podengo-project/idmsvc-backend/internal/api/header"
+	app_context "github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
+)
+
+const (
+	successRequest = "success request"
+)
+
+type LogConfig struct {
+	Skipper middleware.Skipper
+}
+
+func ContextLogConfig(cfg *LogConfig) echo.MiddlewareFunc {
+	if cfg == nil {
+		panic("'cfg' is nil")
+	}
+	if cfg.Skipper == nil {
+		cfg.Skipper = middleware.DefaultSkipper
+	}
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			if cfg.Skipper(c) {
+				return next(c)
+			}
+
+			requestID := c.Request().Header.Get(header.HeaderXRequestID)
+
+			// Let print the request-id for every call of the
+			// request log
+			logger := slog.Default().With(
+				slog.String("request-id", requestID),
+			)
+			ctx := c.Request().Context()
+			ctx = app_context.CtxWithLog(ctx, logger)
+			req := c.Request().WithContext(ctx)
+			c.SetRequest(req)
+
+			// Splitted in two lines for a better debugging
+			// experience
+			err := next(c)
+			return err
+		}
+	}
+}

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -8,6 +8,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/podengo-project/idmsvc-backend/internal/handler"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	app_middleware "github.com/podengo-project/idmsvc-backend/internal/infrastructure/middleware"
 	"github.com/podengo-project/idmsvc-backend/internal/metrics"
 )
 
@@ -69,6 +70,9 @@ func configCommonMiddlewares(e *echo.Echo, c RouterConfig) {
 		c.MetricsPath,
 	}
 
+	e.Use(app_middleware.ContextLogConfig(&app_middleware.LogConfig{
+		Skipper: loggerSkipperWithPaths(skipperPaths...),
+	}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		// Request logger values for middleware.RequestLoggerValues
 		LogError:  true,

--- a/internal/infrastructure/service/impl/mock/rbac/impl/rbac.go
+++ b/internal/infrastructure/service/impl/mock/rbac/impl/rbac.go
@@ -16,6 +16,7 @@ import (
 	"github.com/labstack/echo/v4/middleware"
 	"github.com/podengo-project/idmsvc-backend/internal/config"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	app_middleware "github.com/podengo-project/idmsvc-backend/internal/infrastructure/middleware"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/service"
 	"gopkg.in/yaml.v3"
 )
@@ -134,6 +135,7 @@ func NewRbacMock(ctx context.Context, cfg *config.Config) (service.ApplicationSe
 	ctx, cancelFunc = context.WithCancel(ctx)
 	e := echo.New()
 	e.Pre(middleware.RemoveTrailingSlash())
+	e.Use(app_middleware.ContextLogConfig(&app_middleware.LogConfig{}))
 	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
 		// Request logger values for middleware.RequestLoggerValues
 		LogError:  true,


### PR DESCRIPTION
Add middleware which provide contextual log which print-out the `request-id` for all the messages:

- Add new middleware.
- Initialize middleware for the http router.
- Initialize middleware for the mock rbac service.
- Update current middleware to use the log instance from the request context.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/267

https://issues.redhat.com/browse/HMS-4276