### PR TITLE
fix(HMS-4522): use contextual log in middlewares

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity_test.go
+++ b/internal/infrastructure/middleware/enforce_identity_test.go
@@ -53,6 +53,7 @@ func helperNewEchoEnforceIdentity(m echo.MiddlewareFunc) *echo.Echo {
 	h := func(c echo.Context) error {
 		return c.String(http.StatusOK, "Ok")
 	}
+	e.Use(ContextLogConfig(&LogConfig{}))
 	e.Use(CreateContext())
 	e.Use(m)
 	e.Add("GET", testPath, h)
@@ -197,6 +198,7 @@ func TestEnforceIdentityNoDomainContext(t *testing.T) {
 		return c.String(http.StatusOK, "Ok")
 	}
 	e.Use(
+		ContextLogConfig(&LogConfig{}),
 		EnforceIdentityWithConfig(
 			&IdentityConfig{
 				Predicates: []IdentityPredicateEntry{

--- a/internal/infrastructure/middleware/logger.go
+++ b/internal/infrastructure/middleware/logger.go
@@ -35,7 +35,7 @@ func ContextLogConfig(cfg *LogConfig) echo.MiddlewareFunc {
 			// Let print the request-id for every call of the
 			// request log
 			logger := slog.Default().With(
-				slog.String("request-id", requestID),
+				slog.String("request_id", requestID),
 			)
 			ctx := c.Request().Context()
 			ctx = app_context.CtxWithLog(ctx, logger)

--- a/internal/infrastructure/middleware/rbac_test.go
+++ b/internal/infrastructure/middleware/rbac_test.go
@@ -18,6 +18,7 @@ import (
 
 func helperRbacSetupEcho(config *RBACConfig, method, path string, status int) *echo.Echo {
 	e := echo.New()
+	e.Use(ContextLogConfig(&LogConfig{}))
 	e.Use(CreateContext())
 	e.Use(EnforceIdentityWithConfig(&IdentityConfig{}))
 	e.Use(RBACWithConfig(config))

--- a/internal/usecase/client/inventory/host_inventory_test.go
+++ b/internal/usecase/client/inventory/host_inventory_test.go
@@ -44,6 +44,8 @@ func newMockInventoryServer(
 		status,
 		body,
 		nil,
+
+		middleware.ContextLogConfig(&middleware.LogConfig{}),
 		middleware.CreateContext(),
 		middleware.EnforceIdentityWithConfig(
 			&middleware.IdentityConfig{}),
@@ -163,7 +165,8 @@ func TestGetHostByCN(t *testing.T) {
 	)
 	defer e.Shutdown(context.Background())
 
-	cfg.Clients.InventoryBaseURL = fmt.Sprintf("http://localhost:%s/api/inventory/v1", readPort(e.Listener.Addr().String()))
+	mockPort := e.Listener.Addr().String()
+	cfg.Clients.InventoryBaseURL = fmt.Sprintf("http://localhost:%s/api/inventory/v1", readPort(mockPort))
 	cli := NewHostInventory(&cfg)
 	host, err := cli.GetHostByCN(api_header.EncodeXRHID(&xrhid), "test", cn)
 	require.NoError(t, err)


### PR DESCRIPTION
If a middleware is configured after the contextual log, then it should use it, so the traceability
information is printed out with the messages.

This change add the above for enforcement and rbac middleware.

https://issues.redhat.com/browse/HMS-4522