### PR TITLE
build(HMS-4895): add unit tests -oci-ta

### DIFF
--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -278,6 +278,10 @@ spec:
               #!/bin/bash
               set -ex
 
+              ls -1
+
+              cp -vf configs/config.example.yml configs/config.yml
+
               make test-unit
     - name: build-images
       matrix:

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -251,11 +251,11 @@ spec:
           # New volume to store a copy of the source code accessible only to this Task.
           - name: workdir
             emptyDir: {}
-        # stepTemplates:
-        #   volumeMounts:
-        #     - name: workdir
-        #       mountPath: /var/workdir
-        #       readOnly: false
+        stepTemplates:
+          volumeMounts:
+            - name: workdir
+              mountPath: /var/workdir
+              readOnly: false
         steps:
           - name: use-trusted-artifact
             image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -588,6 +588,16 @@ spec:
           requests:
             storage: 1Gi
       status: {}
+  - name: configs
+    volumeClaimTemplate:
+      metadata:
+        creationTimestamp: null
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 1Mi
   - name: git-auth
     secret:
       secretName: '{{ git_auth_secret }}'

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -247,10 +247,10 @@ spec:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
             name: SOURCE_ARTIFACT
             type: string
-        # volumes:
-        #   # New volume to store a copy of the source code accessible only to this Task.
-        #   - name: workdir
-        #     emptyDir: {}
+        volumes:
+          # New volume to store a copy of the source code accessible only to this Task.
+          - name: workdir
+            emptyDir: {}
         # stepTemplates:
         #   volumeMounts:
         #     - name: workdir
@@ -261,10 +261,10 @@ spec:
             image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
             args:
               - use
-              - $(params.SOURCE_ARTIFACT)=/var/workdir
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: unit-tests
             image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:2fead14be2734020f98c731fef30cc54e99fe889a53cac97e80f6f043778b567
-            workingDir: /var/workdir
+            workingDir: /var/workdir/source
             computeResources:
               requests:
                 memory: 7Gi

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -247,7 +247,7 @@ spec:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
             name: SOURCE_ARTIFACT
             type: string
-        stepTemplates:
+        stepTemplate:
           volumeMounts:
             - name: workdir
               mountPath: /var/workdir

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -240,22 +240,22 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
-        - name: source
-          workspace: workspace
+        # - name: source
+        #   workspace: workspace
       taskSpec:
         params:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
             name: SOURCE_ARTIFACT
             type: string
-        volumes:
-          # New volume to store a copy of the source code accessible only to this Task.
-          - name: workdir
-            emptyDir: {}
-        stepTemplates:
-          volumeMounts:
-            - name: workdir
-              mountPath: /var/workdir
-              readOnly: false
+        # volumes:
+        #   # New volume to store a copy of the source code accessible only to this Task.
+        #   - name: workdir
+        #     emptyDir: {}
+        # stepTemplates:
+        #   volumeMounts:
+        #     - name: workdir
+        #       mountPath: /var/workdir
+        #       readOnly: false
         steps:
           - name: use-trusted-artifact
             image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -247,10 +247,6 @@ spec:
           - description: The Trusted Artifact URI pointing to the artifact with the application source code.
             name: SOURCE_ARTIFACT
             type: string
-        volumes:
-          # New volume to store a copy of the source code accessible only to this Task.
-          - name: workdir
-            emptyDir: {}
         stepTemplates:
           volumeMounts:
             - name: workdir
@@ -261,10 +257,10 @@ spec:
             image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
             args:
               - use
-              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+              - $(params.SOURCE_ARTIFACT)=/var/workdir
           - name: unit-tests
             image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:2fead14be2734020f98c731fef30cc54e99fe889a53cac97e80f6f043778b567
-            workingDir: /var/workdir/source
+            workingDir: /var/workdir
             computeResources:
               requests:
                 memory: 7Gi
@@ -285,6 +281,10 @@ spec:
               cp -vf configs/config.example.yaml configs/config.yaml
 
               make test-unit
+        volumes:
+          # New volume to store a copy of the source code accessible only to this Task.
+          - name: workdir
+            emptyDir: {}
     - name: build-images
       matrix:
         params:

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -257,10 +257,10 @@ spec:
             image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
             args:
               - use
-              - $(params.SOURCE_ARTIFACT)=/var/workdir
+              - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: unit-tests
             image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:2fead14be2734020f98c731fef30cc54e99fe889a53cac97e80f6f043778b567
-            workingDir: /var/workdir
+            workingDir: /var/workdir/source
             computeResources:
               requests:
                 memory: 7Gi

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -274,7 +274,7 @@ spec:
                 cpu: 2000m
             # securityContext:
             #   runAsUser: 0
-            scripts: |
+            script: |
               #!/bin/bash
               set -ex
 

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -240,6 +240,8 @@ spec:
       workspaces:
         - name: git-basic-auth
           workspace: git-auth
+        - name: configs
+          workspace: configs
         # - name: source
         #   workspace: workspace
       taskSpec:
@@ -251,6 +253,9 @@ spec:
           volumeMounts:
             - name: workdir
               mountPath: /var/workdir
+              readOnly: false
+            - name: configs
+              mountPath: /tmp/configs
               readOnly: false
         steps:
           - name: use-trusted-artifact
@@ -278,12 +283,14 @@ spec:
               
               # ls -1 >&2
 
-              # cp -vf configs/config.example.yaml configs/config.yaml
+              cp -vf configs/config.example.yaml /tmp/configs/config.yaml
 
               make test-unit
         volumes:
           # New volume to store a copy of the source code accessible only to this Task.
           - name: workdir
+            emptyDir: {}
+          - name: configs
             emptyDir: {}
     - name: build-images
       matrix:

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -273,16 +273,16 @@ spec:
               limits:
                 memory: 14Gi
                 cpu: 2000m
-            # securityContext:
-            #   runAsUser: 0
+            securityContext:
+              runAsUser: 0
             script: |
               #!/bin/bash
               set -ex
 
               # pwd >&2
-              
               # ls -1 >&2
 
+              export CONFIG_PATH="/tmp/configs"
               cp -vf configs/config.example.yaml /tmp/configs/config.yaml
 
               make test-unit

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -259,7 +259,7 @@ spec:
               - use
               - $(params.SOURCE_ARTIFACT)=/var/workdir/source
           - name: unit-tests
-            image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:2fead14be2734020f98c731fef30cc54e99fe889a53cac97e80f6f043778b567
+            image: registry.access.redhat.com/ubi9/go-toolset:1.22.7-1733160835@sha256:c9c0129bff8e94b9e23e9e4a1ebb5b932cccc24e064940a792bdc002da512d2a
             workingDir: /var/workdir/source
             computeResources:
               requests:

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -278,9 +278,9 @@ spec:
               #!/bin/bash
               set -ex
 
-              pwd
+              pwd >&2
               
-              ls -1
+              ls -1 >&2
 
               cp -vf configs/config.example.yaml configs/config.yaml
 

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -230,6 +230,55 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
+    - name: run-unit-tests
+      description: Execute the unit tests for idmsvc-backend
+      params:
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      runAfter:
+        - prefetch-dependencies
+      workspaces:
+        - name: git-basic-auth
+          workspace: git-auth
+        - name: source
+          workspace: workspace
+      taskSpec:
+        params:
+          - description: The Trusted Artifact URI pointing to the artifact with the application source code.
+            name: SOURCE_ARTIFACT
+            type: string
+        volumes:
+          # New volume to store a copy of the source code accessible only to this Task.
+          - name: workdir
+            emptyDir: {}
+        stepTemplates:
+          volumeMounts:
+            - name: workdir
+              mountPath: /var/workdir
+              readOnly: false
+        steps:
+          - name: use-trusted-artifact
+            image: quay.io/redhat-appstudio/build-trusted-artifacts:latest@sha256:81c4864dae6bb11595f657be887e205262e70086a05ed16ada827fd6391926ac
+            args:
+              - use
+              - $(params.SOURCE_ARTIFACT)=/var/workdir
+          - name: unit-tests
+            image: registry.access.redhat.com/ubi9/go-toolset:1.21.11-9.1726696856@sha256:2fead14be2734020f98c731fef30cc54e99fe889a53cac97e80f6f043778b567
+            workingDir: /var/workdir
+            computeResources:
+              requests:
+                memory: 7Gi
+                cpu: 1000m
+              limits:
+                memory: 14Gi
+                cpu: 2000m
+            # securityContext:
+            #   runAsUser: 0
+            scripts: |
+              #!/bin/bash
+              set -ex
+
+              make test-unit
     - name: build-images
       matrix:
         params:
@@ -263,7 +312,7 @@ spec:
       - name: IMAGE_APPEND_PLATFORM
         value: "true"
       runAfter:
-      - prefetch-dependencies
+      - run-unit-tests
       taskRef:
         params:
         - name: name

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -274,11 +274,11 @@ spec:
               #!/bin/bash
               set -ex
 
-              pwd >&2
+              # pwd >&2
               
-              ls -1 >&2
+              # ls -1 >&2
 
-              cp -vf configs/config.example.yaml configs/config.yaml
+              # cp -vf configs/config.example.yaml configs/config.yaml
 
               make test-unit
         volumes:

--- a/.tekton/idmsvc-backend-pull-request.yaml
+++ b/.tekton/idmsvc-backend-pull-request.yaml
@@ -278,9 +278,11 @@ spec:
               #!/bin/bash
               set -ex
 
+              pwd
+              
               ls -1
 
-              cp -vf configs/config.example.yml configs/config.yml
+              cp -vf configs/config.example.yaml configs/config.yaml
 
               make test-unit
     - name: build-images


### PR DESCRIPTION
Add tekton task for the pull requests which
run the unit tests for the idmsvc-backend
component.

See: https://github.com/konflux-ci/build-definitions/tree/main/task-generator/trusted-artifacts
See: https://github.com/konflux-ci/docs/blob/main/docs/modules/ROOT/pages/advanced-how-tos/using-trusted-artifacts.adoc

https://issues.redhat.com/browse/HMS-4895

---

TODO

- [ ] The `run-unit-tests` task seems running a source2image instead the steps in the `scripts` block; fixing it, likely it finish this pr.