### PR TITLE
fix(HMS-4807): fix pendo API url.

### DIFF
--- a/deployments/clowder.yaml
+++ b/deployments/clowder.yaml
@@ -272,7 +272,7 @@ parameters:
     description: |
       Point out to the rbac service base url
   - name: CLIENTS_PENDO_BASE_URL
-    value: "https://api.pendo.io"
+    value: "https://app.pendo.io"
     required: false
     description: |
       Point out to the pendo service base url


### PR DESCRIPTION
Docs for track events [1] says that URL is:
- https://data.pendo.io/data/track

For metadata [2]:
- https://app.pendo.io/api/v1/metadata

Testing shows that track works also with https://app.pendo.io thus keeping this.

Anyway, https://api.pendo.io is incorrect.

[1] https://engageapi.pendo.io/#e45be48e-e01f-4f0a-acaa-73ef6851c4ac
[2] https://engageapi.pendo.io/#bd14400e-0ff9-49e6-932e-61e7a65c6f3c