### PR TITLE
feat(HMS-4532): mock pendo

### DIFF
--- a/cmd/mock-pendo/main.go
+++ b/cmd/mock-pendo/main.go
@@ -1,0 +1,44 @@
+package main
+
+import (
+	"context"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	mock_pendo_impl "github.com/podengo-project/idmsvc-backend/internal/infrastructure/service/impl/mock/pendo/impl"
+)
+
+func startSignalHandler(c context.Context) (context.Context, context.CancelFunc) {
+	if c == nil {
+		c = context.Background()
+	}
+	ctx, cancel := context.WithCancel(c)
+	go func() {
+		exit := make(chan os.Signal, 1)
+		signal.Notify(exit, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
+		<-exit
+		cancel()
+	}()
+	return ctx, cancel
+}
+
+func main() {
+	ctx, cancel := startSignalHandler(context.Background())
+	defer cancel()
+
+	cfg := config.Get()
+	logger.InitLogger(cfg)
+	srvPendo, mockPendo := mock_pendo_impl.NewPendoMock(ctx, cfg)
+	_ = mockPendo
+
+	if err := srvPendo.Start(); err != nil {
+		panic(err)
+	}
+	<-ctx.Done()
+	if err := srvPendo.Stop(); err != nil {
+		panic(err)
+	}
+}

--- a/deployments/docker-compose.yaml
+++ b/deployments/docker-compose.yaml
@@ -125,7 +125,6 @@ services:
   #       timeout: 3s
   #       start_period: 5s
 
-  # 'make test' will fail with mock-rbac running
   mock-rbac:
     image: "${MOCK_RBAC_CONTAINER}"
     build:
@@ -137,6 +136,21 @@ services:
       CONFIG_PATH: /opt/etc
     ports:
       - 8020:8020
+    volumes:
+      - ../configs/config.yaml:/opt/etc/config.yaml:z
+
+  mock-pendo:
+    image: "${MOCK_PENDO_CONTAINER}"
+    build:
+      dockerfile: build/mock-pendo/Dockerfile
+      context: ../
+    environment:
+      CLIENTS_PENDO_BASE_URL: http://0.0.0.0:8030/api/pendo/v1
+      CLIENTS_PENDO_API_KEY: test-pendo-key
+      CLIENTS_PENDO_REQUEST_TIMEOUT_SECS: 10
+      CONFIG_PATH: /opt/etc
+    ports:
+      - 8030:8030
     volumes:
       - ../configs/config.yaml:/opt/etc/config.yaml:z
 

--- a/internal/infrastructure/service/impl/mock/pendo/impl/pendo.go
+++ b/internal/infrastructure/service/impl/mock/pendo/impl/pendo.go
@@ -1,0 +1,185 @@
+package impl
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	app_middleware "github.com/podengo-project/idmsvc-backend/internal/infrastructure/middleware"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/service"
+	"github.com/podengo-project/idmsvc-backend/internal/interface/client/pendo"
+)
+
+var (
+	errRbacMockAwaitTimeout = errors.New("timeout awaiting rbac mock to be ready")
+	errRbacMockUnknown      = errors.New("unknown error happened on rbac mock")
+)
+
+type MockPendo interface {
+	GetBaseURL() string
+	WaitAddress(timeout time.Duration) error
+	// TODO Add here additional methods
+	GetMetrics() pendo.SetMetadataRequest
+}
+
+type mockPendo struct {
+	echo       *echo.Echo
+	lock       sync.RWMutex
+	context    context.Context
+	cancelFunc context.CancelFunc
+	address    string
+	waitGroup  *sync.WaitGroup
+	port       string
+	appName    string
+	// TODO Add here additional fields
+	metrics pendo.SetMetadataRequest // TODO This will change as we remove uncertainty
+}
+
+func newPendoMockGuards(ctx context.Context, cfg *config.Config) {
+	if ctx == nil {
+		panic("'ctx' is nil")
+	}
+	if cfg == nil {
+		panic("'cfg' is nil")
+	}
+	if cfg.Clients.PendoBaseURL == "" {
+		panic("'Config.Clients.PendoBaseURL' is an empty string")
+	}
+	if cfg.Clients.PendoAPIKey == "" {
+		panic("'Config.Clients.PendoAPIKey' is an empty string")
+	}
+}
+
+// NewPendoMock return a new rbac mock service for testing.
+func NewPendoMock(ctx context.Context, cfg *config.Config) (service.ApplicationService, MockPendo) {
+	var cancelFunc context.CancelFunc
+	newPendoMockGuards(ctx, cfg)
+	urlData, err := url.Parse(cfg.Clients.PendoBaseURL)
+	if err != nil {
+		panic(fmt.Sprintf("error parsing pendo client url: %s", err.Error()))
+	}
+	address := fmt.Sprintf("%s:%s", urlData.Hostname(), urlData.Port())
+	ctx, cancelFunc = context.WithCancel(ctx)
+	e := echo.New()
+	e.Pre(middleware.RemoveTrailingSlash())
+	e.Use(app_middleware.ContextLogConfig(&app_middleware.LogConfig{}))
+	e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+		// Request logger values for middleware.RequestLoggerValues
+		LogError:  true,
+		LogMethod: true,
+		LogStatus: true,
+		LogURI:    true,
+		// Forwards error to the global error handler, so it can decide
+		// appropriate status code.
+		HandleError:   true,
+		LogValuesFunc: logger.MiddlewareLogValues,
+	}))
+	m := &mockPendo{
+		appName:    cfg.Application.Name,
+		address:    address,
+		echo:       e,
+		context:    ctx,
+		cancelFunc: cancelFunc,
+		waitGroup:  &sync.WaitGroup{},
+		lock:       sync.RWMutex{},
+	}
+	e.POST(fmt.Sprintf("%s/:kind/:group/access", urlData.Path), m.CreateMetadataAccountCustomValue)
+	e.GET(fmt.Sprintf("%s/:kind/:group/access", urlData.Path), m.GetMetadataAccountCustomValue)
+	return m, m
+}
+
+func (m *mockPendo) Start() error {
+	m.echo.HideBanner = true
+	m.echo.Debug = false
+	m.echo.HidePort = false
+	m.waitGroup.Add(2)
+	go func() {
+		defer m.waitGroup.Done()
+		slog.Info("mock rbac service starting")
+		if err := m.echo.Start(m.address); err != nil {
+			if err != http.ErrServerClosed {
+				slog.Error(err.Error())
+			} else {
+				slog.Info("Service rbac mock closed")
+			}
+			return
+		}
+	}()
+	go func() {
+		defer m.waitGroup.Done()
+		defer m.cancelFunc()
+		<-m.context.Done()
+		if err := m.echo.Shutdown(m.context); err != nil {
+			slog.Error(err.Error())
+			return
+		}
+	}()
+	return nil
+}
+
+func (m *mockPendo) Stop() error {
+	slog.Info("mock rback service stopping")
+	defer m.waitGroup.Wait()
+	m.cancelFunc()
+	return nil
+}
+
+// WaitAddress is a naive implementation to await the rbac
+// mock has an address assigned.
+func (m *mockPendo) WaitAddress(timeout time.Duration) error {
+	isListening := false
+	deadline := time.Now().Add(timeout)
+	for time.Now().Compare(deadline) < 0 {
+		if m.echo.Listener != nil && m.echo.Listener.Addr().String() != "" {
+			slog.Info(fmt.Sprintf("rbac mock listening at: %s", m.echo.Listener.Addr().String()))
+			isListening = true
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	if !isListening {
+		if time.Now().Compare(deadline) >= 0 {
+			return errRbacMockAwaitTimeout
+		} else {
+			return errRbacMockUnknown
+		}
+	}
+	return nil
+}
+
+// GetBaseURL retrieve the base URL to reach out the
+// rbac mock.
+// Return empty string if the listener is not yet assigned;
+// see WaitAddress method.
+func (m *mockPendo) GetBaseURL() string {
+	addr := ""
+	if m.echo.Listener != nil {
+		addr = m.echo.Listener.Addr().String()
+		if addr != "" {
+			return fmt.Sprintf("http://%s/api/rbac/v1", addr)
+		}
+	}
+
+	return addr
+}
+
+// GetMetrics return a copy of the internal metrics
+func (m *mockPendo) GetMetrics() pendo.SetMetadataRequest {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	output := make(pendo.SetMetadataRequest, 0, len(m.metrics))
+	for i := range m.metrics {
+		output[i] = m.metrics[i]
+	}
+	return output
+}

--- a/internal/infrastructure/service/impl/mock/pendo/impl/pendo_handler.go
+++ b/internal/infrastructure/service/impl/mock/pendo/impl/pendo_handler.go
@@ -1,0 +1,110 @@
+package impl
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
+	"github.com/podengo-project/idmsvc-backend/internal/interface/client/pendo"
+)
+
+func (m *mockPendo) guardKindAndGroup(kind pendo.Kind, group pendo.Group) (pendo.Kind, pendo.Group, error) {
+	if kind == "" {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "'kind' is an empty string")
+	}
+	if kind != pendo.KindVisitor && kind != pendo.KindAccount {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "'kind' must be 'visitor' or 'account' but it is '%s'", kind)
+	}
+	if group == "" {
+		return "", "", echo.NewHTTPError(http.StatusBadRequest, "'group' is an empty string")
+	}
+	return kind, group, nil
+}
+
+func (m *mockPendo) guardCreateMetadataAccountCustomValue(kind pendo.Kind, group pendo.Group) (pendo.Kind, pendo.Group, error) {
+	return m.guardKindAndGroup(kind, group)
+}
+
+// CreateMetadataAccountCustomValue implement POST /metadata/:kind/:group/value
+// endpoint for the pendo mock.
+// See: https://engageapi.pendo.io/?bash%23#bd14400e-0ff9-49e6-932e-61e7a65c6f3c
+func (m *mockPendo) CreateMetadataAccountCustomValue(ctx echo.Context) error {
+	var (
+		kind    pendo.Kind
+		group   pendo.Group
+		err     error
+		metrics pendo.SetMetadataRequest
+	)
+	if kind, group, err = m.guardCreateMetadataAccountCustomValue(
+		pendo.Kind(ctx.Param("kind")),
+		pendo.Group(ctx.Param("group")),
+	); err != nil {
+		kind = kind
+		group = group
+		return err
+	}
+	if err := ctx.Bind(metrics); err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	}
+	// TODO We need more knowledge to know how this works
+	m.lock.Lock()
+	defer m.lock.Unlock()
+	m.metrics = metrics
+	return ctx.String(http.StatusOK, http.StatusText(http.StatusOK))
+}
+
+func (m *mockPendo) guardGetMetadataAccountCustomValue(
+	kind pendo.Kind,
+	group pendo.Group,
+	ID pendo.ID,
+	fieldName pendo.FieldName,
+) (pendo.Kind, pendo.Group, pendo.ID, pendo.FieldName, error) {
+	var err error
+	if kind, group, err = m.guardKindAndGroup(kind, group); err != nil {
+		return "", "", "", "", err
+	}
+	if ID == "" {
+		return "", "", "", "", echo.NewHTTPError(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	}
+	if fieldName == "" {
+		return "", "", "", "", echo.NewHTTPError(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	}
+	return kind, group, ID, fieldName, nil
+}
+
+// GetMetadataAccountCustomValue implement GET /metadata/:kind/:group/value/:id/:fieldName
+// See: https://engageapi.pendo.io/?bash%23#cb0a05c4-709f-4644-bbd7-18f066b94d7e
+func (m *mockPendo) GetMetadataAccountCustomValue(ctx echo.Context) error {
+	var (
+		kind      pendo.Kind
+		group     pendo.Group
+		ID        pendo.ID
+		fieldName pendo.FieldName
+		err       error
+		metrics   pendo.SetMetadataRequest
+	)
+	logger := context.LogFromCtx(ctx.Request().Context())
+	if kind, group, ID, fieldName, err = m.guardGetMetadataAccountCustomValue(
+		pendo.Kind(ctx.Param("kind")),
+		pendo.Group(ctx.Param("group")),
+		pendo.ID(ctx.Param("id")),
+		pendo.FieldName(ctx.Param("fieldName")),
+	); err != nil {
+		logger.Error("bad parameter")
+		return err
+	}
+	if err := ctx.Bind(metrics); err != nil {
+		logger.Error("bad payload",
+			slog.String("kind", string(kind)),
+			slog.String("group", string(group)),
+			slog.String("id", string(ID)),
+			slog.String("fieldName", string(fieldName)),
+		)
+		return echo.NewHTTPError(http.StatusBadRequest, http.StatusText(http.StatusBadRequest))
+	}
+	// TODO We need more knowledge to know how this works
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+	return ctx.JSON(http.StatusOK, m.metrics)
+}

--- a/scripts/mk/includes.mk
+++ b/scripts/mk/includes.mk
@@ -29,6 +29,7 @@ include scripts/mk/venv.mk
 # mocks
 include scripts/mk/meta-mock.mk
 include scripts/mk/mock-rbac.mk
+include scripts/mk/mock-pendo.mk
 # commands
 include scripts/mk/meta-general.mk
 include scripts/mk/help.mk

--- a/scripts/mk/mock-pendo.mk
+++ b/scripts/mk/mock-pendo.mk
@@ -1,0 +1,23 @@
+##
+# Rules to automate pendo mock tasks
+##
+
+# The tag is set manually as it is not expected to generate
+# a new image with every change on the repository.
+# Once it is generated, the same image will be used over
+# and over again.
+MOCK_PENDO_CONTAINER ?= quay.io/podengo/mock-pendo:1.0.0
+export MOCK_PENDO_CONTAINER
+
+.PHONY: mock-pendo-build
+mock-pendo-build: ## Build pendo mock container
+	$(MAKE) container-build CONTAINER_IMAGE="$(MOCK_PENDO_CONTAINER)" CONTAINER_CONTEXT_DIR="$(PROJECT_DIR)" CONTAINER_FILE="$(PROJECT_DIR)/build/mock-pendo/Dockerfile"
+
+.PHONY: mock-pendo-up
+mock-pendo-up: ## Start pendo mock using local infra
+	@[ -e "$(PROJECT_DIR)/configs/config.yaml" ] || { echo "ERROR:Missed configs/config.yaml check README.md file"; exit 1 ; }
+	$(CONTAINER_COMPOSE) -p idmsvc -f "$(COMPOSE_FILE)" up -d mock-pendo
+
+.PHONY: mock-pendo-down
+mock-pendo-down: ## Stop pendo mock using local infra
+	$(CONTAINER_COMPOSE) -p idmsvc -f "$(COMPOSE_FILE)" down mock-pendo


### PR DESCRIPTION
Quick mock service to mock pendo, to prepare
the repository to use it on smoke tests.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/292

https://issues.redhat.com/browse/HMS-4532