### PR TITLE
chore: remove vscode settings "Go: Cover on Save"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,4 @@
         "--fast"
     ],
     "go.coverageOptions": "showUncoveredCodeOnly",
-    "go.coverOnSave": true
 }


### PR DESCRIPTION
The workspace settings has this set. It triggers the tests on each save which is sometimes undesired. E.g. when working on perf tests and launching the tests separately.

Removal of this options makes it still configurable on a user level - when the user prefers it enabled.