### PR TITLE
fix(HMS-4690): configurable maximum of open DB connections

### DIFF
--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -116,6 +116,8 @@ objects:
                     key: track-event-secret
                     name: pendo-creds
                     optional: true
+              - name: DATABASE_MAX_OPEN_CONNS
+                value: "${DATABASE_MAX_OPEN_CONNS}"
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -168,6 +170,8 @@ objects:
                     name: app-secret
               - name: CLIENTS_RBAC_BASE_URL
                 value: "${CLIENTS_RBAC_BASE_URL}"
+              - name: DATABASE_MAX_OPEN_CONNS
+                value: "${DATABASE_MAX_OPEN_CONNS}"
             resources:
               limits:
                 cpu: ${CPU_LIMIT}
@@ -258,3 +262,7 @@ parameters:
     required: false
     description: |
       Point out to the pendo service base url
+  - name: DATABASE_MAX_OPEN_CONNS
+    required: false
+    description: |
+      The maximum number of open connections to the database

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -37,6 +37,9 @@ const (
 	// DefaultEnableRBAC is true
 	DefaultEnableRBAC = true
 
+	// DefaultDatabaseMaxOpenConn is the default for max open database connections
+	DefaultDatabaseMaxOpenConn = 30
+
 	// https://github.com/project-koku/koku/blob/main/koku/api/common/pagination.py
 
 	// PaginationDefaultLimit is the default limit for the pagination
@@ -78,7 +81,8 @@ type Database struct {
 	Password string `json:"-"`
 	Name     string
 	// https://stackoverflow.com/questions/54844546/how-to-unmarshal-golang-viper-snake-case-values
-	CACertPath string `mapstructure:"ca_cert_path"`
+	CACertPath   string `mapstructure:"ca_cert_path"`
+	MaxOpenConns int    `mapstructure:"max_open_conns"`
 }
 
 type Cloudwatch struct {
@@ -229,6 +233,7 @@ func setDefaults(v *viper.Viper) {
 	v.SetDefault("database.password", "")
 	v.SetDefault("database.name", "")
 	v.SetDefault("database.ca_cert_path", "")
+	v.SetDefault("database.max_open_conns", DefaultDatabaseMaxOpenConn)
 
 	// Kafka
 	addEventConfigDefaults(v)

--- a/internal/infrastructure/datastore/db.go
+++ b/internal/infrastructure/datastore/db.go
@@ -48,6 +48,12 @@ func NewDB(cfg *config.Config) (db *gorm.DB) {
 		slog.Error("Error creating database connector", slog.Any("error", err))
 		return nil
 	}
+	sqlDb, err := db.DB()
+	if err != nil {
+		slog.Error("Error getting sql driver", slog.String("error", err.Error()))
+		return nil
+	}
+	sqlDb.SetMaxOpenConns(cfg.Database.MaxOpenConns)
 	return db
 }
 
@@ -58,6 +64,7 @@ func NewDbMigration(config *config.Config) (db *gorm.DB, m *migrate.Migrate, err
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not connect to database: %w", err)
 	}
+	sqlDb.SetMaxOpenConns(config.Database.MaxOpenConns)
 
 	driver, err := postgres.WithInstance(sqlDb, &postgres.Config{})
 	if err != nil {


### PR DESCRIPTION
Introducing DATABASE_MAX_OPEN_CONN config env var to set $subj.

DB connection limit prevents reaching the same limit in database when processing a lot of concurrent requests.

30 was chosen as it is still less than 1/4th of db.t4g.small which could be the initial DB instance. Also it is less than 100 which is the default limit of Postgres container.

Note: I'm thinking it would be nice to print the config of the service on startup - with omitted or obfuscated secrets . To make it easier to validate the combination of clowder/env vars/defaults work in various envs.