### PR TITLE
fix: avoid panic due to unset XRHID on invalid path

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity.go
+++ b/internal/infrastructure/middleware/enforce_identity.go
@@ -149,11 +149,9 @@ func EnforceIdentityWithConfig(config *IdentityConfig) func(echo.HandlerFunc) ec
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
 			var (
-				xrhid    *identity.XRHID
-				xrhidRaw string
-				err      error
-				cc       DomainContextInterface
-				ok       bool
+				err error
+				cc  DomainContextInterface
+				ok  bool
 			)
 			ctx := c.Request().Context()
 			logger := app_context.LogFromCtx(ctx)
@@ -165,11 +163,8 @@ func EnforceIdentityWithConfig(config *IdentityConfig) func(echo.HandlerFunc) ec
 				logger.Error("'DomainContextInterface' is expected")
 				return echo.ErrInternalServerError
 			}
-			xrhidRaw = cc.Request().Header.Get(header.HeaderXRHID)
-			if xrhid, err = decodeXRHID(xrhidRaw); err != nil {
-				logger.Error(err.Error())
-				return echo.ErrBadRequest
-			}
+
+			xrhid := cc.XRHID()
 
 			// The predicate must return no error, otherwise
 			// the request is not authorised.
@@ -182,20 +177,6 @@ func EnforceIdentityWithConfig(config *IdentityConfig) func(echo.HandlerFunc) ec
 				}
 			}
 
-			// Aggregate additional information to the logs
-			logger = logger.With(
-				slog.String("org_id", xrhid.Identity.OrgID),
-				slog.String("identity_type", xrhid.Identity.Type),
-			)
-
-			// Set principal
-			principal := header.GetPrincipal(xrhid)
-			logger = logger.With(slog.String("identity_principal", principal))
-			ctx = app_context.CtxWithLog(ctx, logger)
-			c.SetRequest(c.Request().Clone(ctx))
-
-			// Set the unserialized Identity into the request context
-			cc.SetXRHID(xrhid)
 			return next(c)
 		}
 	}
@@ -214,4 +195,63 @@ func decodeXRHID(b64XRHID string) (*identity.XRHID, error) {
 		return nil, err
 	}
 	return xrhid, nil
+}
+
+type ParseXRHIDMiddlewareConfig struct {
+	// Skipper function to skip for some request if necessary
+	Skipper echo_middleware.Skipper
+}
+
+// Parse the X-RH-Identity header and set it into the request context.
+// This must be called AFTER the "Fake Identity" middleware (if used),
+// but BEFORE the EnforceIdentity middlewares.
+func ParseXRHIDMiddlewareWithConfig(config *ParseXRHIDMiddlewareConfig) func(echo.HandlerFunc) echo.HandlerFunc {
+	if config == nil {
+		panic("'config' is nil")
+	}
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			var (
+				xrhid *identity.XRHID
+				err   error
+				cc    DomainContextInterface
+				ok    bool
+			)
+
+			ctx := c.Request().Context()
+			logger := app_context.LogFromCtx(ctx)
+
+			if config.Skipper != nil && config.Skipper(c) {
+				return next(c)
+			}
+
+			if cc, ok = c.(DomainContextInterface); !ok {
+				logger.Error("'DomainContextInterface' is expected")
+				return echo.ErrInternalServerError
+			}
+
+			xrhidRaw := cc.Request().Header.Get(header.HeaderXRHID)
+			if xrhidRaw == "" {
+				return echo.ErrUnauthorized
+			}
+			if xrhid, err = decodeXRHID(xrhidRaw); err != nil {
+				logger.Error(err.Error())
+				return echo.ErrBadRequest
+			}
+
+			// Aggregate additional information to the logs
+			principal := header.GetPrincipal(xrhid)
+			logger = logger.With(
+				slog.String("org_id", xrhid.Identity.OrgID),
+				slog.String("identity_type", xrhid.Identity.Type),
+				slog.String("identity_principal", principal),
+			)
+			ctx = app_context.CtxWithLog(ctx, logger)
+			c.SetRequest(c.Request().Clone(ctx))
+
+			// Set the unserialized Identity into the request context
+			cc.SetXRHID(xrhid)
+			return next(c)
+		}
+	}
 }

--- a/internal/infrastructure/middleware/rbac_test.go
+++ b/internal/infrastructure/middleware/rbac_test.go
@@ -20,6 +20,7 @@ func helperRbacSetupEcho(config *RBACConfig, method, path string, status int) *e
 	e := echo.New()
 	e.Use(ContextLogConfig(&LogConfig{}))
 	e.Use(CreateContext())
+	e.Use(ParseXRHIDMiddlewareWithConfig(&ParseXRHIDMiddlewareConfig{}))
 	e.Use(EnforceIdentityWithConfig(&IdentityConfig{}))
 	e.Use(RBACWithConfig(config))
 	e.Add(method, path, func(c echo.Context) error {

--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -156,6 +156,10 @@ func newGroupPublic(e *echo.Group, cfg *config.Config, app handler.Application, 
 		)
 	}
 
+	parseXRHIDMiddleware := middleware.ParseXRHIDMiddlewareWithConfig(
+		&middleware.ParseXRHIDMiddlewareConfig{},
+	)
+
 	mixedIdentityMiddleware := middleware.EnforceIdentityWithConfig(
 		&middleware.IdentityConfig{
 			Skipper: skipperMixedPredicate,
@@ -224,6 +228,7 @@ func newGroupPublic(e *echo.Group, cfg *config.Config, app handler.Application, 
 		middleware.CreateContext(),
 		metricsMiddleware,
 		fakeIdentityMiddleware,
+		parseXRHIDMiddleware,
 		mixedIdentityMiddleware,
 		systemIdentityMiddleware,
 		userAndSAIdentityMiddleware,

--- a/internal/test/smoke/system_endpoints_test.go
+++ b/internal/test/smoke/system_endpoints_test.go
@@ -164,6 +164,35 @@ func (s *SuiteSystemEndpoints) TestHostConfExecuteFailure() {
 	mockPendo.AssertExpectations(t)
 }
 
+func (s *SuiteSystemEndpoints) TestInvalidRouteCauses404() {
+	// Given
+	t := s.T()
+	s.As(RBACSuperAdmin)
+	s.prepareDomainIpa(t)
+	s.As(XRHIDSystem, RBACNoPermis)
+
+	// When
+	inventoryID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
+	hdr := http.Header{}
+	url := s.DefaultPublicBaseURL() + "/host-conf/" + inventoryID // MISSING HOSTNAME
+	method := http.MethodPost
+	s.addRequestID(&hdr, "test_system_host_conf")
+	body := ""
+	res, err := s.DoRequest(
+		method,
+		url,
+		hdr,
+		body,
+	)
+
+	// Then
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	err = res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+}
+
 func (s *SuiteSystemEndpoints) TestReadSigningKeys() {
 	t := s.T()
 	s.As(RBACSuperAdmin)


### PR DESCRIPTION
If the HTML resource path is unrecognised, the EnforceIdentity middlewares all get skipped.  This causes the XRHID field in the context to be uninitialised.  As a consequence, the RBAC middleware panics because it expects the field to be set.

To avoid this issue, we create a new middleware which always sets the XHRID into the request context.  This middleware runs after the FakeIdentity middleware (if used), and before the EnforceIdentity and RBAC middlewares.

The EnforceIdentity middleware is simplified as a result; it no longer needs to parse the XRHID and can read it from the context.