### PR TITLE
fix(HMS-4544): remove RequestID middleware

### DIFF
--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/labstack/echo/v4"
 	echo_middleware "github.com/labstack/echo/v4/middleware"
-	"github.com/podengo-project/idmsvc-backend/internal/api/header"
 	"github.com/podengo-project/idmsvc-backend/internal/api/openapi"
 	"github.com/podengo-project/idmsvc-backend/internal/api/public"
 	"github.com/podengo-project/idmsvc-backend/internal/config"
@@ -193,11 +192,6 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 			Metrics: c.Metrics,
 		},
 	)
-	requestIDMiddleware := echo_middleware.RequestIDWithConfig(
-		echo_middleware.RequestIDConfig{
-			TargetHeader: header.HeaderXRequestID, // TODO Check this name is the expected
-		},
-	)
 	validateAPI := middleware.DefaultNooperation
 	if c.EnableAPIValidator {
 		middleware.InitOpenAPIFormats()
@@ -223,7 +217,6 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 		echo_middleware.Secure(),
 		// TODO Check if this is made by 3scale
 		// middleware.CORSWithConfig(middleware.CORSConfig{}),
-		requestIDMiddleware,
 		validateAPI,
 	)
 

--- a/internal/test/smoke/domain_list_test.go
+++ b/internal/test/smoke/domain_list_test.go
@@ -146,7 +146,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				Method: http.MethodGet,
 				URL:    url1,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
+					header.HeaderXRequestID: {"test_domains_list_1"},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -154,8 +154,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				StatusCode: http.StatusOK,
 				Header: http.Header{
 					// FIXME Avoid hardcode the key name of the header
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {
 					require.NotNil(t, body)
@@ -185,7 +184,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				Method: http.MethodGet,
 				URL:    url2,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
+					header.HeaderXRequestID: {"test_domains_list_2"},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -193,8 +192,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				StatusCode: http.StatusOK,
 				Header: http.Header{
 					// FIXME Avoid hardcode the key name of the header
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 					// TODO Check format for X-Rh-Idm-Version
 				},
 				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {
@@ -225,7 +223,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				Method: http.MethodGet,
 				URL:    url3,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
+					header.HeaderXRequestID: {"test_domains_list_3"},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -233,8 +231,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				StatusCode: http.StatusOK,
 				Header: http.Header{
 					// FIXME Avoid hardcode the key name of the header
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 					// TODO Check format for X-Rh-Idm-Version
 				},
 				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {
@@ -265,7 +262,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				Method: http.MethodGet,
 				URL:    url4,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
+					header.HeaderXRequestID: {"test_domains_list_4"},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -273,8 +270,7 @@ func (s *SuiteListDomains) TestListDomains() {
 				StatusCode: http.StatusOK,
 				Header: http.Header{
 					// FIXME Avoid hardcode the key name of the header
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 					// TODO Check format for X-Rh-Idm-Version
 				},
 				BodyFunc: WrapBodyFuncListDomainsResponse(func(t *testing.T, body *public.ListDomainsResponse) error {

--- a/internal/test/smoke/domain_patch_user_test.go
+++ b/internal/test/smoke/domain_patch_user_test.go
@@ -45,8 +45,7 @@ func (s *SuiteDomainUpdateUser) TestPatchDomain() {
 			Expected: TestCaseExpect{
 				StatusCode: http.StatusOK,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_domain_patch"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
 					require.NotNil(t, body)

--- a/internal/test/smoke/domain_read_test.go
+++ b/internal/test/smoke/domain_read_test.go
@@ -39,7 +39,7 @@ func (s *SuiteReadDomain) TestReadDomain() {
 				Method: http.MethodGet,
 				URL:    url,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
+					header.HeaderXRequestID: {"test_read"},
 				},
 				Body: builder_api.NewDomain(domainName).Build(),
 			},
@@ -47,8 +47,7 @@ func (s *SuiteReadDomain) TestReadDomain() {
 				// FIXME It must be http.StatusCreated
 				StatusCode: http.StatusOK,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
 					test_assert.AssertDomain(t, s.Domains[0], body)

--- a/internal/test/smoke/domain_update_system_test.go
+++ b/internal/test/smoke/domain_update_system_test.go
@@ -137,8 +137,7 @@ func (s *SuiteDomainUpdateAgent) TestUpdateDomain() {
 			Expected: TestCaseExpect{
 				StatusCode: http.StatusOK,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_domain_update"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
 					test_assert.AssertDomain(t, expectedResponse, body)

--- a/internal/test/smoke/register_test.go
+++ b/internal/test/smoke/register_test.go
@@ -88,7 +88,7 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 				Method:       http.MethodPost,
 				URL:          url,
 				Header: http.Header{
-					header.HeaderXRequestID:              {"test_token"},
+					header.HeaderXRequestID:              {"test_register"},
 					header.HeaderXRHIDMRegistrationToken: {s.token.DomainToken},
 					header.HeaderXRHIDMVersion: {
 						header.EncodeXRHIDMVersion(
@@ -106,8 +106,7 @@ func (s *SuiteRegisterDomain) TestRegisterDomain() {
 			Expected: TestCaseExpect{
 				StatusCode: http.StatusCreated,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncDomainResponse(func(t *testing.T, body *public.Domain) error {
 					require.NotNil(t, body)

--- a/internal/test/smoke/token_create_test.go
+++ b/internal/test/smoke/token_create_test.go
@@ -81,8 +81,7 @@ func (s *SuiteTokenCreate) TestToken() {
 			Expected: TestCaseExpect{
 				StatusCode: http.StatusOK,
 				Header: http.Header{
-					header.HeaderXRequestID: {"test_token"},
-					header.HeaderXRHID:      nil,
+					header.HeaderXRHID: nil,
 				},
 				BodyFunc: WrapBodyFuncTokenResponse(func(t *testing.T, body *public.DomainRegTokenResponse) error {
 					assert.NotEmpty(t, body.DomainToken)


### PR DESCRIPTION
This change remove the RequestID middleware as
it would be duplicated then in the response to
then end user.

Credits on @pvoborni