### PR TITLE
refactor(HMS-3803): helperTestDeleteById to DeleteByID

### DIFF
--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -1,11 +1,13 @@
 package sql
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+	"gorm.io/gorm"
 )
 
 func PrepSqlSelectDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
@@ -51,6 +53,55 @@ func FindByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint,
 		switch i {
 		case 1:
 			PrepSqlSelectDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}
+
+func PrepSqlSelectCountDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Domain) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "domains" WHERE (org_id = $1 AND domain_uuid = $2) AND "domains"."deleted_at" IS NULL LIMIT $3`)).
+		WithArgs(
+			data.OrgId,
+			data.DomainUuid,
+			1,
+		)
+	if withError {
+		if expectedErr == gorm.ErrRecordNotFound {
+			expectQuery.WillReturnRows(sqlmock.NewRows([]string{"count"}).
+				AddRow(int64(0)))
+		} else {
+			expectQuery.WillReturnError(expectedErr)
+		}
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"count"}).
+			AddRow(int64(1)))
+	}
+}
+
+func PrepSqlDeleteDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Domain) {
+	expectQuery := mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "domains" WHERE (org_id = $1 AND domain_uuid = $2) AND "domains"."id" = $3`)).
+		WithArgs(
+			data.OrgId,
+			data.DomainUuid,
+			data.ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnResult(driver.RowsAffected(1))
+	}
+}
+
+func DeleteByID(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlSelectDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, uint(1), data)
+		case 2:
+			PrepSqlSelectCountDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		case 3:
+			PrepSqlDeleteDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
 		default:
 			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
 		}


### PR DESCRIPTION
Refactor the code from helperTestDeleteById method
to the test shared function DeleteByID into
the internal/test/sql package.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/358