### PR TITLE
fix(HMS-4789): panic on /api/idmsvc/v1/* not found route

### DIFF
--- a/internal/infrastructure/middleware/enforce_identity.go
+++ b/internal/infrastructure/middleware/enforce_identity.go
@@ -1,8 +1,6 @@
 package middleware
 
 import (
-	"encoding/base64"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -166,7 +164,7 @@ func EnforceIdentityWithConfig(config *IdentityConfig) func(echo.HandlerFunc) ec
 				return echo.ErrInternalServerError
 			}
 			xrhidRaw = cc.Request().Header.Get(header.HeaderXRHID)
-			if xrhid, err = decodeXRHID(xrhidRaw); err != nil {
+			if xrhid, err = header.DecodeXRHID(xrhidRaw); err != nil {
 				logger.Error(err.Error())
 				return echo.ErrBadRequest
 			}
@@ -199,19 +197,4 @@ func EnforceIdentityWithConfig(config *IdentityConfig) func(echo.HandlerFunc) ec
 			return next(c)
 		}
 	}
-}
-
-func decodeXRHID(b64XRHID string) (*identity.XRHID, error) {
-	if b64XRHID == "" {
-		return nil, fmt.Errorf("%s not present", header.HeaderXRHID)
-	}
-	stringXRHID, err := base64.StdEncoding.DecodeString(b64XRHID)
-	if err != nil {
-		return nil, err
-	}
-	xrhid := &identity.XRHID{}
-	if err := json.Unmarshal([]byte(stringXRHID), xrhid); err != nil {
-		return nil, err
-	}
-	return xrhid, nil
 }

--- a/internal/infrastructure/middleware/not_found.go
+++ b/internal/infrastructure/middleware/not_found.go
@@ -1,0 +1,28 @@
+package middleware
+
+import (
+	"log/slog"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/context"
+)
+
+// NotFound middleware is a workaround to avoid the middleware chain
+// is executed when the path is not found, because at the moment of
+// writting this, the not found paths are matching a default handler.
+//
+// This workaround evoke an early return by calling the NotFoundHandler
+func NotFound() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			path := c.Path()
+			if path == "" || strings.HasSuffix(path, "/*") {
+				logger := context.LogFromCtx(c.Request().Context())
+				logger.Error("not found", slog.String("path", path))
+				return echo.NotFoundHandler(c)
+			}
+			return next(c)
+		}
+	}
+}

--- a/internal/infrastructure/middleware/not_found_test.go
+++ b/internal/infrastructure/middleware/not_found_test.go
@@ -1,0 +1,188 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+func helperNewEchoNotFound(m echo.MiddlewareFunc) *echo.Echo {
+	e := echo.New()
+	h := func(c echo.Context) error {
+		return c.String(http.StatusOK, "Ok")
+	}
+	e.Use(
+		middleware.RemoveTrailingSlash(),
+		ContextLogConfig(&LogConfig{}),
+		CreateContext(),
+		m,
+	)
+
+	e.Add(http.MethodPost, "/test-1", h)
+	e.Add(http.MethodPost, "/test-2/:param1", h)
+	e.Add(http.MethodPost, "/test-3/:param1/:param2", h)
+
+	g := e.Group("/group-1")
+	g.Add(http.MethodPost, "/test-1", h)
+	g.Add(http.MethodPost, "/test-2/:param1", h)
+	g.Add(http.MethodPost, "/test-3/:param1/:param2", h)
+
+	g = e.Group("/group-2", Nooperation())
+	g.Add(http.MethodPost, "/test-1", h)
+	g.Add(http.MethodPost, "/test-2/:param1", h)
+	g.Add(http.MethodPost, "/test-3/:param1/:param2", h)
+
+	return e
+}
+
+func TestNotFoundMiddleware(t *testing.T) {
+	type TestCase struct {
+		Name               string
+		Path               string
+		ExpectedStatusCode int
+	}
+
+	testCases := []TestCase{
+		// No group
+		{
+			Name:               "Not found for /not-found",
+			Path:               "/not-found",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /",
+			Path:               "/",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /test-2",
+			Path:               "/test-2",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /test-3/value-1",
+			Path:               "/test-3/value-1",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "OK for /test-1",
+			Path:               "/test-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /test-2/:param1",
+			Path:               "/test-2/value-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /test-3/:param1/:param2",
+			Path:               "/test-3/value-1/value-2",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		// With group-1
+		{
+			Name:               "Not found for /group-1/not-found",
+			Path:               "/group-1/not-found",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /group-1",
+			Path:               "/group-1",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /group-1/test-2",
+			Path:               "/group-1/test-2",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /group-1/test-3/value-1",
+			Path:               "/group-1/test-3/value-1",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /group-1/test-3/value-1/",
+			Path:               "/group-1/test-3/value-1/",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "OK for /group-1/test-1",
+			Path:               "/group-1/test-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /group-1/test-2/:param1",
+			Path:               "/group-1/test-2/value-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /group-1/test-3/:param1/:param2",
+			Path:               "/group-1/test-3/value-1/value-2",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		// With group-2
+		{
+			// This replay Path == "/group-2/*"
+			Name:               "Not found for /group-2/not-found",
+			Path:               "/group-2/not-found",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "Not found for /group-2",
+			Path:               "/group-2",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			// This replay Path ==  "/group-2/*"
+			Name:               "Not found for /group-2/test-2",
+			Path:               "/group-2/test-2",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			// This replay Path ==  "/group-2/*"
+			Name:               "Not found for /group-2/test-3/value-1",
+			Path:               "/group-2/test-3/value-1",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			// This replay Path ==  "/group-2/*"
+			Name:               "Not found for /group-2/test-3/value-1/",
+			Path:               "/group-2/test-3/value-1/",
+			ExpectedStatusCode: http.StatusNotFound,
+		},
+		{
+			Name:               "OK for /group-2/test-1",
+			Path:               "/group-2/test-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /group-2/test-2/:param1",
+			Path:               "/group-2/test-2/value-1",
+			ExpectedStatusCode: http.StatusOK,
+		},
+		{
+			Name:               "OK for /group-2/test-3/:param1/:param2",
+			Path:               "/group-2/test-3/value-1/value-2",
+			ExpectedStatusCode: http.StatusOK,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Log(testCase.Name)
+
+		// Given
+		e := helperNewEchoNotFound(NotFound())
+
+		// When
+		res := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, testCase.Path, nil)
+		e.ServeHTTP(res, req)
+
+		// Then
+		assert.Equal(t, testCase.ExpectedStatusCode, res.Result().StatusCode)
+	}
+}

--- a/internal/infrastructure/middleware/rbac_test.go
+++ b/internal/infrastructure/middleware/rbac_test.go
@@ -20,7 +20,6 @@ func helperRbacSetupEcho(config *RBACConfig, method, path string, status int) *e
 	e := echo.New()
 	e.Use(ContextLogConfig(&LogConfig{}))
 	e.Use(CreateContext())
-	e.Use(ParseXRHIDMiddlewareWithConfig(&ParseXRHIDMiddlewareConfig{}))
 	e.Use(EnforceIdentityWithConfig(&IdentityConfig{}))
 	e.Use(RBACWithConfig(config))
 	e.Add(method, path, func(c echo.Context) error {

--- a/internal/infrastructure/router/public.go
+++ b/internal/infrastructure/router/public.go
@@ -156,10 +156,6 @@ func newGroupPublic(e *echo.Group, cfg *config.Config, app handler.Application, 
 		)
 	}
 
-	parseXRHIDMiddleware := middleware.ParseXRHIDMiddlewareWithConfig(
-		&middleware.ParseXRHIDMiddlewareConfig{},
-	)
-
 	mixedIdentityMiddleware := middleware.EnforceIdentityWithConfig(
 		&middleware.IdentityConfig{
 			Skipper: skipperMixedPredicate,
@@ -228,7 +224,6 @@ func newGroupPublic(e *echo.Group, cfg *config.Config, app handler.Application, 
 		middleware.CreateContext(),
 		metricsMiddleware,
 		fakeIdentityMiddleware,
-		parseXRHIDMiddleware,
 		mixedIdentityMiddleware,
 		systemIdentityMiddleware,
 		userAndSAIdentityMiddleware,

--- a/internal/infrastructure/router/router.go
+++ b/internal/infrastructure/router/router.go
@@ -65,6 +65,7 @@ func configCommonMiddlewares(e *echo.Echo, cfg *config.Config) {
 	}))
 
 	e.Use(middleware.Recover())
+	e.Use(app_middleware.NotFound())
 }
 
 // NewRouterWithConfig fill the router configuration for the given echo instance,

--- a/internal/test/smoke/miscelanea_test.go
+++ b/internal/test/smoke/miscelanea_test.go
@@ -1,0 +1,135 @@
+package smoke
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/openlyinc/pointy"
+	"github.com/podengo-project/idmsvc-backend/internal/api/public"
+	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/datastore"
+	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
+	mock_pendo "github.com/podengo-project/idmsvc-backend/internal/test/mock/interface/client/pendo"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type SuiteMiscelanea struct {
+	SuiteBase
+	token  *public.DomainRegTokenResponse
+	domain *public.Domain
+}
+
+func (s *SuiteMiscelanea) SetupTest() {
+	s.PendoClient = mock_pendo.NewPendo(s.T())
+	s.SuiteBase.SetupTest()
+}
+
+func (s *SuiteMiscelanea) prepareDomainIpaCreate(t *testing.T) {
+	s.As(XRHIDUser)
+	token, err := s.CreateToken()
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	require.NotEqual(t, "", token.DomainToken)
+	s.token = token
+}
+
+func (s *SuiteMiscelanea) prepareDomainIpa(t *testing.T) {
+	var err error
+
+	// Add key to the database
+	t.Log("Adding key")
+	hcdb := datastore.NewHostconfJwkDb(s.Config)
+	hcdb.ListKeys()
+	hcdb.Purge()
+	hcdb.Refresh()
+	hcdb.ListKeys()
+
+	// Create a token to register a domain
+	t.Log("Creating token")
+	s.As(XRHIDUser)
+	s.token, err = s.CreateToken()
+	require.NoError(t, err)
+	require.NotNil(t, s.token)
+	require.NotEqual(t, "", s.token.DomainToken)
+
+	// This operation set AutoEnrollmentEnabled = False whatever
+	// is the value we indicate here; we have to PATCH in a second
+	// operation
+	t.Log("Registering a domain")
+	domain := "test.example"
+	s.As(XRHIDSystem)
+	s.domain, err = s.RegisterIpaDomain(s.token.DomainToken,
+		builder_api.NewDomain(domain).
+			WithDomainID(&s.token.DomainId).
+			WithRhelIdm(builder_api.NewRhelIdmDomain(domain).
+				WithServers([]public.DomainIpaServer{}).
+				AddServer(builder_api.NewDomainIpaServer("1."+domain).
+					WithHccUpdateServer(true).
+					WithHccEnrollmentServer(true).
+					WithSubscriptionManagerId(s.systemXRHID.Identity.System.CommonName).
+					Build(),
+				).Build(),
+			).Build(),
+	)
+	require.NoError(t, err)
+	require.NotNil(t, s.domain)
+
+	// Enable auto-join for the domain
+	t.Log("Enabling auto-enrollment")
+	s.As(XRHIDUser)
+	s.domain, err = s.PatchDomain(
+		s.domain.DomainId.String(),
+		builder_api.NewUpdateDomainUserRequest().
+			WithTitle(pointy.String(s.domain.DomainName)).
+			WithDescription(nil).
+			WithAutoEnrollmentEnabled(pointy.Bool(true)).
+			Build())
+	require.NoError(t, err)
+	require.NotNil(t, s.domain)
+}
+
+// TestBugHmsXXXXNotFound check a condition when a path
+// that is not found for /api/idmsvc/domains/v1/host-conf/:inventory_id
+// where the API should return with 404 status code.
+func (s *SuiteMiscelanea) TestBugHmsXXXXNotFound() {
+	// Given
+	t := s.T()
+	s.As(RBACSuperAdmin)
+	s.prepareDomainIpa(t)
+	domainType := public.RhelIdm
+	s.As(XRHIDSystem, RBACNoPermis)
+
+	mockPendo, ok := s.PendoClient.(*mock_pendo.Pendo)
+	require.True(t, ok)
+
+	// When
+	hdr := http.Header{}
+	inventoryID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
+	fqdn := ""
+	hostconf := builder_api.NewHostConf().
+		WithDomainName(pointy.String(s.domain.DomainName)).
+		WithDomainType(&domainType).
+		Build()
+	url := s.DefaultPublicBaseURL() + "/host-conf/" + inventoryID + "/" + fqdn
+	method := http.MethodPost
+	s.addRequestID(&hdr, "test_miscelanea_bug_hms_xxxx_not_found")
+	body := hostconf
+	res, err := s.DoRequest(
+		method,
+		url,
+		hdr,
+		body,
+	)
+
+	// Then
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	err = res.Body.Close()
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNotFound, res.StatusCode)
+	mockPendo.AssertExpectations(t)
+}
+
+func TestSuiteMiscelanea(t *testing.T) {
+	suite.Run(t, new(SuiteMiscelanea))
+}

--- a/internal/test/smoke/system_endpoints_test.go
+++ b/internal/test/smoke/system_endpoints_test.go
@@ -164,35 +164,6 @@ func (s *SuiteSystemEndpoints) TestHostConfExecuteFailure() {
 	mockPendo.AssertExpectations(t)
 }
 
-func (s *SuiteSystemEndpoints) TestInvalidRouteCauses404() {
-	// Given
-	t := s.T()
-	s.As(RBACSuperAdmin)
-	s.prepareDomainIpa(t)
-	s.As(XRHIDSystem, RBACNoPermis)
-
-	// When
-	inventoryID := s.domain.RhelIdm.Servers[0].SubscriptionManagerId.String()
-	hdr := http.Header{}
-	url := s.DefaultPublicBaseURL() + "/host-conf/" + inventoryID // MISSING HOSTNAME
-	method := http.MethodPost
-	s.addRequestID(&hdr, "test_system_host_conf")
-	body := ""
-	res, err := s.DoRequest(
-		method,
-		url,
-		hdr,
-		body,
-	)
-
-	// Then
-	require.NoError(t, err)
-	require.NotNil(t, res)
-	err = res.Body.Close()
-	require.NoError(t, err)
-	require.Equal(t, http.StatusNotFound, res.StatusCode)
-}
-
 func (s *SuiteSystemEndpoints) TestReadSigningKeys() {
 	t := s.T()
 	s.As(RBACSuperAdmin)


### PR DESCRIPTION
This change do an early return in the global
middleware chain, to avoid panics for the not
found routes for the API endpoints.

https://issues.redhat.com/browse/HMS-4789