### PR TITLE
fix: db migration to create index in indepotent way

### DIFF
--- a/scripts/db/migrations/20241014130703_domains_org_index.up.sql
+++ b/scripts/db/migrations/20241014130703_domains_org_index.up.sql
@@ -2,6 +2,6 @@
 -- File created by: ./bin/db-tool new domains_org_index
 BEGIN;
 
-CREATE INDEX idx_domains_org_id ON domains (org_id);
+CREATE INDEX IF NOT EXISTS idx_domains_org_id ON domains (org_id);
 
 COMMIT;


### PR DESCRIPTION
init container failed on creating the index saying that it already exists. It's not clear how we got to the situation. This changes tries to make this update file idepotent so that it won't fail in this situation.