### PR TITLE
refactor(HMS-3803): prepare test/sql package for final commit

### DIFF
--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -1,11 +1,13 @@
 package sql
 
 import (
+	"database/sql/driver"
 	"fmt"
 	"regexp"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+	"gorm.io/gorm"
 )
 
 func PrepSqlSelectDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
@@ -51,6 +53,55 @@ func FindByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint,
 		switch i {
 		case 1:
 			PrepSqlSelectDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}
+
+func PrepSqlSelectCountDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Domain) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT count(*) FROM "domains" WHERE (org_id = $1 AND domain_uuid = $2) AND "domains"."deleted_at" IS NULL LIMIT $3`)).
+		WithArgs(
+			data.OrgId,
+			data.DomainUuid,
+			1,
+		)
+	if withError {
+		if expectedErr == gorm.ErrRecordNotFound {
+			expectQuery.WillReturnRows(sqlmock.NewRows([]string{"count"}).
+				AddRow(int64(0)))
+		} else {
+			expectQuery.WillReturnError(expectedErr)
+		}
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"count"}).
+			AddRow(int64(1)))
+	}
+}
+
+func PrepSqlDeleteDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Domain) {
+	expectQuery := mock.ExpectExec(regexp.QuoteMeta(`DELETE FROM "domains" WHERE (org_id = $1 AND domain_uuid = $2) AND "domains"."id" = $3`)).
+		WithArgs(
+			data.OrgId,
+			data.DomainUuid,
+			data.ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnResult(driver.RowsAffected(1))
+	}
+}
+
+func DeleteByID(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlSelectDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, uint(1), data)
+		case 2:
+			PrepSqlSelectCountDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		case 3:
+			PrepSqlDeleteDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
 		default:
 			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
 		}

--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -128,7 +128,7 @@ func PrepSqlUpdateDomainsForUser(mock sqlmock.Sqlmock, withError bool, expectedE
 	}
 }
 
-func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint, data *model.Domain) {
 	if stage == 0 {
 		return
 	}
@@ -138,7 +138,6 @@ func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.
 	if stage > 2 {
 		panic("'stage' cannot be greater than 3")
 	}
-	domainID := uint(1)
 
 	mock.MatchExpectationsInOrder(true)
 	for i := 1; i <= stage; i++ {

--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -107,3 +107,52 @@ func DeleteByID(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.
 		}
 	}
 }
+
+func PrepSqlUpdateDomainsForUser(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectExec := mock.ExpectExec(regexp.QuoteMeta(`UPDATE "domains" SET "auto_enrollment_enabled"=$1,"description"=$2,"title"=$3 WHERE (org_id = $4 AND domain_uuid = $5) AND "domains"."deleted_at" IS NULL AND "id" = $6`)).
+		WithArgs(
+			data.AutoEnrollmentEnabled,
+			data.Description,
+			data.Title,
+
+			data.OrgId,
+			data.DomainUuid,
+			domainID,
+		)
+	if withError {
+		expectExec.WillReturnError(expectedErr)
+	} else {
+		expectExec.WillReturnResult(
+			driver.RowsAffected(1))
+	}
+}
+
+func UpdateUser(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
+	if stage == 0 {
+		return
+	}
+	if stage < 0 {
+		panic("'stage' cannot be lower than 0")
+	}
+	if stage > 2 {
+		panic("'stage' cannot be greater than 3")
+	}
+	domainID := uint(1)
+
+	mock.MatchExpectationsInOrder(true)
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			if i == stage && expectedErr != nil {
+				FindByID(1, mock, expectedErr, domainID, data)
+			} else {
+				FindByID(1, mock, nil, domainID, data)
+				FindIpaByID(4, mock, nil, domainID, data)
+			}
+		case 2: // Update
+			PrepSqlUpdateDomainsForUser(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}

--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -181,7 +181,7 @@ func PrepSqlInsertIntoDomains(mock sqlmock.Sqlmock, withError bool, expectedErr 
 	}
 }
 
-func Register(stage int, data *model.Domain, mock sqlmock.Sqlmock, expectedErr error) {
+func Register(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Domain) {
 	for i := 1; i <= stage; i++ {
 		switch i {
 		case 1:

--- a/internal/test/sql/domains_sql.go
+++ b/internal/test/sql/domains_sql.go
@@ -1,0 +1,58 @@
+package sql
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+)
+
+func PrepSqlSelectDomainsByID(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "domains" WHERE (org_id = $1 AND domain_uuid = $2) AND "domains"."deleted_at" IS NULL ORDER BY "domains"."id" LIMIT $3`)).
+		WithArgs(
+			data.OrgId,
+			data.DomainUuid,
+			1,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		autoenrollment := false
+		if data.AutoEnrollmentEnabled != nil {
+			autoenrollment = *data.AutoEnrollmentEnabled
+		}
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"org_id", "domain_uuid", "domain_name",
+			"title", "description", "type",
+			"auto_enrollment_enabled",
+		}).
+			AddRow(
+				domainID,
+				data.CreatedAt,
+				data.UpdatedAt,
+				nil,
+
+				data.OrgId,
+				data.DomainUuid,
+				data.DomainName,
+				data.Title,
+				data.Description,
+				data.Type,
+				autoenrollment,
+			))
+	}
+}
+
+func FindByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint, data *model.Domain) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlSelectDomainsByID(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}

--- a/internal/test/sql/helper.go
+++ b/internal/test/sql/helper.go
@@ -1,0 +1,6 @@
+package sql
+
+// WithPredicateExpectedError
+func WithPredicateExpectedError(step, stage int, expectedErr error) bool {
+	return step == stage && expectedErr != nil
+}

--- a/internal/test/sql/ipas_sql.go
+++ b/internal/test/sql/ipas_sql.go
@@ -1,0 +1,147 @@
+package sql
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/podengo-project/idmsvc-backend/internal/domain/model"
+)
+
+func PrepSqlSelectIpas(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipas" WHERE id = $1 AND "ipas"."deleted_at" IS NULL ORDER BY "ipas"."id" LIMIT $2`)).
+		WithArgs(
+			domainID,
+			1,
+		)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		expectedQuery.WillReturnRows(sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"realm_name", "realm_domains",
+		}).AddRow(
+			domainID,
+			data.Model.CreatedAt,
+			data.Model.UpdatedAt,
+			data.Model.DeletedAt,
+
+			data.IpaDomain.RealmName,
+			data.IpaDomain.RealmDomains,
+		))
+	}
+}
+
+func PrepSqlSelectIpaCerts(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_certs" WHERE "ipa_certs"."ipa_id" = $1 AND "ipa_certs"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id", "issuer", "nickname",
+			"not_after", "not_before", "serial_number",
+			"subject", "pem",
+		})
+		for j := range data.IpaDomain.CaCerts {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.CaCerts[j].Model.CreatedAt,
+				data.IpaDomain.CaCerts[j].Model.UpdatedAt,
+				data.IpaDomain.CaCerts[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.CaCerts[j].Issuer,
+				data.IpaDomain.CaCerts[j].Nickname,
+				data.IpaDomain.CaCerts[j].NotAfter,
+				data.IpaDomain.CaCerts[j].NotBefore,
+				data.IpaDomain.CaCerts[j].SerialNumber,
+				data.IpaDomain.CaCerts[j].Subject,
+				data.IpaDomain.CaCerts[j].Pem,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func PrepSqlSelectIpaLocations(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_locations" WHERE "ipa_locations"."ipa_id" = $1 AND "ipa_locations"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id",
+			"name", "description",
+		})
+		for j := range data.IpaDomain.Locations {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.Locations[j].Model.CreatedAt,
+				data.IpaDomain.Locations[j].Model.UpdatedAt,
+				data.IpaDomain.Locations[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.Locations[j].Name,
+				data.IpaDomain.Locations[j].Description,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func PrepSqlSelectIpaServers(mock sqlmock.Sqlmock, withError bool, expectedErr error, domainID uint, data *model.Domain) {
+	expectedQuery := mock.ExpectQuery(regexp.QuoteMeta(`SELECT * FROM "ipa_servers" WHERE "ipa_servers"."ipa_id" = $1 AND "ipa_servers"."deleted_at" IS NULL`)).
+		WithArgs(domainID)
+	if withError {
+		expectedQuery.WillReturnError(expectedErr)
+	} else {
+		rows := sqlmock.NewRows([]string{
+			"id", "created_at", "updated_at", "deletet_at",
+
+			"ipa_id", "fqdn", "rhsm_id", "location",
+			"ca_server", "hcc_enrollment_server", "hcc_update_server",
+			"pk_init_server",
+		})
+		for j := range data.IpaDomain.Servers {
+			rows.AddRow(
+				domainID+uint(j)+1,
+				data.IpaDomain.Servers[j].Model.CreatedAt,
+				data.IpaDomain.Servers[j].Model.UpdatedAt,
+				data.IpaDomain.Servers[j].Model.DeletedAt,
+
+				domainID,
+				data.IpaDomain.Servers[j].FQDN,
+				data.IpaDomain.Servers[j].RHSMId,
+				data.IpaDomain.Servers[j].Location,
+				data.IpaDomain.Servers[j].CaServer,
+				data.IpaDomain.Servers[j].HCCEnrollmentServer,
+				data.IpaDomain.Servers[j].HCCUpdateServer,
+				data.IpaDomain.Servers[j].PKInitServer,
+			)
+		}
+		expectedQuery.WillReturnRows(rows)
+	}
+}
+
+func FindIpaByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID uint, data *model.Domain) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlSelectIpas(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 2:
+			PrepSqlSelectIpaCerts(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 3:
+			PrepSqlSelectIpaLocations(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		case 4:
+			PrepSqlSelectIpaServers(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, domainID, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}

--- a/internal/test/sql/ipas_sql.go
+++ b/internal/test/sql/ipas_sql.go
@@ -167,72 +167,78 @@ func PrepSqlInsertIntoIpas(mock sqlmock.Sqlmock, withError bool, expectedErr err
 }
 
 func PrepSqlInsertIntoIpaCerts(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
-	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_certs" ("created_at","updated_at","deleted_at","ipa_id","issuer","nickname","not_after","not_before","pem","serial_number","subject","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
-		WithArgs(
-			data.CaCerts[0].CreatedAt,
-			data.CaCerts[0].UpdatedAt,
-			nil,
+	for j := range data.CaCerts {
+		expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_certs" ("created_at","updated_at","deleted_at","ipa_id","issuer","nickname","not_after","not_before","pem","serial_number","subject","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
+			WithArgs(
+				data.CaCerts[j].CreatedAt,
+				data.CaCerts[j].UpdatedAt,
+				nil,
 
-			data.CaCerts[0].IpaID,
-			data.CaCerts[0].Issuer,
-			data.CaCerts[0].Nickname,
-			data.CaCerts[0].NotAfter,
-			data.CaCerts[0].NotBefore,
-			data.CaCerts[0].Pem,
-			data.CaCerts[0].SerialNumber,
-			data.CaCerts[0].Subject,
-			data.CaCerts[0].ID,
-		)
-	if withError {
-		expectQuery.WillReturnError(expectedErr)
-	} else {
+				data.CaCerts[j].IpaID,
+				data.CaCerts[j].Issuer,
+				data.CaCerts[j].Nickname,
+				data.CaCerts[j].NotAfter,
+				data.CaCerts[j].NotBefore,
+				data.CaCerts[j].Pem,
+				data.CaCerts[j].SerialNumber,
+				data.CaCerts[j].Subject,
+				data.CaCerts[j].ID,
+			)
+		if withError {
+			expectQuery.WillReturnError(expectedErr)
+			return
+		}
 		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
-			AddRow(data.CaCerts[0].ID))
+			AddRow(100*data.CaCerts[0].ID + uint(j)))
 	}
 }
 
 func PrepSqlInsertIntoIpaServers(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
-	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_servers" ("created_at","updated_at","deleted_at","ipa_id","fqdn","rhsm_id","location","ca_server","hcc_enrollment_server","hcc_update_server","pk_init_server","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
-		WithArgs(
-			data.Servers[0].CreatedAt,
-			data.Servers[0].UpdatedAt,
-			nil,
+	for j := range data.Servers {
+		expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_servers" ("created_at","updated_at","deleted_at","ipa_id","fqdn","rhsm_id","location","ca_server","hcc_enrollment_server","hcc_update_server","pk_init_server","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
+			WithArgs(
+				data.Servers[j].CreatedAt,
+				data.Servers[j].UpdatedAt,
+				nil,
 
-			data.Servers[0].IpaID,
-			data.Servers[0].FQDN,
-			data.Servers[0].RHSMId,
-			data.Servers[0].Location,
-			data.Servers[0].CaServer,
-			data.Servers[0].HCCEnrollmentServer,
-			data.Servers[0].HCCUpdateServer,
-			data.Servers[0].PKInitServer,
-			data.Servers[0].ID,
-		)
-	if withError {
-		expectQuery.WillReturnError(expectedErr)
-	} else {
+				data.Servers[j].IpaID,
+				data.Servers[j].FQDN,
+				data.Servers[j].RHSMId,
+				data.Servers[j].Location,
+				data.Servers[j].CaServer,
+				data.Servers[j].HCCEnrollmentServer,
+				data.Servers[j].HCCUpdateServer,
+				data.Servers[j].PKInitServer,
+				data.Servers[j].ID,
+			)
+		if withError {
+			expectQuery.WillReturnError(expectedErr)
+			return
+		}
 		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
-			AddRow(data.Servers[0].ID))
+			AddRow(200*data.Servers[0].ID + uint(j)))
 	}
 }
 
 func PrepSqlInsertIntoIpaLocations(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
-	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_locations" ("created_at","updated_at","deleted_at","ipa_id","name","description","id") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`)).
-		WithArgs(
-			data.Locations[0].CreatedAt,
-			data.Locations[0].UpdatedAt,
-			nil,
+	for j := range data.Locations {
+		expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_locations" ("created_at","updated_at","deleted_at","ipa_id","name","description","id") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`)).
+			WithArgs(
+				data.Locations[j].CreatedAt,
+				data.Locations[j].UpdatedAt,
+				nil,
 
-			data.Locations[0].IpaID,
-			data.Locations[0].Name,
-			data.Locations[0].Description,
-			data.Locations[0].ID,
-		)
-	if withError {
-		expectQuery.WillReturnError(expectedErr)
-	} else {
+				data.Locations[j].IpaID,
+				data.Locations[j].Name,
+				data.Locations[j].Description,
+				data.Locations[j].ID,
+			)
+		if withError {
+			expectQuery.WillReturnError(expectedErr)
+			return
+		}
 		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
-			AddRow(data.Locations[0].ID))
+			AddRow(300*data.Locations[0].ID + uint(j)))
 	}
 }
 

--- a/internal/test/sql/ipas_sql.go
+++ b/internal/test/sql/ipas_sql.go
@@ -145,3 +145,109 @@ func FindIpaByID(stage int, mock sqlmock.Sqlmock, expectedErr error, domainID ui
 		}
 	}
 }
+
+func PrepSqlInsertIntoIpas(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipas" ("created_at","updated_at","deleted_at","realm_name","realm_domains","id") VALUES ($1,$2,$3,$4,$5,$6) RETURNING "id"`)).
+		WithArgs(
+			data.Model.CreatedAt,
+			data.Model.UpdatedAt,
+			nil,
+
+			data.RealmName,
+			data.RealmDomains,
+			data.ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow(data.ID))
+	}
+}
+
+func PrepSqlInsertIntoIpaCerts(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_certs" ("created_at","updated_at","deleted_at","ipa_id","issuer","nickname","not_after","not_before","pem","serial_number","subject","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
+		WithArgs(
+			data.CaCerts[0].CreatedAt,
+			data.CaCerts[0].UpdatedAt,
+			nil,
+
+			data.CaCerts[0].IpaID,
+			data.CaCerts[0].Issuer,
+			data.CaCerts[0].Nickname,
+			data.CaCerts[0].NotAfter,
+			data.CaCerts[0].NotBefore,
+			data.CaCerts[0].Pem,
+			data.CaCerts[0].SerialNumber,
+			data.CaCerts[0].Subject,
+			data.CaCerts[0].ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow(data.CaCerts[0].ID))
+	}
+}
+
+func PrepSqlInsertIntoIpaServers(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_servers" ("created_at","updated_at","deleted_at","ipa_id","fqdn","rhsm_id","location","ca_server","hcc_enrollment_server","hcc_update_server","pk_init_server","id") VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12) RETURNING "id"`)).
+		WithArgs(
+			data.Servers[0].CreatedAt,
+			data.Servers[0].UpdatedAt,
+			nil,
+
+			data.Servers[0].IpaID,
+			data.Servers[0].FQDN,
+			data.Servers[0].RHSMId,
+			data.Servers[0].Location,
+			data.Servers[0].CaServer,
+			data.Servers[0].HCCEnrollmentServer,
+			data.Servers[0].HCCUpdateServer,
+			data.Servers[0].PKInitServer,
+			data.Servers[0].ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow(data.Servers[0].ID))
+	}
+}
+
+func PrepSqlInsertIntoIpaLocations(mock sqlmock.Sqlmock, withError bool, expectedErr error, data *model.Ipa) {
+	expectQuery := mock.ExpectQuery(regexp.QuoteMeta(`INSERT INTO "ipa_locations" ("created_at","updated_at","deleted_at","ipa_id","name","description","id") VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING "id"`)).
+		WithArgs(
+			data.Locations[0].CreatedAt,
+			data.Locations[0].UpdatedAt,
+			nil,
+
+			data.Locations[0].IpaID,
+			data.Locations[0].Name,
+			data.Locations[0].Description,
+			data.Locations[0].ID,
+		)
+	if withError {
+		expectQuery.WillReturnError(expectedErr)
+	} else {
+		expectQuery.WillReturnRows(sqlmock.NewRows([]string{"id"}).
+			AddRow(data.Locations[0].ID))
+	}
+}
+
+func CreateIpaDomain(stage int, mock sqlmock.Sqlmock, expectedErr error, data *model.Ipa) {
+	for i := 1; i <= stage; i++ {
+		switch i {
+		case 1:
+			PrepSqlInsertIntoIpas(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		case 2:
+			PrepSqlInsertIntoIpaCerts(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		case 3:
+			PrepSqlInsertIntoIpaServers(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		case 4:
+			PrepSqlInsertIntoIpaLocations(mock, WithPredicateExpectedError(i, stage, expectedErr), expectedErr, data)
+		default:
+			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
+		}
+	}
+}

--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -153,6 +153,11 @@ func (r *domainRepository) UpdateAgent(
 		log.Error(err.Error())
 		return err
 	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("Domain.Model.ID cannot be 0")
+		log.Error(err.Error())
+		return err
+	}
 
 	// Check the entity exists
 	if currentDomain, err = r.FindByID(
@@ -220,9 +225,19 @@ func (r *domainRepository) UpdateUser(
 	data *model.Domain,
 ) (err error) {
 	var currentDomain *model.Domain
-	db := app_context.DBFromCtx(ctx)
+	if ctx == nil {
+		err = internal_errors.NilArgError("ctx")
+		slog.Default().Error(err.Error())
+		return err
+	}
 	log := app_context.LogFromCtx(ctx)
+	db := app_context.DBFromCtx(ctx)
 	if err = r.checkCommonAndData(db, orgID, data); err != nil {
+		log.Error(err.Error())
+		return err
+	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("'Domain.Model.ID' cannot be 0")
 		log.Error(err.Error())
 		return err
 	}
@@ -459,6 +474,11 @@ func (r *domainRepository) updateIpaDomain(
 	db *gorm.DB,
 	data *model.Ipa,
 ) (err error) {
+	if log == nil {
+		err = internal_errors.NilArgError("log")
+		slog.Default().Error(err.Error())
+		return err
+	}
 	if db == nil {
 		err = internal_errors.NilArgError("db")
 		log.Error(err.Error())
@@ -466,6 +486,11 @@ func (r *domainRepository) updateIpaDomain(
 	}
 	if data == nil {
 		err = internal_errors.NilArgError("data")
+		log.Error(err.Error())
+		return err
+	}
+	if data.Model.ID == 0 {
+		err = fmt.Errorf("Domain.Model.ID cannot be 0")
 		log.Error(err.Error())
 		return err
 	}

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -868,41 +868,49 @@ func (s *DomainRepositorySuite) TestDeleteById() {
 	require.Panics(t, func() {
 		_ = r.DeleteById(nil, "", model.NilUUID)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	assert.PanicsWithValue(t, "'db' could not be read", func() {
 		_ = r.DeleteById(context.Background(), "", model.NilUUID)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(1, s.mock, gorm.ErrRecordNotFound, d)
 	err := r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("invalid transaction")
 	test_sql.DeleteByID(1, s.mock, gorm.ErrInvalidTransaction, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(2, s.mock, gorm.ErrRecordNotFound, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = fmt.Errorf("code=404, message=unknown domain '%s'", d.DomainUuid.String())
 	test_sql.DeleteByID(3, s.mock, gorm.ErrRecordNotFound, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr = gorm.ErrInvalidTransaction
 	test_sql.DeleteByID(3, s.mock, gorm.ErrInvalidTransaction, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, expectedErr.Error())
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	// Success scenario
 	expectedErr = nil
 	test_sql.DeleteByID(3, s.mock, expectedErr, d)
 	err = r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.NoError(t, err)
+	require.NoError(t, s.mock.ExpectationsWereMet())
 }
 
 func (s *DomainRepositorySuite) TestWrapErrNotFound() {

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -994,11 +994,13 @@ func (s *DomainRepositorySuite) TestDeleteByIdLogError() {
 	t := s.T()
 	r := &domainRepository{}
 
-	d := builder_model.NewDomain(builder_model.NewModel().WithID(1).Build()).Build()
+	domainID := uint(1)
+	d := builder_model.NewDomain(builder_model.NewModel().WithID(domainID).Build()).Build()
 
 	test_sql.DeleteByID(1, s.mock, gorm.ErrInvalidTransaction, d)
 	err := r.DeleteById(s.Ctx, d.OrgId, d.DomainUuid)
 	require.EqualError(t, err, "invalid transaction")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	// Check the log message
 	assert.Contains(t, s.LogBuffer.String(), `level=ERROR msg="deleting domain when checking that the record exist"`)

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -147,7 +147,7 @@ func (s *DomainRepositorySuite) TestCreateIpaDomain() {
 	assert.NoError(t, err)
 }
 
-func (s *DomainRepositorySuite) TestUpdateErrors() {
+func (s *DomainRepositorySuite) TestUpdateAgent() {
 	t := s.Suite.T()
 	orgID := test.OrgId
 	testUUID := test.DomainUUID
@@ -160,16 +160,20 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	assert.Panics(t, func() {
 		_ = s.repository.UpdateAgent(nil, "", nil)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	assert.PanicsWithValue(t, "'db' could not be read", func() {
 		_ = s.repository.UpdateAgent(context.Background(), "", nil)
 	})
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	err = s.repository.UpdateAgent(s.Ctx, "", nil)
 	assert.EqualError(t, err, "'orgID' is empty")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	err = s.repository.UpdateAgent(s.Ctx, orgID, nil)
 	assert.EqualError(t, err, "code=500, message='data' cannot be nil")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	expectedErr := fmt.Errorf("record not found")
 	s.mock.MatchExpectationsInOrder(true)
@@ -177,6 +181,7 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	test_sql.FindIpaByID(1, s.mock, expectedErr, domainID, data)
 	err = s.repository.UpdateAgent(s.Ctx, orgID, data)
 	require.EqualError(t, err, "record not found")
+	require.NoError(t, s.mock.ExpectationsWereMet())
 
 	s.mock.MatchExpectationsInOrder(true)
 	test_sql.FindByID(1, s.mock, nil, domainID, data)
@@ -209,6 +214,7 @@ func (s *DomainRepositorySuite) TestUpdateErrors() {
 	test_sql.CreateIpaDomain(4, s.mock, nil, data.IpaDomain)
 	err = s.repository.UpdateAgent(s.Ctx, orgID, data)
 	require.NoError(t, err)
+	require.NoError(t, s.mock.ExpectationsWereMet())
 }
 
 func (s *DomainRepositorySuite) TestUpdateIpaDomain() {

--- a/internal/usecase/repository/host_repository_test.go
+++ b/internal/usecase/repository/host_repository_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/podengo-project/idmsvc-backend/internal/interface/interactor"
 	"github.com/podengo-project/idmsvc-backend/internal/test/builder/helper"
 	builder_model "github.com/podengo-project/idmsvc-backend/internal/test/builder/model"
+	test_sql "github.com/podengo-project/idmsvc-backend/internal/test/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -85,9 +86,9 @@ func (s *SuiteHost) helperTestMatchDomain(stage int, options *interactor.HostCon
 			}
 		case 2:
 			if len(domains) == 0 {
-				helperTestFindByIDIpa(1, &domains[0], mock, expectedErr)
+				test_sql.FindIpaByID(1, mock, expectedErr, domains[0].ID, &domains[0])
 			}
-			helperTestFindByIDIpa(4, &domains[0], mock, expectedErr)
+			test_sql.FindIpaByID(4, mock, expectedErr, domains[0].ID, &domains[0])
 		default:
 			panic(fmt.Sprintf("scenario %d/%d is not supported", i, stage))
 		}


### PR DESCRIPTION
This refactor prepare the final commit by adding some
missed functions and updating some pending changes.

Add functions:
- PrepSqlUpdateDomainsForAgent
- UpdateAgent

Update functions PrepSqlInsert... at ipas_sql.go
to support multiple entries on the slices, making
them more corrects.