### PR TITLE
feat(HMS-4804): add logs to handlers

### DIFF
--- a/internal/handler/impl/application.go
+++ b/internal/handler/impl/application.go
@@ -15,6 +15,17 @@ import (
 	"gorm.io/gorm"
 )
 
+const (
+	errXRHIDIsNil     = "failed because XRHID is nil"
+	errUnserializing  = "failed to unserialize http api data"
+	errInputAdapter   = "failed to translate the API request to business objects"
+	errDBTXBegin      = "failed to begin database transaction"
+	errDBNotFound     = "failed because a record not found in the database"
+	errDBGeneralError = "failed on database operation"
+	errDBTXCommit     = "failed to commit database transaction"
+	errOutputAdapter  = "failed to translate the business object to the API response"
+)
+
 type domainComponent struct {
 	interactor interactor.DomainInteractor
 	repository repository.DomainRepository

--- a/internal/handler/impl/host_handler.go
+++ b/internal/handler/impl/host_handler.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -49,24 +50,30 @@ func (a *application) hostConf(
 		xrhid   *identity.XRHID
 		keys    []jwk.Key
 	)
+	handlerName := "HostConf"
+	logger := app_context.LogFromCtx(ctx.Request().Context())
+	logger = logger.With(slog.String("handler", handlerName))
 	c := ctx.Request().Context()
-	log := app_context.LogFromCtx(c)
 	if xrhid, err = getXRHID(ctx); err != nil {
-		log.Error(err.Error())
+		logger.Error(errXRHIDIsNil)
 		return err
 	}
 
 	if err = ctx.Bind(&input); err != nil {
-		log.Error(err.Error())
+		logger.Error(errUnserializing)
 		return err
 	}
 	if options, err = a.host.interactor.HostConf(xrhid, inventoryId, fqdn, &params, &input); err != nil {
-		log.Error(err.Error())
+		logger.Error(errInputAdapter)
 		return err
 	}
+	logger = logger.With(
+		slog.String("inventory_id", inventoryId.String()),
+		slog.String("fqdn", fqdn),
+	)
 
 	if tx = a.db.Begin(); tx.Error != nil {
-		log.Error(tx.Error.Error())
+		logger.Error(errDBTXBegin)
 		return tx.Error
 	}
 	defer tx.Rollback()
@@ -76,17 +83,17 @@ func (a *application) hostConf(
 		c,
 		options,
 	); err != nil {
-		log.Error(err.Error())
+		logger.Error("failed to match domain on requesting host-conf")
 		return err
 	}
 
 	if keys, err = a.hostconfjwk.repository.GetPrivateSigningKeys(c); err != nil {
-		log.Error(err.Error())
+		logger.Error("failed to read private signing keys")
 		return err
 	}
 	if len(keys) == 0 {
+		logger.Error("failed because no keys available")
 		err = echo.NewHTTPError(http.StatusInternalServerError, "no keys available")
-		log.Error(err.Error())
 		return err
 	}
 
@@ -96,19 +103,19 @@ func (a *application) hostConf(
 		options,
 		domain,
 	); err != nil {
-		log.Error(err.Error())
+		logger.Error("failed to sign host-conf token")
 		return err
 	}
 
 	if tx.Commit(); tx.Error != nil {
-		log.Error(tx.Error.Error())
+		logger.Error(errDBTXCommit)
 		return tx.Error
 	}
 
 	if output, err = a.host.presenter.HostConf(
 		domain, hctoken,
 	); err != nil {
-		log.Error(err.Error())
+		logger.Error(errOutputAdapter)
 		return err
 	}
 	return ctx.JSON(http.StatusOK, *output)

--- a/internal/handler/impl/keys_handler.go
+++ b/internal/handler/impl/keys_handler.go
@@ -1,6 +1,7 @@
 package impl
 
 import (
+	"log/slog"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
@@ -17,22 +18,28 @@ func (a *application) GetSigningKeys(ctx echo.Context, params public.GetSigningK
 		revokedKids []string
 		output      *public.SigningKeysResponse
 	)
-
+	handlerName := "RegisterDomain"
+	logger := app_context.LogFromCtx(ctx.Request().Context())
+	logger = logger.With(slog.String("handler", handlerName))
 	if tx = a.db.Begin(); tx.Error != nil {
+		logger.Error(errDBTXCommit)
 		return tx.Error
 	}
 	defer tx.Rollback()
 
 	c := app_context.CtxWithDB(ctx.Request().Context(), tx)
 	if keys, revokedKids, err = a.hostconfjwk.repository.GetPublicKeyArray(c); err != nil {
+		logger.Error(errDBGeneralError)
 		return err
 	}
 
 	if tx.Commit(); tx.Error != nil {
+		logger.Error(errDBTXCommit)
 		return tx.Error
 	}
 
 	if output, err = a.hostconfjwk.presenter.PublicSigningKeys(keys, revokedKids); err != nil {
+		logger.Error(errOutputAdapter)
 		return err
 	}
 


### PR DESCRIPTION
This change add logs for every handler of the application.

The change should be aligned to the [guidelines](https://github.com/podengo-project/idmsvc-backend/blob/main/docs/dev/09-logs.md#guidelines).

- Refactor some code to use logger form the context.
- Refactor some not found database conditions to return them.

https://issues.redhat.com/browse/HMS-4804