### PR TITLE
fix: use different Pendo API keys base on endpoint

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,9 @@ type Clients struct {
 	PendoBaseURL string `mapstructure:"pendo_base_url"`
 	// PendoAPIKey indicates the shared key to communicate with the API.
 	PendoAPIKey string `mapstructure:"pendo_api_key" json:"-"`
+	// PendoTrackEventKey indicates the shared key to communicate with the API
+	// for track events.
+	PendoTrackEventKey string `mapstructure:"pendo_track_event_key" json:"-"`
 	// PendoRequestTimeoutSecs indicates the timeout for every request.
 	PendoRequestTimeoutSecs int `mapstructure:"pendo_request_timeout_secs"`
 }
@@ -244,6 +247,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.rbac_base_url", "")
 	v.SetDefault("clients.pendo_base_url", "")
 	v.SetDefault("clients.pendo_api_key", "")
+	v.SetDefault("clients.pendo_track_event_key", "")
 	v.SetDefault("clients.pendo_request_timeout_secs", 0)
 
 	// Application specific

--- a/internal/usecase/client/pendo/pendo_client.go
+++ b/internal/usecase/client/pendo/pendo_client.go
@@ -50,7 +50,7 @@ func (c *pendoClient) SetMetadata(ctx context.Context, kind pendo.Kind, group pe
 	}
 
 	// Prepare the request
-	url := c.Config.Clients.PendoBaseURL + "/metadata/" + url.PathEscape(string(kind)) + "/" + url.PathEscape(string(group)) + "/value"
+	url := c.Config.Clients.PendoBaseURL + "/api/v1/metadata/" + url.PathEscape(string(kind)) + "/" + url.PathEscape(string(group)) + "/value"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		logger.Error(err.Error())
@@ -112,9 +112,8 @@ func (c *pendoClient) SendTrackEvent(ctx context.Context, track *pendo.TrackRequ
 		return fmt.Errorf("error generating request body for SendTrackEvent")
 	}
 
-	// TODO Check by experimenting if the endpoint is correct
 	// Prepare the request
-	url := c.Config.Clients.PendoBaseURL + "/track"
+	url := c.Config.Clients.PendoBaseURL + "/data/track"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		logger.Error(err.Error())
@@ -123,7 +122,7 @@ func (c *pendoClient) SendTrackEvent(ctx context.Context, track *pendo.TrackRequ
 
 	// Add headers to the request
 	req.Header.Set("content-type", "application/json")
-	req.Header.Set(header.HeaderXPendoIntegrationKey, c.Config.Clients.PendoAPIKey)
+	req.Header.Set(header.HeaderXPendoIntegrationKey, c.Config.Clients.PendoTrackEventKey)
 
 	// Launch request
 	resp, err := c.Client.Do(req)
@@ -153,6 +152,9 @@ func newClient(cfg *config.Config) *pendoClient {
 	}
 	if cfg.Clients.PendoAPIKey == "" {
 		panic("'PendoAPIKey' is empty")
+	}
+	if cfg.Clients.PendoTrackEventKey == "" {
+		panic("'PendoTrackEventKey' is empty")
 	}
 	if cfg.Clients.PendoRequestTimeoutSecs == 0 {
 		cfg.Clients.PendoRequestTimeoutSecs = 3


### PR DESCRIPTION
Track Events and Metadata have slightly different endpoint URLs and also they use different API keys.

This change introduces the new config value for the track event key and changes the URLs.

Also now the base URL is expected to be e.g.: `https://app.pendo.io`.

Related to HMS-4503