### PR TITLE
Revert back to old image as the latest image is not stable

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -147,7 +147,7 @@ parameters:
   - name: IQE_TEST_IMPORTANCE
     value: ''
   - name: IQE_SEL_IMAGE
-    value: 'quay.io/cloudservices/selenium-standalone-chrome:4.18.1-20240224'
+    value: 'quay.io/redhatqe/selenium-standalone:ff_91.9.1esr_chrome_103.0.5060.114'
   - name: IQE_BROWSERLOG
     value: "1"
   - name: IQE_NETLOG


### PR DESCRIPTION
The pipeline is paused at INFO: sending shutdown request to selenium... 
The issue was with tests, not images, so reverting to the old image.