### PR TITLE
refactor(HMS-3803): TestUpdateUser

### DIFF
--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -128,7 +128,7 @@ func PrepSqlUpdateDomainsForUser(mock sqlmock.Sqlmock, withError bool, expectedE
 	}
 }
 
-func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint, data *model.Domain) {
 	if stage == 0 {
 		return
 	}
@@ -138,7 +138,6 @@ func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.
 	if stage > 2 {
 		panic("'stage' cannot be greater than 3")
 	}
-	domainID := uint(1)
 
 	mock.MatchExpectationsInOrder(true)
 	for i := 1; i <= stage; i++ {


### PR DESCRIPTION
Refactor TestUpdateUser making that more lineal and easier
to debug and trace the errors in the future.
    
This modify the signature for test_sql.UpdateUset to pass
as argument the domainID for the operation.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/364