### PR TITLE
fix(HMS-4895): push image tekton pipeline

### DIFF
--- a/.tekton/idmsvc-backend-push.yaml
+++ b/.tekton/idmsvc-backend-push.yaml
@@ -27,6 +27,12 @@ spec:
     value: build/package/Dockerfile
   - name: path-context
     value: .
+  - name: build-platforms
+    value:
+    - linux/x86_64
+    # - linux/arm64
+    # - linux/ppc63le
+    # - linux/s390x
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -213,7 +219,12 @@ spec:
         workspace: git-auth
       - name: netrc
         workspace: netrc
-    - name: build-container
+    - name: build-images
+      matrix:
+        params:
+        - name: PLATFORM
+          value:
+          - $(params.build-platforms)
       params:
       - name: IMAGE
         value: $(params.output-image)
@@ -234,14 +245,20 @@ spec:
         - $(params.build-args[*])
       - name: BUILD_ARGS_FILE
         value: $(params.build-args-file)
+      - name: SOURCE_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+      - name: CACHI2_ARTIFACT
+        value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+      - name: IMAGE_APPEND_PLATFORM
+        value: "true"
       runAfter:
       - prefetch-dependencies
       taskRef:
         params:
         - name: name
-          value: buildah
+          value: buildah-remote-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.2@sha256:23883131ea90adb2b8e411420084e13e1dd4d2a9350ee567200a60360e820d10
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.2@sha256:2a3e27910c933d39ec1580dde6c48c61763ba28311a36f38bc2d58ec8b87eece
         - name: kind
           value: task
         resolver: bundles
@@ -250,9 +267,6 @@ spec:
         operator: in
         values:
         - "true"
-      workspaces:
-      - name: source
-        workspace: workspace
     - name: build-image-index
       params:
       - name: IMAGE
@@ -265,9 +279,9 @@ spec:
         value: $(params.build-image-index)
       - name: IMAGES
         value:
-        - $(tasks.build-container.results.IMAGE_URL)@$(tasks.build-container.results.IMAGE_DIGEST)
+        - $(tasks.build-images.results.IMAGE_REF[*])
       runAfter:
-      - build-container
+      - build-images
       taskRef:
         params:
         - name: name


### PR DESCRIPTION
- Refactor build-container to build-images to be aligned with the pull-request pipeline, and update the references.
- This is expected that will fix the message: `Cannot find Dockerfile build/package/Dockerfile`