### PR TITLE
refactor(HMS-4864): align all binaries for the logs

### DIFF
--- a/cmd/db-tool/main.go
+++ b/cmd/db-tool/main.go
@@ -1,22 +1,16 @@
 package main
 
 import (
-	"log/slog"
-
 	"github.com/podengo-project/idmsvc-backend/cmd/db-tool/cmd"
 	"github.com/podengo-project/idmsvc-backend/internal/config"
 	"github.com/podengo-project/idmsvc-backend/internal/infrastructure/logger"
 )
 
-func initLogSystem(name string, cfg *config.Config) {
-	logger.LogBuildInfo("db-tool")
-	logger.InitLogger(cfg)
-	slog.SetDefault(slog.Default().With(slog.String("component", "db-tool")))
-	cfg.Log(slog.Default())
-}
+const component = "db-tool"
 
 func main() {
+	logger.LogBuildInfo(component)
 	cfg := config.Get()
-	initLogSystem("db-tool", cfg)
+	logger.InitLogger(cfg, component)
 	cmd.Execute()
 }

--- a/cmd/mock-rbac/main.go
+++ b/cmd/mock-rbac/main.go
@@ -12,6 +12,8 @@ import (
 	mock_rbac_impl "github.com/podengo-project/idmsvc-backend/internal/infrastructure/service/impl/mock/rbac/impl"
 )
 
+const component = "mock-rbac"
+
 func startSignalHandler(c context.Context) (context.Context, context.CancelFunc) {
 	if c == nil {
 		c = context.Background()
@@ -31,7 +33,7 @@ func main() {
 	defer cancel()
 
 	cfg := config.Get()
-	logger.InitLogger(cfg)
+	logger.InitLogger(cfg, component)
 	if cfg.Clients.RbacBaseURL == "" {
 		panic("'RbacBaseURL' is empty")
 	}

--- a/cmd/pendo-client/main.go
+++ b/cmd/pendo-client/main.go
@@ -15,12 +15,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const component = "pendo-client"
+
 func initPendo() (cfg *config.Config, ctx context.Context, pendoClient pendo.Pendo) {
 	// Initialize dependencies
-	logger.LogBuildInfo("pendo-client")
+	logger.LogBuildInfo(component)
 	cfg = config.Get()
 	cfg.Logging.Level = "debug"
-	logger.InitLogger(cfg)
+	logger.InitLogger(cfg, component)
 
 	ctx = context.Background()
 	ctx = app_context.CtxWithLog(ctx, slog.Default())

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,6 +15,8 @@ import (
 	client_pendo "github.com/podengo-project/idmsvc-backend/internal/usecase/client/pendo"
 	client_rbac "github.com/podengo-project/idmsvc-backend/internal/usecase/client/rbac"
 )
+
+const component = "service"
 
 func startSignalHandler(c context.Context) (context.Context, context.CancelFunc) {
 	if c == nil {
@@ -45,10 +46,9 @@ func initRbacWrapper(ctx context.Context, cfg *config.Config) rbac.Rbac {
 
 func main() {
 	wg := &sync.WaitGroup{}
-	logger.LogBuildInfo("idmscv-backend")
+	logger.LogBuildInfo(component)
 	cfg := config.Get()
-	logger.InitLogger(cfg)
-	cfg.Log(slog.Default())
+	logger.InitLogger(cfg, component)
 	db := datastore.NewDB(cfg)
 	defer datastore.Close(db)
 

--- a/internal/infrastructure/logger/init.go
+++ b/internal/infrastructure/logger/init.go
@@ -44,7 +44,7 @@ func init() {
 	slog.SetDefault(slog.New(h))
 }
 
-func InitLogger(cfg *config.Config) {
+func InitLogger(cfg *config.Config, componentName string) {
 	if cfg == nil {
 		panic("'cfg' cannot be nil")
 	}
@@ -158,6 +158,8 @@ func InitLogger(cfg *config.Config) {
 		globalLevel.Set(LevelWarn)
 	}
 
+	slog.SetDefault(slog.Default().With(slog.String("component", componentName)))
+	cfg.Log(slog.Default())
 	slog.Log(
 		context.Background(),
 		LevelNotice,

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -121,7 +121,7 @@ func (s *SuiteBase) SetupTest() {
 	require.NotNil(t, s.Config)
 	s.Config.Application.EnableRBAC = true
 	s.wg = &sync.WaitGroup{}
-	logger.InitLogger(s.Config)
+	logger.InitLogger(s.Config, "test-suite")
 	s.db = datastore.NewDB(s.Config)
 	require.NotNil(t, s.db)
 


### PR DESCRIPTION
This change refactor the log initialization to use the same code for all the generated binaries. Provide consistency.

https://issues.redhat.com/browse/HMS-4864