### PR TITLE
feat(HMS-1298): http request duration and total metrics

### DIFF
--- a/internal/infrastructure/middleware/metrics_test.go
+++ b/internal/infrastructure/middleware/metrics_test.go
@@ -26,27 +26,6 @@ func TestCreateMetricsMiddleware(t *testing.T) {
 	assert.NotNil(t, middleware)
 }
 
-func TestMapStatus(t *testing.T) {
-	type TestCase struct {
-		Name     string
-		Given    int
-		Expected string
-	}
-	testCases := []TestCase{
-		{Name: "0", Given: 0, Expected: ""},
-		{Name: "1xx", Given: http.StatusContinue, Expected: "1xx"},
-		{Name: "2xx", Given: http.StatusOK, Expected: "2xx"},
-		{Name: "3xx", Given: http.StatusMultipleChoices, Expected: "3xx"},
-		{Name: "4xx", Given: http.StatusBadRequest, Expected: "4xx"},
-		{Name: "5xx", Given: http.StatusInternalServerError, Expected: "5xx"},
-	}
-
-	for _, testCase := range testCases {
-		result := mapStatus(testCase.Given)
-		assert.Equal(t, testCase.Expected, result)
-	}
-}
-
 func TestMetricsMiddlewareWithConfigCreation(t *testing.T) {
 	var (
 		reg              *prometheus.Registry

--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -208,12 +208,12 @@ func newGroupPublic(e *echo.Group, c RouterConfig) *echo.Group {
 	// Wire the middlewares
 	e.Use(
 		middleware.CreateContext(),
+		metricsMiddleware,
 		fakeIdentityMiddleware,
 		mixedIdentityMiddleware,
 		systemIdentityMiddleware,
 		userAndSAIdentityMiddleware,
 		rbacMiddleware,
-		metricsMiddleware,
 		echo_middleware.Secure(),
 		// TODO Check if this is made by 3scale
 		// middleware.CORSWithConfig(middleware.CORSConfig{}),

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,31 +6,36 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-// TODO Update metric names according to: https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 const (
-	NameSpace           = "idmsvc"
-	HttpStatusHistogram = "http_status_histogram"
+	// NameSpace is the namespace for the Prometheus metrics
+	NameSpace = "idmsvc"
 )
 
+// Metrics holds all the Prometheus metrics for the application
 type Metrics struct {
-	HttpStatusHistogram prometheus.HistogramVec
+	// HTTPRequestDuration is a histogram that measures the duration of HTTP requests
+	HTTPRequestDuration *prometheus.HistogramVec
 
 	reg *prometheus.Registry
 }
 
+// See: https://prometheus.io/docs/instrumenting/writing_exporters/#naming
 // See: https://consoledot.pages.redhat.com/docs/dev/platform-documentation/understanding-slo.html
 // See: https://prometheus.io/docs/tutorials/understanding_metric_types/#types-of-metrics
+
+// NewMetrics creates a new Metrics instance
 func NewMetrics(reg *prometheus.Registry) *Metrics {
 	if reg == nil {
 		panic("reg cannot be nil")
 	}
 	metrics := &Metrics{
 		reg: reg,
-		HttpStatusHistogram: *promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+
+		HTTPRequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
 			Namespace: NameSpace,
-			Name:      HttpStatusHistogram,
+			Name:      "http_request_duration_seconds",
 			Help:      "Duration of HTTP requests",
-			Buckets:   prometheus.DefBuckets,
+			Buckets:   prometheus.ExponentialBuckets(0.0005, 2, 20),
 		}, []string{"status", "method", "path"}),
 	}
 


### PR DESCRIPTION
Removing the current metric (due to bad name) and also to not aggregate by status here.

It adds metrics:
- idmsvc_http_request_duration_seconds_bucket
- idmsvc_http_request_duration_seconds_sum
- idmsvc_http_request_duration_seconds_count
- idmsvc_http_requests_total