### PR TITLE
fix(HMS-3393): reject domain update if server RHSM ID not in server list

### DIFF
--- a/internal/test/smoke/domain_delete_test.go
+++ b/internal/test/smoke/domain_delete_test.go
@@ -32,6 +32,8 @@ func (s *SuiteDeleteDomain) TestDeleteDomain() {
 
 		domainName := fmt.Sprintf("domain%d.test", i)
 		domainRequest := builder_api.NewDomain(domainName).Build()
+		setFirstAsUpdateServer(domainRequest)
+		setFirstServerRHSMId(s.T(), domainRequest, s.systemXRHID)
 
 		s.As(RBACAdmin, XRHIDSystem)
 		domain, err = s.RegisterIpaDomain(token.DomainToken, domainRequest)

--- a/internal/test/smoke/domain_list_test.go
+++ b/internal/test/smoke/domain_list_test.go
@@ -72,7 +72,10 @@ func (s *SuiteListDomains) SetupTest() {
 			s.FailNow("error creating token")
 		}
 		s.As(XRHIDSystem)
-		domain, err = s.RegisterIpaDomain(token.DomainToken, builder_api.NewDomain(domainName).Build())
+		domainRequest := builder_api.NewDomain(domainName).Build()
+		setFirstAsUpdateServer(domainRequest)
+		setFirstServerRHSMId(s.T(), domainRequest, s.systemXRHID)
+		domain, err = s.RegisterIpaDomain(token.DomainToken, domainRequest)
 		if err != nil {
 			s.FailNow("error registering domain")
 		}

--- a/internal/test/smoke/suite_base_one_domain_test.go
+++ b/internal/test/smoke/suite_base_one_domain_test.go
@@ -34,6 +34,8 @@ func (s *SuiteBaseWithDomain) SetupTest() {
 	}
 	domainName = fmt.Sprintf("domain%d.test", i)
 	domainRequest := builder_api.NewDomain(domainName).Build()
+	setFirstServerRHSMId(s.T(), domainRequest, s.systemXRHID)
+	setFirstAsUpdateServer(domainRequest)
 	s.As(XRHIDSystem)
 	if domain, err = s.RegisterIpaDomain(token.DomainToken, domainRequest); err != nil {
 		s.FailNow("error creating rhel-idm domain")

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -855,6 +855,20 @@ func StartSignalHandler(c context.Context) (context.Context, context.CancelFunc)
 	return ctx, cancel
 }
 
+func setFirstServerRHSMId(t *testing.T, domain *public.Domain, xrhid identity.XRHID) {
+	require.NotNil(t, domain, "Domain is nil")
+	require.NotNil(t, domain.RhelIdm, "Domain is not a rhel-idm domain")
+	require.NotNil(t, domain.RhelIdm.Servers, "RhelIdm domain has no servers")
+	require.NotNil(t, xrhid.Identity.System, "XRHID is not a system identity")
+	serverUUID, err := uuid.Parse(xrhid.Identity.System.CommonName)
+	require.NoError(t, err, "Error parsing the server UUID")
+	domain.RhelIdm.Servers[0].SubscriptionManagerId = &serverUUID
+}
+
+func setFirstAsUpdateServer(domain *public.Domain) {
+	domain.RhelIdm.Servers[0].HccUpdateServer = true
+}
+
 // TearDownSignalHandler reset the signal handlers
 func TearDownSignalHandler() {
 	signal.Reset(syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)


### PR DESCRIPTION
So that a server cannot DOS itself.

The patch is also fixing test flakiness when HCCUpdate == false by setting the HCCUpdate to true for register domain flows.

The check is the same as for ensureSubscriptionManagerIDAuthorizedToUpdate but the error is different (BadRequest vs Unauthorized).