### PR TITLE
test: fix race condition in enforce_identity_test.go

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity_test.go
+++ b/internal/infrastructure/middleware/enforce_identity_test.go
@@ -506,7 +506,7 @@ func TestEnforceIdentityOrder(t *testing.T) {
 
 		// Check expectations
 		require.Condition(t, func() (success bool) {
-			return order["first"].Compare(order["second"]) < 0
+			return order["first"].Compare(order["second"]) <= 0
 		})
 	}
 }


### PR DESCRIPTION
On fast system, the first and second time could have been the same. And thus the test failed.

Changing the condition to allow the same time.