### PR TITLE
HMS-4554 Added SE_NODE_SESSION_TIMEOUT Environment Variable for Enhan…

### DIFF
--- a/deployments/testing-integration.yaml
+++ b/deployments/testing-integration.yaml
@@ -104,6 +104,8 @@ objects:
                   value: ${SELENIUM_JAVA_OPTS}
                 - name: VNC_GEOMETRY
                   value: ${VNC_GEOMETRY}
+                - name: SE_NODE_SESSION_TIMEOUT
+                  value: ${SE_NODE_SESSION_TIMEOUT}
               resources:
                 limits:
                   cpu: ${SELENIUM_CPU_LIMIT}
@@ -168,3 +170,5 @@ parameters:
     value: 100m
   - name: SELENIUM_MEMORY_REQUEST
     value: 1Gi
+  - name: SE_NODE_SESSION_TIMEOUT
+    value: "600"


### PR DESCRIPTION
…ced Stability in IdM Test Environment

Description: Introduced the SE_NODE_SESSION_TIMEOUT environment variable, setting its value to 600 seconds. This change addresses the issue encountered during testing with a newly installed IdM server, where the extended installation time caused the browser to enter an unknown state, leading to test failures. By increasing the session timeout, we ensure that tests remain stable and pass consistently, even with the added server installation duration.