### PR TITLE
feat: Pendo test CLI client

### DIFF
--- a/cmd/pendo-client/main.go
+++ b/cmd/pendo-client/main.go
@@ -1,0 +1,97 @@
+// Package main is the entry point for the pendo-client application.
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/podengo-project/idmsvc-backend/internal/config"
+	app_context "github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
+	pendo "github.com/podengo-project/idmsvc-backend/internal/interface/client/pendo"
+	client_pendo "github.com/podengo-project/idmsvc-backend/internal/usecase/client/pendo"
+	"github.com/spf13/cobra"
+)
+
+func initPendo() (cfg *config.Config, ctx context.Context, pendoClient pendo.Pendo) {
+	// Initialize dependencies
+	logger.LogBuildInfo("pendo-client")
+	cfg = config.Get()
+	cfg.Logging.Level = "debug"
+	logger.InitLogger(cfg)
+
+	ctx = context.Background()
+	ctx = app_context.CtxWithLog(ctx, slog.Default())
+
+	log := app_context.LogFromCtx(ctx)
+
+	// Initialize the pendo client
+	log.Info("Starting pendo-client")
+	log.Info(fmt.Sprintf("Pendo Base URL: %s", cfg.Clients.PendoBaseURL))
+	log.Info(fmt.Sprintf("Pendo API Key: %s", cfg.Clients.PendoAPIKey))
+	log.Info(fmt.Sprintf("Pendo Track Event Key: %s", cfg.Clients.PendoTrackEventKey))
+	pendoClient = client_pendo.NewClient(cfg)
+
+	return cfg, ctx, pendoClient
+}
+
+func sendPendoTrackEvent(ctx context.Context, client pendo.Pendo, event, accountID, visitorID string) {
+	log := app_context.LogFromCtx(ctx)
+	track := pendo.TrackRequest{
+		AccountID: accountID,
+		Type:      "track",
+		Event:     event,
+		VisitorID: visitorID,
+		Timestamp: time.Now().UTC().UnixMilli(),
+	}
+
+	log.Debug(fmt.Sprintf("%v", track))
+
+	err := client.SendTrackEvent(ctx, &track)
+	if err != nil {
+		log.Warn(err.Error())
+	}
+}
+
+func createRootCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "pendo-client",
+		Short: "Pendo Client",
+		Long: `pendo-client is a CLI tool to interact with the Pendo API.:
+
+	export CLIENTS_PENDO_BASE_URL="https://app.pendo.io"
+	export CLIENTS_PENDO_API_KEY="your-api-key"
+	export CLIENTS_PENDO_TRACK_EVENT_KEY="your-track-event-secret-key"
+	pendo-client track [name] [accountID] [visitorID]
+`,
+	}
+}
+
+func createTrackCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "track [name] [accountID] [visitorID]",
+		Short: "Create new Track Event",
+		Args:  cobra.ExactArgs(3),
+		Run: func(_ *cobra.Command, args []string) {
+			_, ctx, pendoClient := initPendo()
+			sendPendoTrackEvent(ctx, pendoClient, args[0], args[1], args[2])
+		},
+	}
+}
+
+func initCLI() *cobra.Command {
+	rootCmd := createRootCmd()
+	trackCmd := createTrackCmd()
+
+	rootCmd.AddCommand(trackCmd)
+	return rootCmd
+}
+
+func main() {
+	rootCmd := initCLI()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -162,6 +162,9 @@ type Clients struct {
 	PendoBaseURL string `mapstructure:"pendo_base_url"`
 	// PendoAPIKey indicates the shared key to communicate with the API.
 	PendoAPIKey string `mapstructure:"pendo_api_key" json:"-"`
+	// PendoTrackEventKey indicates the shared key to communicate with the API
+	// for track events.
+	PendoTrackEventKey string `mapstructure:"pendo_track_event_key" json:"-"`
 	// PendoRequestTimeoutSecs indicates the timeout for every request.
 	PendoRequestTimeoutSecs int `mapstructure:"pendo_request_timeout_secs"`
 }
@@ -244,6 +247,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("clients.rbac_base_url", "")
 	v.SetDefault("clients.pendo_base_url", "")
 	v.SetDefault("clients.pendo_api_key", "")
+	v.SetDefault("clients.pendo_track_event_key", "")
 	v.SetDefault("clients.pendo_request_timeout_secs", 0)
 
 	// Application specific

--- a/internal/usecase/client/pendo/pendo_client.go
+++ b/internal/usecase/client/pendo/pendo_client.go
@@ -50,7 +50,7 @@ func (c *pendoClient) SetMetadata(ctx context.Context, kind pendo.Kind, group pe
 	}
 
 	// Prepare the request
-	url := c.Config.Clients.PendoBaseURL + "/metadata/" + url.PathEscape(string(kind)) + "/" + url.PathEscape(string(group)) + "/value"
+	url := c.Config.Clients.PendoBaseURL + "/api/v1/metadata/" + url.PathEscape(string(kind)) + "/" + url.PathEscape(string(group)) + "/value"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		logger.Error(err.Error())
@@ -112,9 +112,8 @@ func (c *pendoClient) SendTrackEvent(ctx context.Context, track *pendo.TrackRequ
 		return fmt.Errorf("error generating request body for SendTrackEvent")
 	}
 
-	// TODO Check by experimenting if the endpoint is correct
 	// Prepare the request
-	url := c.Config.Clients.PendoBaseURL + "/track"
+	url := c.Config.Clients.PendoBaseURL + "/data/track"
 	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(reqBody))
 	if err != nil {
 		logger.Error(err.Error())
@@ -123,7 +122,7 @@ func (c *pendoClient) SendTrackEvent(ctx context.Context, track *pendo.TrackRequ
 
 	// Add headers to the request
 	req.Header.Set("content-type", "application/json")
-	req.Header.Set(header.HeaderXPendoIntegrationKey, c.Config.Clients.PendoAPIKey)
+	req.Header.Set(header.HeaderXPendoIntegrationKey, c.Config.Clients.PendoTrackEventKey)
 
 	// Launch request
 	resp, err := c.Client.Do(req)
@@ -153,6 +152,9 @@ func newClient(cfg *config.Config) *pendoClient {
 	}
 	if cfg.Clients.PendoAPIKey == "" {
 		panic("'PendoAPIKey' is empty")
+	}
+	if cfg.Clients.PendoTrackEventKey == "" {
+		panic("'PendoTrackEventKey' is empty")
 	}
 	if cfg.Clients.PendoRequestTimeoutSecs == 0 {
 		cfg.Clients.PendoRequestTimeoutSecs = 3


### PR DESCRIPTION
A CLI wrapper for pendo client for testing the implementation. Starting with Track Events.