### PR TITLE
fix: url to renew token

### DIFF
--- a/scripts/mk/private.example.mk
+++ b/scripts/mk/private.example.mk
@@ -35,7 +35,7 @@ CONTAINER_IMAGE_BASE ?= quay.io/$(QUAY_LOGIN)/$(QUAY_REPOSITORY)
 #   https://access.redhat.com/RegistryAuthentication
 #   https://access.redhat.com/RegistryAuthentication#creating-registry-service-accounts-6
 # To retrieve your token or regenerate it, go to:
-#   https://access.redhat.com/terms-based-registry/#/token/YOUR_USERNAME
+#   https://access.redhat.com/terms-based-registry/token/YOUR_USERNAME
 # Use the user and token from the "Docker login" tab (e.g. `12345|nickname`).
 # If the Dockerfile is using the authenticated repositories, you will need this values
 # The build_deploy.sh script which is called by jenkins job automation, log in the


### PR DESCRIPTION
It was detected a wrong url into the
scripts/mk/private.example.mk file which
is used to get started the configuration
for the development environment.

This change update the url to renew the
token when we could need so it is easy
to make the operation for the developer.