### PR TITLE
refactor(HMS-3803): align a bit more before the fix

### DIFF
--- a/internal/usecase/repository/domain_repository.go
+++ b/internal/usecase/repository/domain_repository.go
@@ -467,7 +467,7 @@ func (r *domainRepository) createIpaDomain(
 func (r *domainRepository) updateIpaDomain(
 	log *slog.Logger,
 	db *gorm.DB,
-	data *model.Ipa,
+	dataIPA *model.Ipa,
 ) (err error) {
 	if log == nil {
 		err = internal_errors.NilArgError("log")
@@ -479,51 +479,51 @@ func (r *domainRepository) updateIpaDomain(
 		log.Error(err.Error())
 		return err
 	}
-	if data == nil {
+	if dataIPA == nil {
 		err = internal_errors.NilArgError("data")
 		log.Error(err.Error())
 		return err
 	}
-	if data.Model.ID == 0 {
+	if dataIPA.Model.ID == 0 {
 		err = fmt.Errorf("Domain.Model.ID cannot be 0")
 		log.Error(err.Error())
 		return err
 	}
 	if err = db.Unscoped().
-		Delete(data).Error; err != nil {
+		Delete(dataIPA).Error; err != nil {
 		log.Error("updating ipa domain when deleting old record")
 		return err
 	}
 
 	if err = db.Omit(clause.Associations).
-		Create(data).
+		Create(dataIPA).
 		Error; err != nil {
 		log.Error("updating ipa domain when creating new ipa record")
 		return err
 	}
 
 	// CaCerts
-	for i := range data.CaCerts {
-		data.CaCerts[i].IpaID = data.ID
-		if err = db.Create(&data.CaCerts[i]).Error; err != nil {
+	for i := range dataIPA.CaCerts {
+		dataIPA.CaCerts[i].IpaID = dataIPA.ID
+		if err = db.Create(&dataIPA.CaCerts[i]).Error; err != nil {
 			log.Error("updating ipa domain when creating new ipa certificate record")
 			return err
 		}
 	}
 
 	// Servers
-	for i := range data.Servers {
-		data.Servers[i].IpaID = data.ID
-		if err = db.Create(&data.Servers[i]).Error; err != nil {
+	for i := range dataIPA.Servers {
+		dataIPA.Servers[i].IpaID = dataIPA.ID
+		if err = db.Create(&dataIPA.Servers[i]).Error; err != nil {
 			log.Error("updating ipa domain when creating new ipa server record")
 			return err
 		}
 	}
 
 	// Locations
-	for i := range data.Locations {
-		data.Locations[i].IpaID = data.ID
-		if err = db.Create(&data.Locations[i]).Error; err != nil {
+	for i := range dataIPA.Locations {
+		dataIPA.Locations[i].IpaID = dataIPA.ID
+		if err = db.Create(&dataIPA.Locations[i]).Error; err != nil {
 			log.Error("updating ipa domain when creating new ipa location record")
 			return err
 		}

--- a/internal/usecase/repository/domain_repository_test.go
+++ b/internal/usecase/repository/domain_repository_test.go
@@ -123,19 +123,19 @@ func (s *DomainRepositorySuite) TestCreateIpaDomain() {
 	assert.EqualError(t, err, expectedError.Error())
 
 	// Error on INSERT INTO "ipa_certs"
-	expectedError = fmt.Errorf(`INSERT INTO "ipa_certs"`)
+	expectedError = fmt.Errorf(`error at INSERT INTO "ipa_certs"`)
 	test_sql.CreateIpaDomain(2, s.mock, expectedError, &data)
 	err = s.repository.createIpaDomain(s.Log, s.DB, 1, &data)
 	assert.EqualError(t, err, expectedError.Error())
 
 	// Error on INSERT INTO "ipa_servers"
-	expectedError = fmt.Errorf(`INSERT INTO "ipa_servers"`)
+	expectedError = fmt.Errorf(`error at INSERT INTO "ipa_servers"`)
 	test_sql.CreateIpaDomain(3, s.mock, expectedError, &data)
 	err = s.repository.createIpaDomain(s.Log, s.DB, 1, &data)
 	assert.EqualError(t, err, expectedError.Error())
 
 	// Error on INSERT INTO "ipa_locations"
-	expectedError = fmt.Errorf(`INSERT INTO "ipa_locations"`)
+	expectedError = fmt.Errorf(`error at INSERT INTO "ipa_locations"`)
 	test_sql.CreateIpaDomain(4, s.mock, expectedError, &data)
 	err = s.repository.createIpaDomain(s.Log, s.DB, 1, &data)
 	assert.EqualError(t, err, expectedError.Error())
@@ -231,88 +231,13 @@ func (s *DomainRepositorySuite) TestUpdateIpaDomain() {
 		expectedErr error
 	)
 	t := s.Suite.T()
-	currentTime := time.Now()
 	orgID := "11111"
 	domainID := uint(1)
-	domainUUID := uuid.MustParse("3bccb88e-dd25-11ed-99e0-482ae3863d30")
-	subscriptionManagerID := pointy.String("fe106208-dd32-11ed-aa87-482ae3863d30")
-	data := model.Domain{
-		Model: gorm.Model{
-			ID:        domainID,
-			CreatedAt: currentTime,
-			UpdatedAt: currentTime,
-		},
-		OrgId:                 orgID,
-		DomainUuid:            domainUUID,
-		DomainName:            pointy.String("mydomain.example"),
-		Title:                 pointy.String("My Domain Example"),
-		Description:           pointy.String("Description of My Domain Example"),
-		AutoEnrollmentEnabled: pointy.Bool(true),
-		Type:                  pointy.Uint(model.DomainTypeIpa),
-		IpaDomain: &model.Ipa{
-			Model: gorm.Model{
-				ID:        domainID,
-				CreatedAt: currentTime,
-				UpdatedAt: currentTime,
-				DeletedAt: gorm.DeletedAt{},
-			},
-			RealmName: pointy.String("MYDOMAIN.EXAMPLE"),
-			CaCerts: []model.IpaCert{
-				{
-					Model: gorm.Model{
-						ID:        2,
-						CreatedAt: currentTime,
-						UpdatedAt: currentTime,
-						DeletedAt: gorm.DeletedAt{},
-					},
-					IpaID:        domainID,
-					Issuer:       "CN=Certificate Authority,O=MYDOMAIN.EXAMPLE",
-					Nickname:     "MYDOMAIN.EXAMPLE IPA CA",
-					NotAfter:     currentTime.Add(24 * time.Hour),
-					NotBefore:    currentTime,
-					SerialNumber: "1",
-					Subject:      "CN=Certificate Authority,O=MYDOMAIN.EXAMPLE",
-					Pem:          "-----BEGIN CERTIFICATE-----\nMII...\n-----END CERTIFICATE-----",
-				},
-			},
-			Servers: []model.IpaServer{
-				{
-					Model: gorm.Model{
-						ID:        3,
-						CreatedAt: currentTime,
-						UpdatedAt: currentTime,
-						DeletedAt: gorm.DeletedAt{},
-					},
-					IpaID:               domainID,
-					FQDN:                "server1.mydomain.example",
-					RHSMId:              subscriptionManagerID,
-					Location:            pointy.String("europe"),
-					CaServer:            true,
-					HCCEnrollmentServer: true,
-					HCCUpdateServer:     true,
-					PKInitServer:        true,
-				},
-			},
-			Locations: []model.IpaLocation{
-				{
-					Model: gorm.Model{
-						ID:        4,
-						CreatedAt: currentTime,
-						UpdatedAt: currentTime,
-						DeletedAt: gorm.DeletedAt{},
-					},
-					IpaID:       domainID,
-					Name:        "boston",
-					Description: pointy.String("Boston data center"),
-				},
-			},
-			RealmDomains: pq.StringArray{"mydomain.example"},
-		},
-	}
+	data := test.BuildDomainModel(orgID)
 
 	// database error at INSERT INTO 'ipas'
 	expectedErr = fmt.Errorf("database error at INSERT INTO 'ipas'")
-	test_sql.UpdateIpaDomain(2, s.mock, expectedErr, &data)
+	test_sql.UpdateIpaDomain(2, s.mock, expectedErr, data)
 	data.IpaDomain.Model.ID = domainID
 	err = s.repository.updateIpaDomain(s.Log, s.DB, data.IpaDomain)
 	require.EqualError(t, err, expectedErr.Error())
@@ -320,7 +245,7 @@ func (s *DomainRepositorySuite) TestUpdateIpaDomain() {
 
 	// database error at INSERT INTO 'ipa_certs'
 	expectedErr = fmt.Errorf("database error at INSERT INTO 'ipa_certs'")
-	test_sql.UpdateIpaDomain(3, s.mock, expectedErr, &data)
+	test_sql.UpdateIpaDomain(3, s.mock, expectedErr, data)
 	data.IpaDomain.Model.ID = domainID
 	err = s.repository.updateIpaDomain(s.Log, s.DB, data.IpaDomain)
 	require.EqualError(t, err, expectedErr.Error())
@@ -328,7 +253,7 @@ func (s *DomainRepositorySuite) TestUpdateIpaDomain() {
 
 	// database error at INSERT INTO 'ipa_servers'
 	expectedErr = fmt.Errorf("database error at INSERT INTO 'ipa_servers'")
-	test_sql.UpdateIpaDomain(4, s.mock, expectedErr, &data)
+	test_sql.UpdateIpaDomain(4, s.mock, expectedErr, data)
 	data.IpaDomain.Model.ID = domainID
 	err = s.repository.updateIpaDomain(s.Log, s.DB, data.IpaDomain)
 	require.EqualError(t, err, expectedErr.Error())
@@ -336,7 +261,7 @@ func (s *DomainRepositorySuite) TestUpdateIpaDomain() {
 
 	// database error at INSERT INTO 'ipa_locations'
 	expectedErr = fmt.Errorf("database error at INSERT INTO 'ipa_locations'")
-	test_sql.UpdateIpaDomain(5, s.mock, expectedErr, &data)
+	test_sql.UpdateIpaDomain(5, s.mock, expectedErr, data)
 	data.IpaDomain.Model.ID = domainID
 	err = s.repository.updateIpaDomain(s.Log, s.DB, data.IpaDomain)
 	require.EqualError(t, err, expectedErr.Error())
@@ -344,7 +269,7 @@ func (s *DomainRepositorySuite) TestUpdateIpaDomain() {
 
 	// Success scenario
 	expectedErr = nil
-	test_sql.UpdateIpaDomain(5, s.mock, expectedErr, &data)
+	test_sql.UpdateIpaDomain(5, s.mock, expectedErr, data)
 	err = s.repository.updateIpaDomain(s.Log, s.DB, data.IpaDomain)
 	require.NoError(t, err)
 	require.NoError(t, s.mock.ExpectationsWereMet())


### PR DESCRIPTION
Update some differences observed with the final code
to fix:
- Update error messages making them more consistent
  on the unit tests.
- Clean-up an initialization.
- Some renames to be more clear about the data that
  is used at updateIpaDomain method.

Depends on: https://github.com/podengo-project/idmsvc-backend/pull/371