### PR TITLE
fix: timeout duration of Pendo client

### DIFF
--- a/internal/usecase/client/pendo/pendo_client.go
+++ b/internal/usecase/client/pendo/pendo_client.go
@@ -158,7 +158,7 @@ func newClient(cfg *config.Config) *pendoClient {
 		cfg.Clients.PendoRequestTimeoutSecs = 3
 	}
 	client := &http.Client{
-		Timeout: time.Duration(cfg.Clients.PendoRequestTimeoutSecs),
+		Timeout: time.Duration(cfg.Clients.PendoRequestTimeoutSecs) * time.Second,
 	}
 	return &pendoClient{
 		Config: cfg,


### PR DESCRIPTION
The timeout was not using correct duration unit as default is Nanosecond.

So when used with defaults, the request almost immediately timed out.