### PR TITLE
log database version on service startup

### DIFF
--- a/internal/infrastructure/datastore/db.go
+++ b/internal/infrastructure/datastore/db.go
@@ -54,6 +54,12 @@ func NewDB(cfg *config.Config) (db *gorm.DB) {
 		return nil
 	}
 	sqlDb.SetMaxOpenConns(cfg.Database.MaxOpenConns)
+
+	rows := sqlDb.QueryRow("SELECT version();")
+	var version string
+	rows.Scan(&version)
+	slog.Info("Connected to database", "version", version)
+
 	return db
 }
 


### PR DESCRIPTION
Log the database version on service startup.  Example output:

```
2024/10/22 13:39:11 INFO SSL_CERT_DIR not updated
time=2024-10-22T13:39:11.525+10:00 level=INFO msg=idmscv-backend Version=(devel) Commit=b400ae2dbc80a70892a9525ceebea21512ec6391 CommitTime=2024-10-18T14:29:52Z Dirty=true
time=2024-10-22T13:39:11.527+10:00 level=INFO msg=idmsvc-backend Logging.Console=true Logging.Type=null Logging.Level=info Logging.Location=false
time=2024-10-22T13:39:11.527+10:00 level=NOTICE msg="Logging successfully initialized"
time=2024-10-22T13:39:11.527+10:00 level=INFO msg=Configuration Web.Port=8000 Database.Host=localhost Database.Port=5432 Database.User=idmsvc-user Database.Password=*** Database.Name=idmsvc-db Database.CACertPath="" Database.MaxOpenConns=30 Logging.Level=info Logging.Console=true Logging.Location=false Logging.Type=null Logging.Cloudwatch.Region="" Logging.Cloudwatch.Key="" Logging.Cloudwatch.Secret="" Logging.Cloudwatch.Session="" Logging.Cloudwatch.Group="" Logging.Cloudwatch.Stream=f36-2.ipa.test Metrics.Path=/metrics Metrics.Port=9000 Clients.RbacBaseURL=http://localhost:8020/api/rbac/v1 Clients.PendoBaseURL=http://localhost:8010 Clients.PendoAPIKey=*** Clients.PendoTrackEventKey=*** Clients.PendoRequestTimeoutSecs=0 Application.Name=idmsvc Application.PathPrefix=/api/idmsvc/v1 Application.TokenExpirationTimeSeconds=7200 Application.HostconfJwkValidity=2160h0m0s Application.HostconfJwkRenewalThreshold=720h0m0s Application.PaginationDefaultLimit=10 Application.PaginationMaxLimit=100 Application.AcceptXRHFakeIdentity=true Application.ValidateAPI=true Application.MainSecret=*** Application.EnableRBAC=true Application.IdleTimeout=5m0s Application.ReadTimeout=3s Application.WriteTimeout=3s Application.SizeLimitRequestHeader=32768 Application.SizeLimitRequestBody=131072
time=2024-10-22T13:39:11.538+10:00 level=INFO msg="Connected to database" version="PostgreSQL 15.1 on x86_64-redhat-linux-gnu, compiled by gcc (GCC) 12.2.1 20221121 (Red Hat 12.2.1-4), 64-bit"
⇨ http server started on [::]:9000
⇨ http server started on [::]:8000
```