### PR TITLE
refactor(HMS-3803): helperTestFindByIDIpa to FindIpaByID

### DIFF
--- a/internal/test/sql/helper.go
+++ b/internal/test/sql/helper.go
@@ -1,0 +1,6 @@
+package sql
+
+// WithPredicateExpectedError
+func WithPredicateExpectedError(step, stage int, expectedErr error) bool {
+	return step == stage && expectedErr != nil
+}

--- a/internal/test/sql/ipas_sql.go
+++ b/internal/test/sql/ipas_sql.go
@@ -1,0 +1,147 @@
+package sql
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+)
+
+func PrepSqlSelectIpas(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipas" WHERE id = $1 AND "ipas"."deleted_at" IS NULL ORDER BY "ipas"."id" LIMIT $2`)).
+		WithArgs(
+			domainID,
+			1,
+		)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		expectedQuery.WillReturnRows(sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"realm_name", "realm_domains",
+		}).AddRow(
+			domainID,
+			data.Model.CreatedAt,
+			data.Model.UpdatedAt,
+			data.Model.DeletedAt,
+
+			data.IpaDomain.RealmName,
+			data.IpaDomain.RealmDomains,
+		))
+	}
+}
+
+func PrepSqlSelectIpaCerts(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_certs" WHERE "ipa_certs"."ipa_id" = $1 AND "ipa_certs"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id", "issuer", "nickname",
+			"not_after", "not_before", "serial_number",
+			"subject", "pem",
+		})
+		for j := range data.IpaDomain.CaCerts {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.CaCerts[j].Model.CreatedAt,
+				data.IpaDomain.CaCerts[j].Model.UpdatedAt,
+				data.IpaDomain.CaCerts[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.CaCerts[j].Issuer,
+				data.IpaDomain.CaCerts[j].Nickname,
+				data.IpaDomain.CaCerts[j].NotAfter,
+				data.IpaDomain.CaCerts[j].NotBefore,
+				data.IpaDomain.CaCerts[j].SerialNumber,
+				data.IpaDomain.CaCerts[j].Subject,
+				data.IpaDomain.CaCerts[j].Pem,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func PrepSqlSelectIpaLocations(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_locations" WHERE "ipa_locations"."ipa_id" = $1 AND "ipa_locations"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id",
+			"name", "description",
+		})
+		for j := range data.IpaDomain.Locations {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.Locations[j].Model.CreatedAt,
+				data.IpaDomain.Locations[j].Model.UpdatedAt,
+				data.IpaDomain.Locations[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.Locations[j].Name,
+				data.IpaDomain.Locations[j].Description,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func PrepSqlSelectIpaServers(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_servers" WHERE "ipa_servers"."ipa_id" = $1 AND "ipa_servers"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id", "fqdn", "rhsm_id", "location",
+			"ca_server", "hcc_enrollment_server", "hcc_update_server",
+			"pk_init_server",
+		})
+		for j := range data.IpaDomain.Servers {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.Servers[j].Model.CreatedAt,
+				data.IpaDomain.Servers[j].Model.UpdatedAt,
+				data.IpaDomain.Servers[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.Servers[j].FQDN,
+				data.IpaDomain.Servers[j].RHSMId,
+				data.IpaDomain.Servers[j].Location,
+				data.IpaDomain.Servers[j].CaServer,
+				data.IpaDomain.Servers[j].HCCEnrollmentServer,
+				data.IpaDomain.Servers[j].HCCUpdateServer,
+				data.IpaDomain.Servers[j].PKInitServer,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func FindIpaByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint, data *model.Domain) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlSelectIpas(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 2:
+			PrepSqlSelectIpaCerts(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 3:
+			PrepSqlSelectIpaLocations(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 4:
+			PrepSqlSelectIpaServers(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}

--- a/internal/usecase/repository/host_repository_test.go
+++ b/internal/usecase/repository/host_repository_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
 	builder_model "github.com/podengo-project/idmsvc-backend/internal/test/builder/model"
+	test_sql "github.com/podengo-project/idmsvc-backend/internal/test/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -85,9 +86,9 @@ func (s *SuiteHost) helperTestMatchDomain(stage int, options *interactor.HostCon
 			}
 		case 2:
 			if len(domains) == 0 {
-				helperTestFindByIDIpa(1, &domains[0], mock, expectedErr)
+				test_sql.FindIpaByID(1, mock, expectedErr, domains[0].ID, &domains[0])
 			}
-			helperTestFindByIDIpa(4, &domains[0], mock, expectedErr)
+			test_sql.FindIpaByID(4, mock, expectedErr, domains[0].ID, &domains[0])
 		default:
 			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
 		}


### PR DESCRIPTION
This change refactor helperTestFindByIDIpa function
into a simpler way, starting to create the package
internal/test/sql/ipas which will hold the code for
the SQL mock helpers, and making them more simple.

The public functions will match with the real
method/function. That helper will be currently
orquestating the preparation of the sql mock
statement. The first 3 arguments would be
(stage, mock, expectedErr, ...) where stage
is the step in the control flow, mock is the
sqlmock instance where prepare the expectations,
and expectedErr is nil for success or an error
reference for error expectations.

Additional functions named PrepSql... will
mock the specific SQL statement, decomposing
complex executions in smaller units. This functions
will haveas 3 first arguments: mock, withError and
expectedErr
- mock is the sqlmock.Sqlmock instance which will
  receive the expectations.
- withError will be the result of the helper
  WithPredicateExpectedError(step, stage, expectedErr)
- expectedErr is nil (when no error expected) or the
  error to be returned.

The predicate WithPredicateExpectedError simplify to
think about when the error should be returned, and remove
duplications on the logic as it always check if the current
step is the final (stage) and if an error expectations is
provided, it is prepared to be returned on that stage. This
helps to get the error returned in the specific step.
