### PR TITLE
chore(HMS-4521): clowder - default logging level set to info

### DIFF
--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -196,7 +196,7 @@ parameters:
     description: |
       The resource request for the memory per pod
   - name: LOGGING_LEVEL
-    value: warn
+    value: info
     description: |
       The log level for the deployment; valid values
       are "info", "warn", "error", "debug", "trace".


### PR DESCRIPTION
It was agreed as the least-verbose level accross all envs.