### PR TITLE
fix(HMS-4848): db-tool migrate down 1

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -77,7 +77,7 @@
             "mode": "debug",
             "program": "${workspaceFolder}/cmd/db-tool",
             "cwd": "${workspaceFolder}",
-            "args": ["migrate", "down", "0"],
+            "args": ["migrate", "down", "1"],
             "env": {
                 "CONFIG_PATH": "${workspaceFolder}/configs",
             }

--- a/internal/infrastructure/datastore/migration.go
+++ b/internal/infrastructure/datastore/migration.go
@@ -58,7 +58,7 @@ COMMIT;
 	return nil
 }
 
-func MigrateDb(config *config.Config, direction string, steps ...int) error {
+func MigrateDb(config *config.Config, direction string, steps int) error {
 	if config == nil {
 		return fmt.Errorf("'config' cannot be nil")
 	}
@@ -79,19 +79,17 @@ func MigrateDb(config *config.Config, direction string, steps ...int) error {
 		slog.Info("No database version")
 	}
 
-	var step int
-
 	switch direction {
 	case "up":
-		if step > 0 {
-			err = m.Steps(step)
+		if steps > 0 {
+			err = m.Steps(steps)
 		} else {
 			err = m.Up()
 		}
 	case "down":
-		if step > 0 {
-			step *= -1
-			err = m.Steps(step)
+		if steps > 0 {
+			steps *= -1
+			err = m.Steps(steps)
 		} else {
 			err = m.Down()
 		}
@@ -103,6 +101,7 @@ func MigrateDb(config *config.Config, direction string, steps ...int) error {
 		slog.Info("No new migrations")
 		return nil
 	} else if err != nil {
+		slog.Error("Error running migration", slog.String("error", err.Error()))
 		// Force back to previous migration version. If errors running version 1,
 		// drop everything (which would just be the schema_migrations table).
 		// This is safe if migrations are wrapped in transaction.
@@ -159,10 +158,11 @@ func getPreviousMigrationVersion(m *migrate.Migrate) (int, error) {
 		return datetimes[previousMigrationIndex], err
 	}
 }
-func MigrateUp(config *config.Config, steps ...int) error {
-	return MigrateDb(config, "up", steps...)
+
+func MigrateUp(config *config.Config, steps int) error {
+	return MigrateDb(config, "up", steps)
 }
 
-func MigrateDown(config *config.Config, steps ...int) error {
-	return MigrateDb(config, "down", steps...)
+func MigrateDown(config *config.Config, steps int) error {
+	return MigrateDb(config, "down", steps)
 }

--- a/scripts/mk/db.mk
+++ b/scripts/mk/db.mk
@@ -10,6 +10,9 @@ db-migrate-up: $(BIN)/db-tool  ## Migrate the database upto the current state an
 	$(BIN)/db-tool migrate up 0
 	$(BIN)/db-tool jwk refresh
 
+db-migrate-down: $(BIN)/db-tool  ## Migrate the database down by one step
+	$(BIN)/db-tool migrate down 1
+
 .PHONY: db-cli
 db-cli:  ## Open a cli shell inside the databse container
 	$(CONTAINER_COMPOSE) \


### PR DESCRIPTION
db-tool had an issue that the `steps` arg was not used in practice and thus variant with `0` was always run.

There is an issue present in run  `db-tool migrate down 0` which ends with `panic: database locked`. But in practice the issue is:

```
migration failed: cannot drop table domains because other objects depend
on it, constraint fk_ipas_id__domains_id on table ipas depends on table domains
in line 0
```

I.e. one of the older `down` updates is not correct.

This patch is fixing handling of the `steps` arg to be used and it adds log statement to not hide error like the above.

In addition it adds new make file target to test it more easily and modifies vscode launch to use down by one step instead of all (the same in makefile target).