### PR TITLE
Add SonarQube job to GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,8 @@ check missed commits:
 
 run tests:
   stage: test
+  rules:
+    - when: never
   tags:
     - shared
   needs: []
@@ -58,6 +60,5 @@ compile project:
   stage: build
   tags:
     - shared
-  needs: ["run tests"]
   script:
     - make build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,6 +5,7 @@ stages:
   - check
   - test
   - build
+  - sonarqube-check
 
 check missed commits:
   stage: check
@@ -62,3 +63,28 @@ compile project:
     - shared
   script:
     - make build
+
+sonarqube-check:
+  stage: sonarqube-check
+  tags:
+    - shared
+  rules:
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_BRANCH == 'main'
+    - if: $CI_COMMIT_BRANCH == 'sq-test'
+  image:
+    name: images.paas.redhat.com/alm/sonar-scanner-alpine:latest
+    entrypoint: [""]
+  variables:
+    SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"  # Defines the location of the analysis task cache
+    GIT_DEPTH: "0"  # Tells git to fetch all the branches of the project, required by the analysis task
+  dependencies:
+    - compile project
+  cache:
+    policy: pull
+    key: "${CI_COMMIT_SHORT_SHA}"
+    paths:
+      - sonar-scanner/
+  script:
+    - sonar-scanner
+  allow_failure: true

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,2 @@
+sonar.projectKey=identity-management_idmocp_idm-domains-backend_6971a5a7-d864-43cc-acf8-cb88b147bc71
+sonar.qualitygate.wait=true


### PR DESCRIPTION
Add SonarQube SAST job to git GitLab CI (needs to be GitLab because it reports to the
Red Hat internal SonarQube instance).

The GitLab `test` CI job has gone stale and doesn't work (due to no database service, and
other gaps).  Because we use GitHub for the main CI, I just disabled the tests in GitLab
rather than wrestling with them.

Because GitLab is mirroring from idmsvc, CI jobs do not run automatically.  I have set up
and **hourly** GitLab scheduled pipeline to run on the `main` branch.  After this changed
has been merged and everything is verified to be working, I will wind that back to daily
or weekly.