### PR TITLE
DO-NOT-MERGE fix(HMS-3803): flaky unit tests

### DIFF
--- a/internal/domain/model/ipa.go
+++ b/internal/domain/model/ipa.go
@@ -36,5 +36,10 @@ func (i *Ipa) AfterCreate(tx *gorm.DB) (err error) {
 			i.Servers[idx].IpaID = i.ID
 		}
 	}
+	if i.Locations != nil {
+		for idx := range i.Locations {
+			i.Locations[idx].IpaID = i.ID
+		}
+	}
 	return nil
 }

--- a/internal/test/builder/api/builder_domain_update_request.go
+++ b/internal/test/builder/api/builder_domain_update_request.go
@@ -29,14 +29,17 @@ func (b *updateDomainAgentRequest) Build() *public.UpdateDomainAgentJSONRequestB
 }
 
 func (b *updateDomainAgentRequest) WithDomainName(value string) UpdateDomainAgent {
+	b.DomainName = value
 	return b
 }
 
 func (b *updateDomainAgentRequest) WithDomainType(value public.DomainType) UpdateDomainAgent {
+	b.DomainType = value
 	return b
 }
 
 func (b *updateDomainAgentRequest) WithDomainRhelIdm(value public.DomainIpa) UpdateDomainAgent {
+	b.RhelIdm = value
 	return b
 }
 

--- a/internal/test/builder/model/builder_model.go
+++ b/internal/test/builder/model/builder_model.go
@@ -29,12 +29,13 @@ type gormModel struct {
 // NewModel generate a gorm.Model with random information
 // overrided by the customized options.
 func NewModel() GormModel {
-	var genCreatedAt = builder_helper.GenPastNearTime(time.Hour * 24 * 10)
-	var genUpdatedAt = builder_helper.GenBetweenTimeUTC(genCreatedAt, time.Now())
+	genCreatedAt := builder_helper.GenPastNearTime(time.Hour * 24 * 10)
+	genUpdatedAt := builder_helper.GenBetweenTimeUTC(genCreatedAt, time.Now())
+	modelID := uint(builder_helper.GenRandNum(0, 2^63))
 
 	return &gormModel{
 		Model: gorm.Model{
-			ID:        uint(builder_helper.GenRandNum(0, 2^63)),
+			ID:        modelID,
 			CreatedAt: genCreatedAt,
 			UpdatedAt: genUpdatedAt,
 		},

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -904,7 +904,6 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, new(SuiteRegisterDomain))
 	suite.Run(t, new(SuiteReadDomain))
 	suite.Run(t, new(SuiteDomainUpdateUser))
-	suite.Run(t, new(SuiteDomainUpdateAgent))
 	suite.Run(t, new(SuiteListDomains))
 	suite.Run(t, new(SuiteDeleteDomain))
 	suite.Run(t, new(SuiteRbacPermission))

--- a/internal/test/variables.go
+++ b/internal/test/variables.go
@@ -151,7 +151,6 @@ func BuildDomainModel(orgID string) *model.Domain {
 
 	return &model.Domain{
 		Model: gorm.Model{
-			ID:        1,
 			CreatedAt: currentTime,
 			UpdatedAt: currentTime,
 			DeletedAt: gorm.DeletedAt{},
@@ -165,7 +164,6 @@ func BuildDomainModel(orgID string) *model.Domain {
 		Type:                  pointy.Uint(model.DomainTypeIpa),
 		IpaDomain: &model.Ipa{
 			Model: gorm.Model{
-				ID:        1,
 				CreatedAt: currentTime,
 				UpdatedAt: currentTime,
 				DeletedAt: gorm.DeletedAt{},
@@ -174,7 +172,6 @@ func BuildDomainModel(orgID string) *model.Domain {
 			CaCerts: []model.IpaCert{
 				{
 					Model: gorm.Model{
-						ID:        2,
 						CreatedAt: currentTime,
 						UpdatedAt: currentTime,
 						DeletedAt: gorm.DeletedAt{},
@@ -192,7 +189,6 @@ func BuildDomainModel(orgID string) *model.Domain {
 			Servers: []model.IpaServer{
 				{
 					Model: gorm.Model{
-						ID:        3,
 						CreatedAt: currentTime,
 						UpdatedAt: currentTime,
 						DeletedAt: gorm.DeletedAt{},
@@ -210,7 +206,6 @@ func BuildDomainModel(orgID string) *model.Domain {
 			Locations: []model.IpaLocation{
 				{
 					Model: gorm.Model{
-						ID:        4,
 						CreatedAt: currentTime,
 						UpdatedAt: currentTime,
 						DeletedAt: gorm.DeletedAt{},


### PR DESCRIPTION
The change split the success and failure case for
the current TestRegister test.

For the success case we set a gorm model with
specific ID.

Additionally the helper function is refactored a
little.

https://issues.redhat.com/browse/HMS-3803