### PR TITLE
fix(HMS-4864): flush cloudwatch logs

### DIFF
--- a/cmd/db-tool/main.go
+++ b/cmd/db-tool/main.go
@@ -12,5 +12,7 @@ func main() {
 	logger.LogBuildInfo(component)
 	cfg := config.Get()
 	logger.InitLogger(cfg, component)
+	defer logger.DoneLogger()
+
 	cmd.Execute()
 }

--- a/cmd/mock-rbac/main.go
+++ b/cmd/mock-rbac/main.go
@@ -34,6 +34,8 @@ func main() {
 
 	cfg := config.Get()
 	logger.InitLogger(cfg, component)
+	defer logger.DoneLogger()
+
 	if cfg.Clients.RbacBaseURL == "" {
 		panic("'RbacBaseURL' is empty")
 	}

--- a/cmd/pendo-client/main.go
+++ b/cmd/pendo-client/main.go
@@ -93,6 +93,8 @@ func initCLI() *cobra.Command {
 
 func main() {
 	rootCmd := initCLI()
+	defer logger.DoneLogger()
+
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 	}

--- a/cmd/service/main.go
+++ b/cmd/service/main.go
@@ -49,6 +49,8 @@ func main() {
 	logger.LogBuildInfo(component)
 	cfg := config.Get()
 	logger.InitLogger(cfg, component)
+	defer logger.DoneLogger()
+
 	db := datastore.NewDB(cfg)
 	defer datastore.Close(db)
 

--- a/internal/test/smoke/suite_base_test.go
+++ b/internal/test/smoke/suite_base_test.go
@@ -169,6 +169,7 @@ func (s *SuiteBase) TearDownTest() {
 	s.svcRbac.Stop()
 	s.svc.Stop()
 	s.wg.Wait()
+	logger.DoneLogger()
 }
 
 // As is a helper function that makes it easy to select


### PR DESCRIPTION
This change will call the Flush() method when the services
and tools is finishing its execution.