### PR TITLE
fix(HMS-3803): TestUpdateAgent add sqlmock checks

### DIFF
--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -181,7 +181,7 @@ func PrepSqlInsertIntoDomains(mock sqlmock.Sqlmock, withError bool, expectedErr 
 	}
 }
 
-func Register(stage int, data *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
+func Register(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
 	for i := 1; i <= stage; i++ {
 		switch i {
 		case 1:

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -868,41 +868,49 @@ func (s *DomainRepositorySuite) TestDeleteById() {
 	require.Panics(t, func() {
 		_ = r.DeleteById(nil, "", model.NilUUID)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	assert.PanicsWithValue(t, "'db' could not be read", func() {
 		_ = r.DeleteById(context.Background(), "", model.NilUUID)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(1, s.mock, gorm.ErrRecordNotFound, d)
 	err := r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("invalid transaction")
 	test_sql.DeleteByID(1, s.mock, gorm.ErrInvalidTransaction, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(2, s.mock, gorm.ErrRecordNotFound, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(3, s.mock, gorm.ErrRecordNotFound, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = gorm.ErrInvalidTransaction
 	test_sql.DeleteByID(3, s.mock, gorm.ErrInvalidTransaction, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	// Success scenario
 	expectedErr = nil
 	test_sql.DeleteByID(3, s.mock, expectedErr, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.NoError(t, err)
+	require.NoError(t, s.mock.ExpectationsWereMet())
 }
 
 func (s *DomainRepositorySuite) TestWrapErrNotFound() {

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -994,11 +994,13 @@ func (s *DomainRepositorySuite) TestDeleteByIdLogError() {
 	t := s.T()
 	r := &domainRepository{}
 
-	d := builder_model.NewDomain(builder_model.NewModel().WithID(1).Build()).Build()
+	domainID := uint(1)
+	d := builder_model.NewDomain(builder_model.NewModel().WithID(domainID).Build()).Build()
 
 	test_sql.DeleteByID(1, s.mock, gorm.ErrInvalidTransaction, d)
 	err := r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, "invalid transaction")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	// Check the log message
 	assert.Contains(t, s.LogBuffer.String(), `level=ERROR msg="deleting domain when checking that the record exist"`)

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -147,7 +147,7 @@ func (s *DomainRepositorySuite) TestCreateIpaDomain() {
 	assert.NoError(t, err)
 }
 
-func (s *DomainRepositorySuite) TestUpdateErrors() {
+func (s *DomainRepositorySuite) TestUpdateAgent() {
 	t := s.Suite.T()
 	orgID := test.OrgId
 	testUUID := test.DomainUUID
@@ -160,16 +160,20 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	assert.Panics(t, func() {
 		_ = s.repository.UpdateAgent(nil, "", nil)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	assert.PanicsWithValue(t, "'db' could not be read", func() {
 		_ = s.repository.UpdateAgent(context.Background(), "", nil)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	err = s.repository.UpdateAgent(s.Ctx, "", nil)
 	assert.EqualError(t, err, "'orgID' is empty")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	err = s.repository.UpdateAgent(s.Ctx, orgID, nil)
 	assert.EqualError(t, err, "code=500, message='data' cannot be nil")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr := fmt.Errorf("record not found")
 	s.mock.MatchExpectationsInOrder(true)
@@ -177,6 +181,7 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	test_sql.FindIpaByID(1, s.mock, expectedErr, domainID, data)
 	err = s.repository.UpdateAgent(s.Ctx, orgID, data)
 	require.EqualError(t, err, "record not found")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	s.mock.MatchExpectationsInOrder(true)
 	test_sql.FindByID(1, s.mock, nil, domainID, data)
@@ -209,6 +214,7 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	test_sql.CreateIpaDomain(4, s.mock, nil, data.IpaDomain)
 	err = s.repository.UpdateAgent(s.Ctx, orgID, data)
 	require.NoError(t, err)
+	require.NoError(t, s.mock.ExpectationsWereMet())
 }
 
 func (s *DomainRepositorySuite) TestUpdateIpaDomain() {


### PR DESCRIPTION
Rename TestUpdateErrors to TestUpdateAgent and add
checks for the sqlmocks. This prepare for additional
changes.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/368
