### PR TITLE
fix(HMS-4760): make CLIENTS_RBAC_BASE_URL optional in clowder.yaml

### DIFF
--- a/configs/bonfire.example.yaml
+++ b/configs/bonfire.example.yaml
@@ -34,7 +34,6 @@ apps:
           APP_VALIDATE_API: "true"
           APP_TOKEN_EXPIRATION_SECONDS: "7200"
           # APP_ENABLE_RBAC: "true"
-          CLIENTS_RBAC_BASE_URL: "http://rbac-service:8000/api/rbac/v1"
 
       - name: frontend
         host: github

--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -264,7 +264,7 @@ parameters:
     description: |
       It allows to enable / disable RBAC middleware.
   - name: CLIENTS_RBAC_BASE_URL
-    required: true
+    required: false
     description: |
       Point out to the rbac service base url
   - name: CLIENTS_PENDO_BASE_URL

--- a/internal/infrastructure/service/impl/mock/rbac/impl/rbac_test.go
+++ b/internal/infrastructure/service/impl/mock/rbac/impl/rbac_test.go
@@ -17,7 +17,7 @@ func helperConfig() *config.Config {
 	// Override config values
 	cfg.Application.EnableRBAC = true
 	if cfg.Clients.RbacBaseURL == "" {
-		panic("when rbac is enabled, set your 'clients.rbac_base_url' at your 'congis/config.yaml' file or CLIENTS_RBAC_BASE_URL variable to override")
+		panic("when rbac is enabled, set your 'clients.rbac_base_url' at your 'configs/config.yaml' file or CLIENTS_RBAC_BASE_URL variable to override")
 	}
 	return cfg
 }


### PR DESCRIPTION
For clowder enabled environments where the endpoints are provided via e.g. ACG_CONFIG=/cdapp/cdappconfig.json., the value in CLIENTS_RBAC_BASE_URL is ignored.

Thus make it optional so that it doesn't have to be set in those envs.