### PR TITLE
fix(HMS-4769): log configuration on startup

### DIFF
--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 	"os"
 	"os/signal"
 	"sync"
@@ -47,6 +48,7 @@ func main() {
 	logger.LogBuildInfo("idmscv-backend")
 	cfg := config.Get()
 	logger.InitLogger(cfg)
+	cfg.Log(slog.Default())
 	db := datastore.NewDB(cfg)
 	defer datastore.Close(db)
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -509,6 +509,75 @@ func Load(cfg *Config) *viper.Viper {
 	return v
 }
 
+// Log logs the configuration
+func (c *Config) Log(logger *slog.Logger) {
+	logger.Info(
+		"Configuration",
+		slog.Group("Web",
+			slog.Int("Port", int(c.Web.Port)),
+		),
+		slog.Group("Database",
+			slog.String("Host", c.Database.Host),
+			slog.Int("Port", c.Database.Port),
+			slog.String("User", c.Database.User),
+			slog.String("Password", obfuscateSecret(c.Database.Password)),
+			slog.String("Name", c.Database.Name),
+			slog.String("CACertPath", c.Database.CACertPath),
+			slog.Int("MaxOpenConns", c.Database.MaxOpenConns),
+		),
+		slog.Group("Logging",
+			slog.String("Level", c.Logging.Level),
+			slog.Bool("Console", c.Logging.Console),
+			slog.Bool("Location", c.Logging.Location),
+			slog.String("Type", c.Logging.Type),
+			slog.Group("Cloudwatch",
+				slog.String("Region", c.Logging.Cloudwatch.Region),
+				slog.String("Key", c.Logging.Cloudwatch.Key),
+				slog.String("Secret", obfuscateSecret(c.Logging.Cloudwatch.Secret)),
+				slog.String("Session", c.Logging.Cloudwatch.Session),
+				slog.String("Group", c.Logging.Cloudwatch.Group),
+				slog.String("Stream", c.Logging.Cloudwatch.Stream),
+			),
+		),
+		slog.Group("Metrics",
+			slog.String("Path", c.Metrics.Path),
+			slog.Int("Port", c.Metrics.Port),
+		),
+		slog.Group("Clients",
+			slog.String("RbacBaseURL", c.Clients.RbacBaseURL),
+			slog.String("PendoBaseURL", c.Clients.PendoBaseURL),
+			slog.String("PendoAPIKey", obfuscateSecret(c.Clients.PendoAPIKey)),
+			slog.String("PendoTrackEventKey", obfuscateSecret(c.Clients.PendoTrackEventKey)),
+			slog.Int("PendoRequestTimeoutSecs", c.Clients.PendoRequestTimeoutSecs),
+		),
+		slog.Group("Application",
+			slog.String("Name", c.Application.Name),
+			slog.String("PathPrefix", c.Application.PathPrefix),
+			slog.Int("TokenExpirationTimeSeconds", c.Application.TokenExpirationTimeSeconds),
+			slog.Duration("HostconfJwkValidity", c.Application.HostconfJwkValidity),
+			slog.Duration("HostconfJwkRenewalThreshold", c.Application.HostconfJwkRenewalThreshold),
+			slog.Int("PaginationDefaultLimit", c.Application.PaginationDefaultLimit),
+			slog.Int("PaginationMaxLimit", c.Application.PaginationMaxLimit),
+			slog.Bool("AcceptXRHFakeIdentity", c.Application.AcceptXRHFakeIdentity),
+			slog.Bool("ValidateAPI", c.Application.ValidateAPI),
+			slog.String("MainSecret", obfuscateSecret(c.Application.MainSecret)),
+			slog.Bool("EnableRBAC", c.Application.EnableRBAC),
+			slog.Duration("IdleTimeout", c.Application.IdleTimeout),
+			slog.Duration("ReadTimeout", c.Application.ReadTimeout),
+			slog.Duration("WriteTimeout", c.Application.WriteTimeout),
+			slog.Int("SizeLimitRequestHeader", c.Application.SizeLimitRequestHeader),
+			slog.Int("SizeLimitRequestBody", c.Application.SizeLimitRequestBody),
+		),
+	)
+}
+
+func obfuscateSecret(value string) string {
+	if value == "" {
+		return ""
+	}
+	return "***"
+}
+
 func reportError(err error) {
 	for _, err := range err.(validator.ValidationErrors) {
 		slog.Error(


### PR DESCRIPTION
Log also secrets but obfuscate them so that it is visible if they are set or not but not their value.

Setting as draft to get initial feedback. Qs:

- is it worth the time to implement tests for this. IMHO the only useful test would be to check that secrets are obfuscated. But to test it, it would need something like: https://pkg.go.dev/github.com/thejerf/slogassert#Handler.Assert 
- is the place where it is logged good? I.e before or after logger initialization? 

Example output:


> time=2024-10-03T18:02:34.477+02:00 level=INFO msg=idmscv-backend Version=(devel) Commit=5e87078ba927d1d626e84a7f873527abb357b4bf CommitTime=2024-10-03T06:00:45Z Dirty=true
> time=2024-10-03T18:02:34.478+02:00 level=INFO msg=idmsvc-backend Logging.Console=true Logging.Type=null Logging.Level=debug Logging.Location=false
> time=2024-10-03T18:02:34.478+02:00 level=NOTICE msg="Logging successfully initialized"
> time=2024-10-03T18:02:34.478+02:00 level=INFO msg=Configuration Web.Port=8000 Database.Host=localhost Database.Port=5432 Database.User=idmsvc-user Database.Password=*** Database.Name=idmsvc-db Database.CACertPath="" Database.MaxOpenConns=30 Logging.Level=debug Logging.Console=true Logging.Location=false Logging.Type=null Logging.Cloudwatch.Region="" Logging.Cloudwatch.Key="" Logging.Cloudwatch.Secret="" Logging.Cloudwatch.Session="" Logging.Cloudwatch.Group="" Logging.Cloudwatch.Stream=pvoborni-mac Metrics.Path=/metrics Metrics.Port=9000 Clients.RbacBaseURL=http://localhost:8020/api/rbac/v1 Clients.PendoBaseURL=http://localhost:8010 Clients.PendoAPIKey=*** Clients.PendoTrackEventKey=*** Clients.PendoRequestTimeoutSecs=0 Application.Name=idmsvc Application.PathPrefix=/api/idmsvc/v1 Application.TokenExpirationTimeSeconds=7200 Application.HostconfJwkValidity=2160h0m0s Application.HostconfJwkRenewalThreshold=720h0m0s Application.PaginationDefaultLimit=10 Application.PaginationMaxLimit=100 Application.AcceptXRHFakeIdentity=true Application.ValidateAPI=true Application.MainSecret=*** Application.EnableRBAC=true Application.IdleTimeout=5m0s Application.ReadTimeout=3s Application.WriteTimeout=3s Application.SizeLimitRequestHeader=32768 Application.SizeLimitRequestBody=131072
> time=2024-10-03T18:02:34.524+02:00 level=DEBUG msg="Printing metrics routes"
