### PR TITLE
fix(HMS-3803): add additional guards

### DIFF
--- a/internal/test/smoke/domain_patch_user_test.go
+++ b/internal/test/smoke/domain_patch_user_test.go
@@ -10,6 +10,7 @@ import (
 	builder_api "github.com/podengo-project/idmsvc-backend/internal/test/builder/api"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
 )
 
 // SuiteDomainUpdateUser is the suite to validate the smoke test when a user update the domain endpoint at PATCH /api/idmsvc/v1/domains/:domain_id
@@ -71,4 +72,8 @@ func (s *SuiteDomainUpdateUser) TestPatchDomain() {
 		}
 		s.RunTestCases(testCases)
 	}
+}
+
+func TestSuiteDomainUpdateUser(t *testing.T) {
+	suite.Run(t, new(SuiteDomainUpdateUser))
 }

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -903,7 +903,6 @@ func TestSuite(t *testing.T) {
 	suite.Run(t, new(SuiteTokenCreate))
 	suite.Run(t, new(SuiteRegisterDomain))
 	suite.Run(t, new(SuiteReadDomain))
-	suite.Run(t, new(SuiteDomainUpdateUser))
 	suite.Run(t, new(SuiteDomainUpdateAgent))
 	suite.Run(t, new(SuiteListDomains))
 	suite.Run(t, new(SuiteDeleteDomain))

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -153,6 +153,11 @@ func (r *domainRepository) UpdateAgent(
 		log.Error(err.Error())
 		return err
 	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("Domain.Model.ID cannot be 0")
+		log.Error(err.Error())
+		return err
+	}
 
 	// Check the entity exists
 	if currentDomain, err = r.FindByID(
@@ -220,9 +225,19 @@ func (r *domainRepository) UpdateUser(
 	data *model.Domain,
 ) (err error) {
 	var currentDomain *model.Domain
-	db := app_context.DBFromCtx(ctx)
+	if ctx == nil {
+		err = internal_errors.NilArgError("ctx")
+		slog.Default().Error(err.Error())
+		return err
+	}
 	log := app_context.LogFromCtx(ctx)
+	db := app_context.DBFromCtx(ctx)
 	if err = r.checkCommonAndData(db, orgID, data); err != nil {
+		log.Error(err.Error())
+		return err
+	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("'Domain.Model.ID' cannot be 0")
 		log.Error(err.Error())
 		return err
 	}
@@ -459,6 +474,11 @@ func (r *domainRepository) updateIpaDomain(
 	db *gorm.DB,
 	data *model.Ipa,
 ) (err error) {
+	if log == nil {
+		err = internal_errors.NilArgError("log")
+		slog.Default().Error(err.Error())
+		return err
+	}
 	if db == nil {
 		err = internal_errors.NilArgError("db")
 		log.Error(err.Error())
@@ -466,6 +486,11 @@ func (r *domainRepository) updateIpaDomain(
 	}
 	if data == nil {
 		err = internal_errors.NilArgError("data")
+		log.Error(err.Error())
+		return err
+	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("Domain.Model.ID cannot be 0")
 		log.Error(err.Error())
 		return err
 	}

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -236,11 +236,6 @@ func (r *domainRepository) UpdateUser(
 		log.Error(err.Error())
 		return err
 	}
-	if data.Model.ID == 0 {
-		err = fmt.Errorf("'Domain.Model.ID' cannot be 0")
-		log.Error(err.Error())
-		return err
-	}
 
 	// Check the entity exists
 	if currentDomain, err = r.FindByID(

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -667,13 +667,6 @@ func (s *DomainRepositorySuite) TestUpdateUser() {
 	require.EqualError(t, err, expectedErr.Error())
 	require.NoError(t, s.mock.ExpectationsWereMet())
 
-	// Domain.Model.ID is 0
-	expectedErr = fmt.Errorf("'Domain.Model.ID' cannot be 0")
-	data.Model.ID = 0
-	err = s.repository.UpdateUser(c, orgID, data)
-	require.EqualError(t, err, expectedErr.Error())
-	require.NoError(t, s.mock.ExpectationsWereMet())
-
 	// error at FindByID
 	expectedErr = fmt.Errorf("error at FindByID")
 	data.Model.ID = domainID


### PR DESCRIPTION
Add additional guards for:
- UpdateAgent
- UpdateUser
- updateIpaDomain
    
And update the unit tests according to them.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/369