### PR TITLE
refactor(HMS-3803): helperTestUpdateUser to UpdateUser

### DIFF
--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -107,3 +107,52 @@ func DeleteByID(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.
 		}
 	}
 }
+
+func PrepSqlUpdateDomainsForUser(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectExec := mock.ExpectExec(regexp.QuoteMeta(`UPDATE "domains" SET "auto_enrollment_enabled"=$1,"description"=$2,"title"=$3 WHERE (org_id = $4 AND domain_uuid = $5) AND "domains"."deleted_at" IS NULL AND "id" = $6`)).
+		WithArgs(
+			data.AutoEnrollmentEnabled,
+			data.Description,
+			data.Title,
+
+			data.OrgId,
+			data.DomainUuid,
+			domainID,
+		)
+	if withError {
+		expectExec.WillReturnError(expectedErr)
+	} else {
+		expectExec.WillReturnResult(
+			driver.RowsAffected(1))
+	}
+}
+
+func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+	if stage == 0 {
+		return
+	}
+	if stage < 0 {
+		panic("'stage' cannot be lower than 0")
+	}
+	if stage > 2 {
+		panic("'stage' cannot be greater than 3")
+	}
+	domainID := uint(1)
+
+	mock.MatchExpectationsInOrder(true)
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			if i == stage && expectedErr != nil {
+				FindByID(1, mock, expectedErr, domainID, data)
+			} else {
+				FindByID(1, mock, nil, domainID, data)
+				FindIpaByID(4, mock, nil, domainID, data)
+			}
+		case 2: // Update
+			PrepSqlUpdateDomainsForUser(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}


### PR DESCRIPTION
This change refactor helperTestUpdateUser to UpdateUser
at the internal/test/sql package.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/359