### PR TITLE
fix: db migration 20230125102205_create_table_domains.down

### DIFF
--- a/scripts/db/migrations/20230125102205_create_table_domains.down.sql
+++ b/scripts/db/migrations/20230125102205_create_table_domains.down.sql
@@ -3,10 +3,10 @@
 BEGIN;
 -- your migration here
 
-DROP TABLE IF EXISTS domains;
-DROP TABLE IF EXISTS ipas;
-DROP TABLE IF EXISTS ipa_certs;
-DROP TABLE IF EXISTS ipa_servers;
 DROP TABLE IF EXISTS ipa_locations;
+DROP TABLE IF EXISTS ipa_servers;
+DROP TABLE IF EXISTS ipa_certs;
+DROP TABLE IF EXISTS ipas;
+DROP TABLE IF EXISTS domains;
 
 COMMIT;


### PR DESCRIPTION
This migration failed as the dropping of tables was done in wrong order (same as creation). The order must be reversed to the one in creation.

This is fixing it. And thus fixes `db-tool migrate down 0`.

Partly related to HMS-4848

Note: But I wonder if we actually want this to work as it prunes the database. 